### PR TITLE
certval: rewrite locking for the `CrlSource`

### DIFF
--- a/certval/src/revocation/crl.rs
+++ b/certval/src/revocation/crl.rs
@@ -1201,7 +1201,7 @@ async fn fetch_crl_test() {
     if crl_source.index_crls(1647011592).is_err() {
         panic!("Failed to index CRLs")
     }
-    pe.add_crl_source(Box::new(crl_source.clone()));
+    pe.add_crl_source(Box::new(crl_source));
     pe.add_revocation_cache(Box::new(RevocationCache::new()));
     pe.add_check_remote(Box::new(RemoteStatus::new(f.as_path().to_str().unwrap())));
 

--- a/certval/tests/revocation.rs
+++ b/certval/tests/revocation.rs
@@ -401,7 +401,7 @@ async fn cached_crl_async() {
 
     let mut pe = PkiEnvironment::new();
     pe.populate_5280_pki_environment();
-    pe.add_crl_source(Box::new(crl_source.clone()));
+    pe.add_crl_source(Box::new(crl_source));
     pe.add_revocation_cache(Box::new(RevocationCache::new()));
 
     ee.parse_extensions(EXTS_OF_INTEREST);
@@ -477,7 +477,7 @@ async fn cached_crl_revoked_async() {
 
     let mut pe = PkiEnvironment::new();
     pe.populate_5280_pki_environment();
-    pe.add_crl_source(Box::new(crl_source.clone()));
+    pe.add_crl_source(Box::new(crl_source));
     pe.add_revocation_cache(Box::new(RevocationCache::new()));
 
     ee.parse_extensions(EXTS_OF_INTEREST);
@@ -559,7 +559,7 @@ async fn cached_crl_revoked_remote_async() {
 
     let mut pe = PkiEnvironment::new();
     pe.populate_5280_pki_environment();
-    pe.add_crl_source(Box::new(crl_source.clone()));
+    pe.add_crl_source(Box::new(crl_source));
     pe.add_revocation_cache(Box::new(RevocationCache::new()));
 
     ee.parse_extensions(EXTS_OF_INTEREST);
@@ -641,7 +641,7 @@ async fn cached_crl_remote_async() {
 
     let mut pe = PkiEnvironment::new();
     pe.populate_5280_pki_environment();
-    pe.add_crl_source(Box::new(crl_source.clone()));
+    pe.add_crl_source(Box::new(crl_source));
     pe.add_revocation_cache(Box::new(RevocationCache::new()));
 
     ee.parse_extensions(EXTS_OF_INTEREST);

--- a/pittv3/src/options_std.rs
+++ b/pittv3/src/options_std.rs
@@ -730,12 +730,12 @@ async fn generate_and_validate(args: &Pittv3Args) {
         .map(|crl_folder| RemoteStatus::new(crl_folder));
 
     #[cfg(all(feature = "std", feature = "revocation"))]
-    if let Some(crl_source) = &crl_source {
-        pe.add_crl_source(Box::new(crl_source.clone()));
+    if let Some(crl_source) = crl_source {
+        pe.add_crl_source(Box::new(crl_source));
     }
     #[cfg(all(feature = "std", feature = "revocation"))]
-    if let Some(remote_status) = &remote_status {
-        pe.add_check_remote(Box::new(remote_status.clone()));
+    if let Some(remote_status) = remote_status {
+        pe.add_check_remote(Box::new(remote_status));
     }
     #[cfg(all(feature = "std", feature = "revocation"))]
     pe.add_revocation_cache(Box::new(RevocationCache::new()));


### PR DESCRIPTION
This moves the locking to a `RwLock` in the hope that two concurrent threads might access the data at the same time, should one of them need to alter underlying data, it will then acquire a write lock.

It also removes the `Arc<RefCell>` mechanism.