### PR TITLE
dependency bumps, dependency cleanup and related changes

### DIFF
--- a/certval/Cargo.toml
+++ b/certval/Cargo.toml
@@ -12,24 +12,24 @@ categories = ["cryptography", "pki", "no-std"]
 keywords = ["crypto", "x.509", "OCSP"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-x509-cert = { version="0.2.3", default-features = false, features = ["pem"] }
-const-oid = { version = "0.9.2", default-features = false, features = ["db"] }
-cms = "0.2.1"
-der = { version="0.7.6", features = ["alloc", "derive", "flagset", "oid"] }
+x509-cert = { version="0.2.4", default-features = false, features = ["pem"] }
+const-oid = { version = "0.9.4", default-features = false, features = ["db"] }
+cms = "0.2.2"
+der = { version="0.7.7", features = ["alloc", "derive", "flagset", "oid"] }
 x509-ocsp = { git = "https://github.com/RustCrypto/formats" }
 base64ct = { version="1.6.0", features = ["alloc"], optional=true }
 spki = { version = "0.7.2", default-features = false, features = ["alloc"] }
-pqckeys = { git = "https://github.com/carl-wallace/pqckeys" }
+pqckeys = { git = "https://github.com/carl-wallace/pqckeys", optional=true }
 pem-rfc7468 = { version="0.7.0", features = ["alloc"]}
 
 pkiprocmacros = { path = "../pkiprocmacros"}
 
-ecdsa = {version = "0.16.7", default-features = false, features = ["der"]}
+ecdsa = {version = "0.16.8", default-features = false, features = ["der"]}
 p256 = {version = "0.13.2", default-features = false, features = ["ecdsa", "ecdsa-core"]}
 p384 = {version = "0.13.0", default-features = false, features = ["ecdsa"]}
 rsa = {version = "0.9.2", default-features = false}
@@ -40,25 +40,22 @@ cfg-if = "1.0.0"
 # serde feature is added to std, revocation,std and remote
 flagset = { version = "0.4.3", package = "flagset", default-features = false }
 lazy_static = {version = "1.4.*", features = ["spin_no_std"]}
-readonly = "0.2.8"
-serde = {version = "1.0.164", default-features = false, features = ["derive", "alloc"]}
+readonly = "0.2.11"
+serde = {version = "1.0.177", default-features = false, features = ["derive", "alloc"]}
 subtle-encoding = {version = "0.5.1", default-features = false, features = ["hex", "alloc"]}
 
 ciborium = {version = "0.2.1", default-features = false }
 log = {version = "0.4.19", default-features = false}
-log4rs = {version = "1.2.0", optional = true, default-features = false}
 ndarray = {version = "0.15.6", optional = true, default-features = false}
 reqwest = { version = "0.11.18", features = ["blocking"], optional = true}
-serde_json = {version = "1.0.97", optional = true, default-features = false, features = ["alloc"] }
-tokio = { version = "1.28.2", features = ["full", "time", "rt-multi-thread"], optional = true }
-tokio-test = {version = "0.4.2", optional = true}
+serde_json = {version = "1.0.104", optional = true, default-features = false, features = ["alloc"] }
+tokio = { version = "1.29.1", features = ["full", "time", "rt-multi-thread"], optional = true }
 url = {version = "2.4.0", optional = true}
-walkdir = { version = "2.3.3", optional = true}
-getrandom = { version = "0.2.10", features = ["js"], optional = true, default-features = false }
+walkdir = { version = "2.2.3", optional = true}
 
 # regex documentation notes a std feature that at some point in the future could be omitted
 # to enable no_std support, but for now std is required, so mark it optional
-regex = {version = "1.8.4", optional = true}
+regex = {version = "1.9.1", optional = true}
 
 pqcrypto-internals =  {version = "0.2.4", optional = true}
 pqcrypto-dilithium =  {version = "0.4.6", optional = true}
@@ -68,8 +65,9 @@ pqcrypto = {version = "0.16.1", optional = true}
 pqcrypto-traits = {version = "0.3.4", optional = true}
 
 [dev-dependencies]
-tempfile = "3.6.0"
+tempfile = "3.7.0"
 hex-literal = "0.4.1"
+tokio-test = "0.4.2"
 
 # There are five feature gates:
 #   - no-default-features (i.e., no-std) provides full path validation without file system support, network or thread safety (and no revocation support)
@@ -81,9 +79,9 @@ hex-literal = "0.4.1"
 [features]
 default = ["remote"]
 revocation = ["ndarray"]
-std = ["ndarray", "tokio", "tokio-test", "base64ct", "walkdir", "log4rs", "url", "serde_json", "serde/rc",  "flagset/serde", "regex", "lazy_static/spin", "getrandom"]
+std = ["ndarray", "tokio", "base64ct", "walkdir", "url", "serde_json", "serde/rc",  "flagset/serde", "regex", "lazy_static/spin"]
 remote = ["revocation", "std", "reqwest", "lazy_static/spin"]
-pqc = ["pqcrypto-internals", "pqcrypto-dilithium", "pqcrypto-falcon", "pqcrypto-sphincsplus", "pqcrypto", "pqcrypto-traits"]
+pqc = ["pqcrypto-internals", "pqcrypto-dilithium", "pqcrypto-falcon", "pqcrypto-sphincsplus", "pqcrypto", "pqcrypto-traits", "pqckeys"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/certval/README.md
+++ b/certval/README.md
@@ -8,7 +8,7 @@ as augmented by [RFC 5937]. Support for certification path building and revocati
 
 ASN.1 encoders and decoders and cryptographic support are primarily provided by various [RustCrypto] libraries.
 
-A change log is available at the root of the certval project.
+A [change log](CHANGELOG.md) is available at the root of the certval project.
 
 ## Crate Feature Flags
 
@@ -23,7 +23,7 @@ The certval library provides five feature gates that enable varying levels of su
 
 ## Sample Usage
 
-The [PITTv3](../pittv3/index.html) application provides means of exercising the certval library and can serve as sample code for usage of the library.
+The [PITTv3](../pittv3/index.html) application uses the certval library and can serve as sample code for usage of the library.
 
 ## Status
 
@@ -34,9 +34,9 @@ development.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
-We may change the MSRV in the future, but it will be accompanied by a minor
+The MSRV may change in the future, but it will be accompanied by a minor
 version bump.
 
 ## License

--- a/certval/src/asn1.rs
+++ b/certval/src/asn1.rs
@@ -1,4 +1,4 @@
-//! Sources of ASN.1 encoders and decoders not included in a RustCrypto formats repo
+//! ASN.1 encoders and decoders not included in a RustCrypto formats repo
 
 pub mod piv_naci_indicator;
 

--- a/certval/src/source/cert_source.rs
+++ b/certval/src/source/cert_source.rs
@@ -1800,10 +1800,10 @@ fn get_certificates_test() {
     assert!(r.is_err());
     assert_eq!(r.err(), Some(Error::NotFound));
 
-    let en = encode_dn_from_string("C=US,O=Test Certificates 2011,CN=Valid EE Certificate Test1")
+    let en = encode_dn_from_string("CN=Valid EE Certificate Test1,O=Test Certificates 2011,C=US")
         .unwrap();
     let n = Name::from_der(en.as_slice()).unwrap();
-    let en2 = encode_dn_from_string("C=US,O=Test Certificates 2011,CN=Does Not Exist").unwrap();
+    let en2 = encode_dn_from_string("CN=Does Not Exist,O=Test Certificates 2011,C=US").unwrap();
     let n2 = Name::from_der(en2.as_slice()).unwrap();
     let v = cert_store.get_certificates_for_name(&n).unwrap();
     assert_eq!(v.len(), 1);

--- a/certval/src/validator/name_constraints_set.rs
+++ b/certval/src/validator/name_constraints_set.rs
@@ -890,28 +890,28 @@ pub(crate) fn name_constraints_set_to_name_constraints_settings(
 fn intersection_tests() {
     use crate::path_settings::*;
     let perm = crate::NameConstraintsSettings {
-        directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Joe".to_string()]),
+        directory_name: Some(vec!["CN=Joe,OU=Org Unit,O=Org,C=US".to_string()]),
         rfc822_name: Some(vec!["x@example.com".to_string()]),
         user_principal_name: Some(vec!["1234567890@mil".to_string()]),
         dns_name: Some(vec!["j.example.com".to_string()]),
         uniform_resource_identifier: Some(vec!["https://j.example.com".to_string()]),
     };
     let perm_copy = crate::NameConstraintsSettings {
-        directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Joe".to_string()]),
+        directory_name: Some(vec!["CN=Joe,OU=Org Unit,O=Org,C=US".to_string()]),
         rfc822_name: Some(vec!["x@example.com".to_string()]),
         user_principal_name: Some(vec!["1234567890@mil".to_string()]),
         dns_name: Some(vec!["j.example.com".to_string()]),
         uniform_resource_identifier: Some(vec!["https://j.example.com".to_string()]),
     };
     let perm2 = crate::NameConstraintsSettings {
-        directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Sue".to_string()]),
+        directory_name: Some(vec!["CN=Sue,OU=Org Unit,O=Org,C=US".to_string()]),
         rfc822_name: Some(vec!["y@example.com".to_string()]),
         user_principal_name: Some(vec!["0987654321@mil".to_string()]),
         dns_name: Some(vec!["s.example.com".to_string()]),
         uniform_resource_identifier: Some(vec!["https://s.example.com".to_string()]),
     };
     let perm3 = crate::NameConstraintsSettings {
-        directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Abe".to_string()]),
+        directory_name: Some(vec!["CN=Abe,OU=Org Unit,O=Org,C=US".to_string()]),
         rfc822_name: Some(vec!["z@example.com".to_string()]),
         user_principal_name: Some(vec!["1236547890@mil".to_string()]),
         dns_name: Some(vec!["t.example.com".to_string()]),

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -964,7 +964,7 @@ fn test_no_default_sets_cps() {
     set_initial_permitted_subtrees(
         &mut cps,
         crate::NameConstraintsSettings {
-            directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Joe".to_string()]),
+            directory_name: Some(vec!["CN=Joe,OU=Org Unit,O=Org,C=US".to_string()]),
             rfc822_name: Some(vec!["x@example.com".to_string()]),
             user_principal_name: Some(vec!["1234567890@mil".to_string()]),
             dns_name: Some(vec!["j.example.com".to_string()]),
@@ -983,7 +983,7 @@ fn test_no_default_sets_cps() {
     );
     assert_eq!(Some(vec!["x@example.com".to_string()]), perm.rfc822_name);
     assert_eq!(
-        Some(vec!["C=US,O=Org,OU=Org Unit,CN=Joe".to_string()]),
+        Some(vec!["CN=Joe,OU=Org Unit,O=Org,C=US".to_string()]),
         perm.directory_name
     );
     let perm_set = get_initial_permitted_subtrees_as_set(&cps, &mut bufs1)
@@ -1019,7 +1019,7 @@ fn test_no_default_sets_cps() {
     set_initial_excluded_subtrees(
         &mut cps,
         crate::NameConstraintsSettings {
-            directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Sue".to_string()]),
+            directory_name: Some(vec!["CN=Sue,OU=Org Unit,O=Org,C=US".to_string()]),
             rfc822_name: Some(vec!["y@example.com".to_string()]),
             user_principal_name: Some(vec!["0987654321@mil".to_string()]),
             dns_name: Some(vec!["s.example.com".to_string()]),
@@ -1038,7 +1038,7 @@ fn test_no_default_sets_cps() {
     );
     assert_eq!(Some(vec!["y@example.com".to_string()]), excl.rfc822_name);
     assert_eq!(
-        Some(vec!["C=US,O=Org,OU=Org Unit,CN=Sue".to_string()]),
+        Some(vec!["CN=Sue,OU=Org Unit,O=Org,C=US".to_string()]),
         excl.directory_name
     );
     let excl_set = get_initial_excluded_subtrees_as_set(&cps, &mut bufs1)

--- a/certval/tests/path_settings.rs
+++ b/certval/tests/path_settings.rs
@@ -25,7 +25,7 @@ fn settings_serialization_test() {
     let policies = vec![ANY_POLICY.to_string()];
     set_initial_policy_set(&mut cps, policies);
     let perm = certval::NameConstraintsSettings {
-        directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Joe".to_string()]),
+        directory_name: Some(vec!["CN=Joe,OU=Org Unit,O=Org,C=US".to_string()]),
         rfc822_name: Some(vec!["x@example.com".to_string()]),
         user_principal_name: Some(vec!["1234567890@mil".to_string()]),
         dns_name: Some(vec!["j.example.com".to_string()]),
@@ -33,7 +33,7 @@ fn settings_serialization_test() {
     };
     set_initial_permitted_subtrees(&mut cps, perm);
     let excl = certval::NameConstraintsSettings {
-        directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Sue".to_string()]),
+        directory_name: Some(vec!["CN=Sue,OU=Org Unit,O=Org,C=US".to_string()]),
         rfc822_name: Some(vec!["y@example.com".to_string()]),
         user_principal_name: Some(vec!["0987654321@mil".to_string()]),
         dns_name: Some(vec!["s.example.com".to_string()]),

--- a/pittv3/Cargo.toml
+++ b/pittv3/Cargo.toml
@@ -12,15 +12,15 @@ categories = ["cryptography", "pki", "no-std"]
 keywords = ["crypto", "x.509", "OCSP"]
 readme = "README.md"
 edition = "2021"
-rust-version = "1.57"
+rust-version = "1.65"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-x509-cert = { version="0.2.3", default-features = false, features = ["pem"] }
-const-oid = { version = "0.9.2", default-features = false, features = ["db"] }
-cms = "0.2.1"
-der = { version="0.7.6", features = ["alloc", "derive", "flagset", "oid"] }
+x509-cert = { version="0.2.4", default-features = false, features = ["pem"] }
+const-oid = { version = "0.9.4", default-features = false, features = ["db"] }
+cms = "0.2.2"
+der = { version="0.7.7", features = ["alloc", "derive", "flagset", "oid"] }
 x509-ocsp = { git = "https://github.com/RustCrypto/formats" }
 base64ct = { version="1.6.0", features = ["alloc"], optional=true }
 spki = { version = "0.7.2", default-features = false, features = ["alloc"] }
@@ -30,25 +30,23 @@ certval = { path = "../certval", default-features = false}
 sha-1 = {version = "0.10.1", default-features = false}
 sha2 = {version = "0.10.7", default-features = false, features = ["oid"] }
 
-async-recursion = "1.0.0"
+async-recursion = "1.0.4"
 bytes = "1.4.0"
 cfg-if = "1.0.0"
 ciborium = {version = "0.2.1", default-features = false }
-clap = {version = "4.3.5", features=["std", "derive"]}
+clap = {version = "4.3.19", features=["std", "derive"]}
 flagset = { version = "0.4.3", default-features = false }
 lazy_static = "1.4.*"
-serde = { version = "1.0.164", default-features = false, features = ["derive", "alloc"] }
-serde_json = { version = "1.0.97", default-features = false, features = ["alloc"] }
+serde = { version = "1.0.177", default-features = false, features = ["derive", "alloc"] }
+serde_json = { version = "1.0.104", default-features = false, features = ["alloc"] }
 
 csv = {version = "1.2.2", optional = true, default-features = false}
 log = {version = "0.4.19"}
 log4rs = {version = "1.2.0", optional = true}
-futures = {version = "0.3.28", optional = true}
 
 ndarray = {version = "0.15.6", optional = true}
 reqwest = { version = "0.11.18", features = ["blocking"], optional = true}
-tokio = { version = "1.28.2", features = ["full", "time", "rt-multi-thread"], optional = true }
-tokio-test = {version = "0.4.2", optional = true}
+tokio = { version = "1.29.1", features = ["full", "time", "rt-multi-thread"], optional = true }
 walkdir = { version = "2.3.3", optional = true}
 
 pqcrypto-internals =  {version = "0.2.4", optional = true}
@@ -57,6 +55,13 @@ pqcrypto-falcon = {version = "0.2.10", optional = true}
 pqcrypto-sphincsplus = {version = "0.6.4", optional = true}
 pqcrypto = {version = "0.16.1", optional = true}
 pqcrypto-traits = {version = "0.3.4", optional = true}
+
+[dev-dependencies]
+assert_cmd = "2.0.12"
+predicates = "3.0.3"
+hex-literal = "0.4.1"
+tempfile = "3.7.0"
+tokio-test = "0.4.2"
 
 # Similar to certval, there are six feature gates (one more than certval):
 #   - no-default-features (i.e., no-std) provides full path validation without file system support, network or thread safety (and no revocation support)
@@ -69,16 +74,10 @@ pqcrypto-traits = {version = "0.3.4", optional = true}
 [features]
 default = ["remote"]
 revocation = ["certval/revocation"]
-std_app = ["certval/revocation", "ndarray", "tokio", "tokio-test", "base64ct", "walkdir", "log4rs", "futures", "csv"]
+std_app = ["certval/revocation", "ndarray", "tokio", "base64ct", "walkdir", "log4rs", "csv"]
 std = ["std_app", "certval/std", "revocation"]
 remote = ["certval/remote", "revocation", "std"]
 pqc = ["pqcrypto-internals", "pqcrypto-dilithium", "pqcrypto-falcon", "pqcrypto-sphincsplus", "pqcrypto", "pqcrypto-traits"]
-
-[dev-dependencies]
-assert_cmd = "2.0.11"
-predicates = "3.0.3"
-hex-literal = "0.4.1"
-tempfile = "3.6.0"
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pittv3/README.md
+++ b/pittv3/README.md
@@ -112,9 +112,9 @@ development.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.56** at a minimum.
+This crate requires **Rust 1.65** at a minimum.
 
-We may change the MSRV in the future, but it will be accompanied by a minor
+The MSRV may change in the future, but it will be accompanied by a minor
 version bump.
 
 ## License

--- a/pittv3/src/pitt_log.rs
+++ b/pittv3/src/pitt_log.rs
@@ -793,7 +793,7 @@ fn test_cps_log() {
     let policies = vec![ANY_POLICY.to_string()];
     set_initial_policy_set(&mut cps, policies);
     let perm = NameConstraintsSettings {
-        directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Joe".to_string()]),
+        directory_name: Some(vec!["CN=Joe,OU=Org Unit,O=Org,C=US".to_string()]),
         rfc822_name: Some(vec!["x@example.com".to_string()]),
         user_principal_name: Some(vec!["1234567890@mil".to_string()]),
         dns_name: Some(vec!["j.example.com".to_string()]),
@@ -801,7 +801,7 @@ fn test_cps_log() {
     };
     set_initial_permitted_subtrees(&mut cps, perm);
     let excl = NameConstraintsSettings {
-        directory_name: Some(vec!["C=US,O=Org,OU=Org Unit,CN=Sue".to_string()]),
+        directory_name: Some(vec!["CN=Sue,OU=Org Unit,O=Org,C=US".to_string()]),
         rfc822_name: Some(vec!["y@example.com".to_string()]),
         user_principal_name: Some(vec!["0987654321@mil".to_string()]),
         dns_name: Some(vec!["s.example.com".to_string()]),

--- a/pittv3/tests/pittv3.rs
+++ b/pittv3/tests/pittv3.rs
@@ -120,7 +120,7 @@ fn dump_cert_at_index() -> Result<(), Box<dyn std::error::Error>> {
     let mut cmd = Command::cargo_bin("pittv3")?;
     cmd.arg("-b").arg("tests/examples/fpki_and_crtsh.cbor");
     cmd.arg("--dump-cert-at-index").arg("1781");
-    cmd.assert().stdout(predicate::str::contains("Encountered error while processing certificate with subject C=US,O=U.S. Government,OU=DoD,OU=PKI,CN=DOD ID SW CA-45: certificate is expired relative to the configured time of interest"));
+    cmd.assert().stdout(predicate::str::contains("Encountered error while processing certificate with subject CN=DOD ID SW CA-45,OU=PKI,OU=DoD,O=U.S. Government,C=US: certificate is expired relative to the configured time of interest"));
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("1781.der");
     let p = Path::new(&d);

--- a/pkiprocmacros/Cargo.toml
+++ b/pkiprocmacros/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pkiprocmacros"
-version = "0.1.1"
+version = "0.1.2"
 edition = "2021"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
@@ -9,7 +9,7 @@ edition = "2021"
 proc-macro = true
 
 [dependencies]
-proc-macro2 = "1.0.60"
-quote = "1.0.28"
-syn = { version = "2.0.18", features = ["extra-traits", "full"] }
+proc-macro2 = "1.0.66"
+quote = "1.0.32"
+syn = { version = "2.0.27", features = ["extra-traits", "full"] }
 


### PR DESCRIPTION
reverse RDN ordering in some test cases (ao align with upstream change). minor documentation edits. bump the MSRV. remove some unused dependencies.