### PR TITLE
certval: use strongly typed `KeyUsages`

### DIFF
--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -709,10 +709,10 @@ cps_gets_and_sets_with_default!(PS_USE_POLICY_GRAPH, bool, false);
 impl CertificationPathSettings {
     /// `get_target_key_usage` retrieves the `PS_KEY_USAGE` value from a
     /// [`CertificationPathSettings`] map. If present, a u8 value is returned, else None is returned.
-    pub fn get_target_key_usage(&self) -> Option<u16> {
+    pub fn get_target_key_usage(&self) -> Option<KeyUsageSettings> {
         if self.0.contains_key(PS_KEY_USAGE) {
             return match &self.0[PS_KEY_USAGE] {
-                CertificationPathProcessingTypes::U16(v) => Some(*v),
+                CertificationPathProcessingTypes::KeyUsageValue(v) => Some(*v),
                 _ => None,
             };
         }
@@ -720,10 +720,10 @@ impl CertificationPathSettings {
     }
 
     /// `set_target_key_usage` is used to set the [`PS_KEY_USAGE`] value in a [`CertificationPathSettings`] map.
-    pub fn set_target_key_usage(&mut self, v: u16) {
+    pub fn set_target_key_usage(&mut self, v: KeyUsageSettings) {
         self.0.insert(
             PS_KEY_USAGE.to_string(),
-            CertificationPathProcessingTypes::U16(v),
+            CertificationPathProcessingTypes::KeyUsageValue(v),
         );
     }
 }

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -4,8 +4,6 @@ use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::format;
 use alloc::vec;
 
-use flagset::FlagSet;
-
 use log::info;
 
 use crate::policy_tree::check_certificate_policies;
@@ -416,14 +414,7 @@ pub fn check_key_usage(
 
     let target_ku = cp.target.get_extension(&ID_CE_KEY_USAGE)?;
     if let Some(PDVExtension::KeyUsage(target_ku_bits)) = target_ku {
-        if let Some(ku) = cps.get_target_key_usage() {
-            let nku = match FlagSet::<KeyUsages>::new(ku) {
-                Ok(ku) => ku,
-                _ => {
-                    return Err(Error::Unrecognized);
-                }
-            };
-
+        if let Some(nku) = cps.get_target_key_usage() {
             // TODO TEST THIS
             for i in nku {
                 if !target_ku_bits.0.contains(i) {

--- a/certval/tests/path_settings.rs
+++ b/certval/tests/path_settings.rs
@@ -71,7 +71,7 @@ fn settings_serialization_test() {
     let exclcountries = vec!["BB".to_string()];
     cps.set_perm_countries(exclcountries);
     let fs = KeyUsages::DigitalSignature | KeyUsages::KeyEncipherment;
-    cps.set_target_key_usage(fs.bits());
+    cps.set_target_key_usage(fs);
 
     let ser = serde_json::to_string(&cps).unwrap();
     let deser: CertificationPathSettings = serde_json::from_slice(ser.as_bytes()).unwrap();

--- a/pittv3/src/pitt_log.rs
+++ b/pittv3/src/pitt_log.rs
@@ -838,7 +838,7 @@ fn test_cps_log() {
     let exclcountries = vec!["BB".to_string()];
     cps.set_perm_countries(exclcountries);
     let fs = KeyUsages::DigitalSignature | KeyUsages::KeyEncipherment;
-    cps.set_target_key_usage(fs.bits());
+    cps.set_target_key_usage(fs);
 
     use tempfile::tempdir;
     let temp_dir = tempdir().unwrap();

--- a/support/x509-limbo-tests/src/main.rs
+++ b/support/x509-limbo-tests/src/main.rs
@@ -327,7 +327,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
                 KeyUsage::DecipherOnly => target_ku |= KeyUsages::DecipherOnly,
             }
         }
-        cps.set_target_key_usage(target_ku.bits());
+        cps.set_target_key_usage(target_ku);
     }
 
     if !tc.extended_key_usage.is_empty() {


### PR DESCRIPTION
`FlagSet<KeyUsages>` allows for invalid/unknown bits to be defined using [`flagset::FlagSet::new_unchecked`](https://docs.rs/flagset/latest/flagset/struct.FlagSet.html#method.new_unchecked) (a function that is marked unsafe).