### PR TITLE
Path validation cleanup

### DIFF
--- a/certval/src/util/crypto.rs
+++ b/certval/src/util/crypto.rs
@@ -6,8 +6,6 @@ use alloc::{format, vec::Vec};
 #[cfg(feature = "pqc")]
 use der::Decode;
 use der::{asn1::ObjectIdentifier, AnyRef, Encode};
-use p256::ecdsa::{Signature as Signature256, VerifyingKey as VerifyingKey256};
-use p384::ecdsa::{Signature as Signature384, VerifyingKey as VerifyingKey384};
 use rsa::pkcs8::DecodePublicKey;
 use rsa::{hash::Hash, PaddingScheme, PublicKey, RsaPublicKey};
 use sha2::{Digest, Sha224, Sha256, Sha384, Sha512};

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -758,14 +758,14 @@ pub fn verify_signatures(
     cp: &mut CertificationPath<'_>,
     cpr: &mut CertificationPathResults<'_>,
 ) -> Result<()> {
-    // for convenience, combine target into array with the intermediate CA certs
-    let mut v = cp.intermediates.clone();
-    v.push(cp.target);
+    let intermediates_and_target = cp.intermediates
+        .iter()
+        .chain(core::iter::once(&cp.target));
 
     let mut working_spki =
         get_subject_public_key_info_from_trust_anchor(&cp.trust_anchor.decoded_ta);
 
-    for cur_cert_ref in v.iter() {
+    for cur_cert_ref in intermediates_and_target {
         let cur_cert = cur_cert_ref.deref();
 
         let defer_cert = DeferDecodeSigned::from_der(cur_cert.encoded_cert);

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -274,16 +274,8 @@ pub fn check_names<'a>(
     let certs_in_cert_path = v.len();
 
     let mut perm_names_set = initial_perm.is_some();
-    let mut permitted_subtrees = if let Some(perm) = initial_perm {
-        perm
-    } else {
-        NameConstraintsSet::default()
-    };
-    let mut excluded_subtrees = if let Some(excl) = initial_excl {
-        excl
-    } else {
-        NameConstraintsSet::default()
-    };
+    let mut permitted_subtrees = initial_perm.unwrap_or_default();
+    let mut excluded_subtrees = initial_excl.unwrap_or_default();
 
     let mut working_issuer_name = get_trust_anchor_name(&cp.trust_anchor.decoded_ta)?;
 

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -13,7 +13,7 @@ use crate::{
     path_results::*, path_settings::*, pdv_certificate::*, pdv_extension::*,
     pdv_trust_anchor::get_trust_anchor_name, util::error::*, util::pdv_utilities::*,
     validator::pdv_trust_anchor::PDVTrustAnchorChoice, validator::policy_utilities::*,
-    CertificationPath, NameConstraintsSet,
+    CertificationPath
 };
 use const_oid::db::rfc5280::ANY_POLICY;
 use const_oid::db::rfc5912::*;


### PR DESCRIPTION
* Control flow changes to use early returns
* Removing some unnecessary clones (e.g. the intermediates + target iterators) (and the `.retain` call)
* Making use of the `Extend` trait, this may also improve perf some since it can use size hints from iterators
* A few additional uses of convenient std/core lib functions