### PR TITLE
limit quadratic blowup

### DIFF
--- a/certval/src/validator/name_constraints_set.rs
+++ b/certval/src/validator/name_constraints_set.rs
@@ -790,6 +790,15 @@ impl NameConstraintsSet {
         }
     }
     // TODO support UPN name constraints
+
+    pub(crate) fn len(&self) -> usize {
+        self.user_principal_name.len()
+            + self.rfc822_name.len()
+            + self.dns_name.len()
+            + self.directory_name.len()
+            + self.uniform_resource_identifier.len()
+            + self.not_supported.len()
+    }
 }
 
 /// NameConstraintsSettings is a serializable equivalent of NameConstraintsSet. The getters and setters

--- a/certval/src/validator/name_constraints_set.rs
+++ b/certval/src/validator/name_constraints_set.rs
@@ -797,6 +797,7 @@ impl NameConstraintsSet {
             + self.dns_name.len()
             + self.directory_name.len()
             + self.uniform_resource_identifier.len()
+            + self.ip_address.len()
             + self.not_supported.len()
     }
 }

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -272,6 +272,7 @@ pub fn check_names(
     let mut perm_names_set = initial_perm.is_some();
     let mut permitted_subtrees = initial_perm.unwrap_or_default();
     let mut excluded_subtrees = initial_excl.unwrap_or_default();
+    let constraint_count = permitted_subtrees.len() + excluded_subtrees.len();
 
     let mut working_issuer_name = get_trust_anchor_name(&cp.trust_anchor.decoded_ta)?.clone();
 
@@ -331,6 +332,15 @@ pub fn check_names(
             } else {
                 None
             };
+
+            let san_len = san.map(|s| s.0.len()).unwrap_or(0);
+            if san_len > 0 {
+                if constraint_count > 1048576 / san_len {
+                    return Err(Error::PathValidation(
+                        PathValidationStatus::NameConstraintsViolation,
+                    ));
+                }
+            }
 
             if !permitted_subtrees.san_within_permitted_subtrees(&san) {
                 log_error_for_ca(ca_cert, "permitted name constraints violation for SAN");

--- a/support/x509-limbo-tests/rust-certval.json
+++ b/support/x509-limbo-tests/rust-certval.json
@@ -94,18 +94,18 @@
     },
     {
       "id": "pathological::nc-dos-1",
-      "actual_result": "SKIPPED",
-      "context": "computationally intensive test case"
+      "actual_result": "FAILURE",
+      "context": "[]: [\"validate_path failed with PathValidation(NameConstraintsViolation)\"]"
     },
     {
       "id": "pathological::nc-dos-2",
-      "actual_result": "SKIPPED",
-      "context": "computationally intensive test case"
+      "actual_result": "FAILURE",
+      "context": "[]: [\"validate_path failed with PathValidation(NameConstraintsViolation)\"]"
     },
     {
       "id": "pathological::nc-dos-3",
-      "actual_result": "SKIPPED",
-      "context": "computationally intensive test case"
+      "actual_result": "FAILURE",
+      "context": "peer name check failed because SAN was absent"
     },
     {
       "id": "rfc5280::aki::critical-aki",

--- a/support/x509-limbo-tests/src/main.rs
+++ b/support/x509-limbo-tests/src/main.rs
@@ -124,11 +124,6 @@ fn main() {
         .par_iter()
         .map(|tc| {
             let id = tc.id.as_str();
-            // Filter out computationally intensive test cases
-            // TODO(baloo): Those should be rejected by certval itself.
-            if PATHOLOGICAL_CHECKS.contains(&id) {
-                return TestcaseResult::skip(tc, "computationally intensive test case");
-            }
 
             let start = Instant::now();
             let out = evaluate_testcase(tc);
@@ -200,10 +195,6 @@ fn main() {
     eprintln!(
         "- {} featured results that are ignored as a bug to be fixed.",
         BUG.len()
-    );
-    eprintln!(
-        "- {} were skipped as pathological cases that need attention.",
-        PATHOLOGICAL_CHECKS.len()
     );
     eprintln!(
         "- {} featured results that were ignored as unsupported application-level checks.",
@@ -465,7 +456,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
                     if certval::PathValidationStatus::Valid == status {
                         if tc.expected_result == ExpectedResult::Failure
                             && (tc.expected_peer_name.is_some()
-                            || !tc.expected_peer_names.is_empty())
+                                || !tc.expected_peer_names.is_empty())
                         {
                             // Some test cases should fail due to name checking that would normally be performed by an application.
                             // Approximate that here.
@@ -478,7 +469,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
                                     let ncs = name_constraints_settings_to_name_constraints_set(
                                         &init_perm, &mut bufs,
                                     )
-                                        .unwrap();
+                                    .unwrap();
                                     if let Ok(Some(PDVExtension::SubjectAltName(san))) =
                                         path.target.get_extension(&ID_CE_SUBJECT_ALT_NAME)
                                     {


### PR DESCRIPTION
When verifying certificates with multiple SAN and name contraints, this could lead to a DoS.

This is best described here:
https://x509-limbo.com/testcases/pathological/#pathologicalnc-dos-1
```
The root CA contains 2048 permits and excludes name constraints, which are checked against the EE's 2048 SANs and 2048 subjects. This is typically rejected by implementations due to quadratic blowup, but is technically valid.
```

This reuses the same limits as the one implemented in openssl.