### PR TITLE
Tighten path validation & add TAI 

### DIFF
--- a/certval/src/validator/pdv_trust_anchor.rs
+++ b/certval/src/validator/pdv_trust_anchor.rs
@@ -77,6 +77,11 @@ impl ExtensionProcessing for PDVTrustAnchorChoice<'_> {
             TrustAnchorChoice::Certificate(c) => &c.tbs_certificate.extensions,
             TrustAnchorChoice::TaInfo(tai) => {
                 if let Some(cp) = &tai.cert_path {
+                    // TODO Support all TrustAnchorInfo overrides
+                    // TrustAnchorInfo may override some extensions per RFC 5914.
+                    // This includes the TAI fields policySet, policyFlags,
+                    // nameConstr, pathLenConstraint, and ext.
+                    // Seems we're currently only using nameConstr and policySet here.
                     if *oid == ID_CE_NAME_CONSTRAINTS {
                         if let Some(nc) = &cp.name_constr {
                             let ext = PDVExtension::NameConstraints(nc.clone());


### PR DESCRIPTION
Ensures path validation fails if we can't `DeferDecodeSigned::from_der` the current encoded cert in `verify_signatures`. Previously we'd just skip checking such a cert's signature.

Also added a TODO note for the TrustAnchorInfo overrides.

I'd like to make some other refactorings for readability, mainly early exits to reduce if-nesting in the different `validate_path_rfc5280` functions. Is that something you'd welcome?

Also wondering if you've put this project on the back burner or not. I'm in need of `no_std` (but with `alloc`) capable pure rust path validation, and so far this is the least hacky code I've found for it.

These and any further contributions I make to rust-pki are explicitly provided under Apache License Version 2.0 and the MIT License.