### PR TITLE
certval: make `TimeOfInterest` a type

### DIFF
--- a/certval/Cargo.toml
+++ b/certval/Cargo.toml
@@ -84,7 +84,7 @@ tokio-test = "0.4.2"
 [features]
 default = ["remote", "webpki"]
 revocation = ["ndarray"]
-std = ["ndarray", "tokio", "base64ct", "walkdir", "url", "serde_json", "serde/rc",  "flagset/serde", "regex", "lazy_static/spin", "bitvec", "cidr"]
+std = ["ndarray", "tokio", "base64ct", "walkdir", "url", "serde_json", "serde/rc",  "flagset/serde", "regex", "lazy_static/spin", "bitvec", "cidr", "der/std"]
 remote = ["revocation", "std", "reqwest", "lazy_static/spin"]
 pqc = ["pqcrypto-internals", "pqcrypto-dilithium", "pqcrypto-falcon", "pqcrypto-sphincsplus", "pqcrypto", "pqcrypto-traits", "pqckeys"]
 webpki = ["webpki-roots"]

--- a/certval/src/builder/file_utils.rs
+++ b/certval/src/builder/file_utils.rs
@@ -41,7 +41,7 @@ pub fn ta_folder_to_vec(
     pe: &PkiEnvironment,
     tas_dir: &str,
     tas_vec: &mut dyn CertVector,
-    time_of_interest: u64,
+    time_of_interest: TimeOfInterest,
 ) -> Result<usize> {
     cert_or_ta_folder_to_vec(pe, tas_dir, tas_vec, time_of_interest, true)
 }
@@ -60,7 +60,7 @@ pub fn cert_folder_to_vec(
     pe: &PkiEnvironment,
     certs_dir: &str,
     certs_vec: &mut dyn CertVector,
-    time_of_interest: u64,
+    time_of_interest: TimeOfInterest,
 ) -> Result<usize> {
     cert_or_ta_folder_to_vec(pe, certs_dir, certs_vec, time_of_interest, false)
 }
@@ -71,7 +71,7 @@ fn cert_or_ta_folder_to_vec(
     pe: &PkiEnvironment,
     certsdir: &str,
     certsvec: &mut dyn CertVector,
-    time_of_interest: u64,
+    time_of_interest: TimeOfInterest,
     collect_tas: bool,
 ) -> Result<usize> {
     if !Path::is_dir(Path::new(certsdir)) {
@@ -275,7 +275,7 @@ pub fn get_file_as_byte_vec_pem(filename: &Path) -> Result<Vec<u8>> {
 fn non_existent_dir() {
     let pe = PkiEnvironment::default();
     let mut certsvec = CertSource::default();
-    let toi = 0;
+    let toi = TimeOfInterest::disabled();
     let r = cert_or_ta_folder_to_vec(&pe, "tests/examples/nonexistent", &mut certsvec, toi, false);
     assert!(r.is_err());
     let r = r.err();
@@ -288,7 +288,7 @@ fn with_expired() {
 
     //disable validity check
     let mut certsvec = CertSource::default();
-    let toi = 0;
+    let toi = TimeOfInterest::disabled();
     let r = cert_or_ta_folder_to_vec(
         &pe,
         "tests/examples/cert_store_with_expired",
@@ -300,7 +300,7 @@ fn with_expired() {
     assert_eq!(5, r.unwrap());
 
     //enable validity check but vector is already full of what would otherwise be read
-    let toi = 1647443375;
+    let toi = TimeOfInterest::from_unix_secs(1647443375).unwrap();
     let r = cert_or_ta_folder_to_vec(
         &pe,
         "tests/examples/cert_store_with_expired",
@@ -313,7 +313,7 @@ fn with_expired() {
 
     // validity check with empty vector results in one fewer certificate being harvested
     let mut certsvec = CertSource::default();
-    let toi = 1647443375;
+    let toi = TimeOfInterest::from_unix_secs(1647443375).unwrap();
     let r = cert_or_ta_folder_to_vec(
         &pe,
         "tests/examples/cert_store_with_expired",

--- a/certval/src/builder/graph_builder.rs
+++ b/certval/src/builder/graph_builder.rs
@@ -205,7 +205,13 @@ async fn non_existent_dir() {
     pe.populate_5280_pki_environment();
 
     let mut ta_store = TaSource::new();
-    ta_folder_to_vec(&pe, &ta_store_folder, &mut ta_store, 0).unwrap();
+    ta_folder_to_vec(
+        &pe,
+        &ta_store_folder,
+        &mut ta_store,
+        TimeOfInterest::disabled(),
+    )
+    .unwrap();
     ta_store.initialize().unwrap();
 
     let mut cps = CertificationPathSettings::default();

--- a/certval/src/builder/uri_utils.rs
+++ b/certval/src/builder/uri_utils.rs
@@ -46,7 +46,7 @@ fn save_certs_from_p7(
     bytes: &[u8],
     target: &str,
     buffers: &mut dyn CertVector,
-    time_of_interest: u64,
+    time_of_interest: TimeOfInterest,
 ) -> bool {
     let mut at_least_one_saved = false;
     let filename = if let Some(fname) = filename.to_str() {
@@ -103,7 +103,7 @@ fn save_cert(
     bytes: &[u8],
     target: &str,
     buffers: &mut dyn CertVector,
-    time_of_interest: u64,
+    time_of_interest: TimeOfInterest,
 ) -> bool {
     let mut saved = false;
     let filename = if let Some(fname) = filename.to_str() {
@@ -179,7 +179,7 @@ pub async fn fetch_to_buffer(
     start_index: usize,
     last_mod_map: &mut BTreeMap<String, String>,
     blocklist: &mut Vec<String>,
-    time_of_interest: u64,
+    time_of_interest: TimeOfInterest,
 ) -> Result<()> {
     // Downloaded artifacts are saved for future use, create a path object for that folder
     let path = Path::new(folder);

--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -46,7 +46,7 @@ use crate::PathValidationStatus::RevocationStatusNotDetermined;
 use crate::{
     environment::pki_environment_traits::*, path_settings::*, util::crypto::*, util::error::*,
     util::pdv_utilities::oid_lookup, validate_path_rfc5280, CertificationPath,
-    CertificationPathResults, PDVCertificate, PDVTrustAnchorChoice,
+    CertificationPathResults, PDVCertificate, PDVTrustAnchorChoice, TimeOfInterest,
 };
 
 /// [`PkiEnvironment`] provides a switchboard of callback functions that allow support to vary on
@@ -451,7 +451,11 @@ impl PkiEnvironment {
     }
 
     /// Retrieves cached revocation status determination for given certificate from store
-    pub fn get_status(&self, cert: &PDVCertificate, time_of_interest: u64) -> PathValidationStatus {
+    pub fn get_status(
+        &self,
+        cert: &PDVCertificate,
+        time_of_interest: TimeOfInterest,
+    ) -> PathValidationStatus {
         for f in &self.revocation_cache {
             let status = f.get_status(cert, time_of_interest);
             if RevocationStatusNotDetermined != status {
@@ -481,7 +485,7 @@ impl PkiEnvironment {
         target: &PDVCertificate,
         paths: &mut Vec<CertificationPath>,
         threshold: usize,
-        time_of_interest: u64,
+        time_of_interest: TimeOfInterest,
     ) -> Result<()> {
         for f in &self.certificate_sources {
             let r = f.get_paths_for_target(pe, target, paths, threshold, time_of_interest);

--- a/certval/src/environment/pki_environment_traits.rs
+++ b/certval/src/environment/pki_environment_traits.rs
@@ -11,7 +11,7 @@ use x509_cert::{certificate::Raw, crl::CertificateList, name::Name};
 use crate::util::error::*;
 use crate::{
     CertFile, CertificationPath, CertificationPathResults, CertificationPathSettings,
-    PDVCertificate, PDVTrustAnchorChoice, PkiEnvironment,
+    PDVCertificate, PDVTrustAnchorChoice, PkiEnvironment, TimeOfInterest,
 };
 
 /// `ValidatePath` provides a function signature for implementations that perform certification path
@@ -132,7 +132,7 @@ pub trait CertificateSource {
         target: &PDVCertificate,
         paths: &mut Vec<CertificationPath>,
         threshold: usize,
-        time_of_interest: u64,
+        time_of_interest: TimeOfInterest,
     ) -> Result<()>;
 }
 
@@ -172,7 +172,11 @@ pub trait CheckRemoteResource {
 pub trait RevocationStatusCache {
     /// Returns Ok(Valid) is status is known to be good at time of interest, Ok(Revoked) if
     /// certificate is known to be revoked and Err(RevocationStatusDetermined) otherwise.
-    fn get_status(&self, cert: &PDVCertificate, time_of_interest: u64) -> PathValidationStatus;
+    fn get_status(
+        &self,
+        cert: &PDVCertificate,
+        time_of_interest: TimeOfInterest,
+    ) -> PathValidationStatus;
 
     /// Sets status for certificate to one of Valid or Revoked and a next update value.
     fn add_status(&self, cert: &PDVCertificate, next_update: u64, status: PathValidationStatus);

--- a/certval/src/revocation/ocsp_client.rs
+++ b/certval/src/revocation/ocsp_client.rs
@@ -127,20 +127,20 @@ fn cert_id_match(
 
 fn check_response_time(cps: &CertificationPathSettings, sr: &SingleResponse) -> bool {
     let time_of_interest = cps.get_time_of_interest();
-    if 0 == time_of_interest {
+    if time_of_interest.is_disabled() {
         return true;
     }
 
     // TODO support grace periods?
 
-    let tu = sr.this_update.0.to_unix_duration().as_secs();
+    let tu = sr.this_update.0;
     if tu > time_of_interest {
         //future request
         return false;
     }
 
     if let Some(next_update) = sr.next_update {
-        let nu = next_update.0.to_unix_duration().as_secs();
+        let nu = next_update.0;
         if nu < time_of_interest {
             //stale
             return false;
@@ -543,7 +543,7 @@ fn process_ocsp_response_internal(
                             }
 
                             let time_of_interest = cps.get_time_of_interest();
-                            if 0 != time_of_interest {
+                            if time_of_interest.is_disabled() {
                                 let target_ttl =
                                     valid_at_time(&cert.tbs_certificate, time_of_interest, false);
                                 if let Err(_e) = target_ttl {

--- a/certval/src/source/ta_source.rs
+++ b/certval/src/source/ta_source.rs
@@ -469,7 +469,13 @@ fn get_trust_anchor_test() {
 
     let mut pe = PkiEnvironment::default();
     pe.populate_5280_pki_environment();
-    ta_folder_to_vec(&pe, &ta_store_folder, &mut ta_store, 0).unwrap();
+    ta_folder_to_vec(
+        &pe,
+        &ta_store_folder,
+        &mut ta_store,
+        crate::TimeOfInterest::disabled(),
+    )
+    .unwrap();
     ta_store.initialize().unwrap();
     pe.add_trust_anchor_source(Box::new(ta_store.clone()));
     let bad = hex!("BA7816BF8F01CFEA414140DE5DAE2223B00361A396177A9CB410FF61F20015AD");

--- a/certval/src/util.rs
+++ b/certval/src/util.rs
@@ -4,5 +4,6 @@ pub mod crypto;
 pub mod error;
 pub mod pdv_alg_oids;
 pub mod pdv_utilities;
+pub mod time_of_interest;
 
-pub use crate::{util::crypto::*, util::error::*, util::pdv_alg_oids::*, util::pdv_utilities::*};
+pub use self::{crypto::*, error::*, pdv_alg_oids::*, pdv_utilities::*, time_of_interest::*};

--- a/certval/src/util/time_of_interest.rs
+++ b/certval/src/util/time_of_interest.rs
@@ -1,0 +1,162 @@
+//! Utils to define the time of interest when validating certificate
+
+use core::{cmp::Ordering, fmt, ops::Sub, time::Duration};
+
+/// Time of interest for the validation of a certificate or check against revocation.
+#[derive(Copy, Clone, Debug, Eq, PartialEq, PartialOrd, Ord)]
+pub struct TimeOfInterest(pub der::DateTime);
+
+impl fmt::Display for TimeOfInterest {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
+impl TimeOfInterest {
+    /// Make [`TimeOfInterest`] where checks are disabled
+    pub fn disabled() -> Self {
+        TimeOfInterest(
+            der::DateTime::from_unix_duration(Duration::ZERO)
+                // NOTE(safety): only values before 1970 or values after 9999 would be throwing errors
+                .expect("Could not create a DateTime from Unix Epoch"),
+        )
+    }
+
+    /// Should time checks be disabled?
+    pub fn is_disabled(&self) -> bool {
+        self.0.unix_duration() == Duration::ZERO
+    }
+
+    /// Create a [`TimeOfInterest`] from Unix epoch
+    pub fn from_unix_secs(v: u64) -> der::Result<Self> {
+        Ok(Self(der::DateTime::from_unix_duration(
+            Duration::from_secs(v),
+        )?))
+    }
+
+    /// Return Unix epoch (in seconds) for this value
+    pub fn as_unix_secs(&self) -> u64 {
+        self.0.unix_duration().as_secs()
+    }
+}
+
+#[cfg(not(feature = "std"))]
+impl Default for TimeOfInterest {
+    fn default() -> Self {
+        Self::disabled()
+    }
+}
+
+impl PartialEq<x509_cert::time::Time> for TimeOfInterest {
+    fn eq(&self, other: &x509_cert::time::Time) -> bool {
+        self.0.eq(&other.to_date_time())
+    }
+}
+
+impl PartialOrd<x509_cert::time::Time> for TimeOfInterest {
+    fn partial_cmp(&self, other: &x509_cert::time::Time) -> Option<Ordering> {
+        self.0.partial_cmp(&other.to_date_time())
+    }
+}
+
+impl PartialEq<TimeOfInterest> for x509_cert::time::Time {
+    fn eq(&self, other: &TimeOfInterest) -> bool {
+        self.to_date_time().eq(&other.0)
+    }
+}
+
+impl PartialOrd<TimeOfInterest> for x509_cert::time::Time {
+    fn partial_cmp(&self, other: &TimeOfInterest) -> Option<Ordering> {
+        self.to_date_time().partial_cmp(&other.0)
+    }
+}
+
+impl PartialEq<der::asn1::GeneralizedTime> for TimeOfInterest {
+    fn eq(&self, other: &der::asn1::GeneralizedTime) -> bool {
+        self.0.eq(&other.to_date_time())
+    }
+}
+
+impl PartialOrd<der::asn1::GeneralizedTime> for TimeOfInterest {
+    fn partial_cmp(&self, other: &der::asn1::GeneralizedTime) -> Option<Ordering> {
+        self.0.partial_cmp(&other.to_date_time())
+    }
+}
+
+impl PartialEq<TimeOfInterest> for der::asn1::GeneralizedTime {
+    fn eq(&self, other: &TimeOfInterest) -> bool {
+        self.to_date_time().eq(&other.0)
+    }
+}
+
+impl PartialOrd<TimeOfInterest> for der::asn1::GeneralizedTime {
+    fn partial_cmp(&self, other: &TimeOfInterest) -> Option<Ordering> {
+        self.to_date_time().partial_cmp(&other.0)
+    }
+}
+
+impl Sub<TimeOfInterest> for x509_cert::time::Time {
+    type Output = u64;
+    fn sub(self, other: TimeOfInterest) -> Self::Output {
+        self.to_unix_duration().as_secs() - other.as_unix_secs()
+    }
+}
+
+#[cfg(feature = "std")]
+mod std {
+    use super::*;
+    use serde::{
+        de::{self, Deserializer, Visitor},
+        ser::Serializer,
+        Deserialize, Serialize,
+    };
+
+    impl Serialize for TimeOfInterest {
+        fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+        where
+            S: Serializer,
+        {
+            serializer.serialize_u64(self.as_unix_secs())
+        }
+    }
+
+    impl<'de> Deserialize<'de> for TimeOfInterest {
+        fn deserialize<D>(deserializer: D) -> Result<TimeOfInterest, D::Error>
+        where
+            D: Deserializer<'de>,
+        {
+            struct ToiVisitor;
+
+            impl<'de> Visitor<'de> for ToiVisitor {
+                type Value = TimeOfInterest;
+
+                fn expecting(&self, formatter: &mut fmt::Formatter<'_>) -> fmt::Result {
+                    formatter.write_str("an integer between 0 and 2^64")
+                }
+
+                fn visit_u64<E>(self, value: u64) -> Result<Self::Value, E>
+                where
+                    E: de::Error,
+                {
+                    TimeOfInterest::from_unix_secs(value)
+                        .map_err(|_| E::custom("time of interest out of range: {value}"))
+                }
+            }
+
+            deserializer.deserialize_u64(ToiVisitor)
+        }
+    }
+
+    impl TimeOfInterest {
+        /// Creates a [`TimeOfInterest`] for today's date
+        pub fn now() -> Self {
+            Self(der::DateTime::from_system_time(::std::time::SystemTime::now()).unwrap())
+        }
+    }
+
+    impl Default for TimeOfInterest {
+        fn default() -> Self {
+            Self::now()
+        }
+    }
+}

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -196,7 +196,7 @@ pub fn check_validity(
     // RFC 5280 states: (2)  The certificate validity period includes the current time.
     // get_time_of_interest_or_now will return now or a caller specified time of interest.
     let toi = cps.get_time_of_interest();
-    if 0 == toi {
+    if toi.is_disabled() {
         info!("check_validity invoked with no time of interest; validity check disabled",);
         return Ok(());
     }

--- a/certval/tests/path_settings.rs
+++ b/certval/tests/path_settings.rs
@@ -2,6 +2,7 @@
 
 use certval::path_settings::*;
 use certval::CertificationPathSettings;
+use certval::TimeOfInterest;
 use const_oid::db::rfc5280::ANY_POLICY;
 use x509_cert::ext::pkix::KeyUsages;
 
@@ -16,7 +17,6 @@ fn path_settings_serialize_deserialize() {
 #[test]
 fn settings_serialization_test() {
     use const_oid::db::rfc5280::ID_KP_SERVER_AUTH;
-    use std::time::{SystemTime, UNIX_EPOCH};
 
     let mut cps = CertificationPathSettings::new();
     cps.set_initial_explicit_policy_indicator(true);
@@ -44,12 +44,7 @@ fn settings_serialization_test() {
         not_supported: None,
     };
     cps.set_initial_excluded_subtrees(excl);
-    let toi = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {
-        n.as_secs()
-    } else {
-        0
-    };
-    cps.set_time_of_interest(toi);
+    cps.set_time_of_interest(TimeOfInterest::now());
     let ekus = vec![ID_KP_SERVER_AUTH.to_string()];
     cps.set_extended_key_usage(ekus);
     cps.set_extended_key_usage_path(false);

--- a/certval/tests/pkits_data.rs
+++ b/certval/tests/pkits_data.rs
@@ -116,7 +116,7 @@ lazy_static! {
     pub static ref G_DEFAULT_SETTINGS: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest( t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         cs
     };
     pub static ref G_DEFAULT_SETTINGS_TA: String = {
@@ -127,7 +127,7 @@ lazy_static! {
     pub static ref G_DEFAULT_SETTINGS_5914: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest(t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         cs.set_enforce_trust_anchor_constraints( true);
         cs
     };
@@ -136,7 +136,7 @@ lazy_static! {
     pub static ref G_SETTINGS1: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest( t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         cs.set_initial_explicit_policy_indicator(true);
         cs
     };
@@ -147,7 +147,7 @@ lazy_static! {
     pub static ref G_SETTINGS2: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest( t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         cs.set_initial_explicit_policy_indicator( true);
         let mut oids = ObjectIdentifierSet::new();
         oids.insert(PKITS_TEST_POLICY_1);
@@ -161,7 +161,7 @@ lazy_static! {
     pub static ref G_SETTINGS3: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest(t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         cs.set_initial_explicit_policy_indicator(true);
         let mut oids = ObjectIdentifierSet::new();
         oids.insert(PKITS_TEST_POLICY_2);
@@ -175,7 +175,7 @@ lazy_static! {
     pub static ref G_SETTINGS4: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest(t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         cs.set_initial_explicit_policy_indicator( true);
         let mut oids = ObjectIdentifierSet::new();
         oids.insert(PKITS_TEST_POLICY_1);
@@ -191,7 +191,7 @@ lazy_static! {
     pub static ref G_SETTINGS5: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest(t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         let mut oids = ObjectIdentifierSet::new();
         oids.insert(PKITS_TEST_POLICY_1);
         cs.set_initial_policy_set_from_oid_set( oids);
@@ -204,7 +204,7 @@ lazy_static! {
     pub static ref G_SETTINGS6: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest(t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         let mut oids = ObjectIdentifierSet::new();
         oids.insert(PKITS_TEST_POLICY_2);
         cs.set_initial_policy_set_from_oid_set( oids);
@@ -217,7 +217,7 @@ lazy_static! {
     pub static ref G_SETTINGS7: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest( t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         let mut oids = ObjectIdentifierSet::new();
         oids.insert(PKITS_TEST_POLICY_3);
         cs.set_initial_policy_set_from_oid_set( oids);
@@ -231,7 +231,7 @@ lazy_static! {
     pub static ref G_SETTINGS8: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest( t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         cs.set_initial_policy_mapping_inhibit_indicator( true);
         cs
     };
@@ -243,7 +243,7 @@ lazy_static! {
     pub static ref G_SETTINGS9: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest( t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         let mut oids = ObjectIdentifierSet::new();
         oids.insert(PKITS_TEST_POLICY_6);
         cs.set_initial_policy_set_from_oid_set( oids);
@@ -257,7 +257,7 @@ lazy_static! {
     pub static ref G_SETTINGS10: CertificationPathSettings = {
         let mut cs = CertificationPathSettings::new();
         let t = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {n.as_secs()} else {0};
-        cs.set_time_of_interest(t);
+        cs.set_time_of_interest(TimeOfInterest::from_unix_secs(t).unwrap());
         cs.set_initial_inhibit_any_policy_indicator(true);
         cs
     };

--- a/certval/tests/revocation.rs
+++ b/certval/tests/revocation.rs
@@ -241,7 +241,7 @@ async fn stapled_crl_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1646567209);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1646567209).unwrap());
         let mut r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -253,7 +253,7 @@ async fn stapled_crl_async() {
     }
     #[cfg(feature = "remote")]
     {
-        cps.set_time_of_interest(1646567209);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1646567209).unwrap());
         let mut r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -325,7 +325,7 @@ async fn stapled_mix_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1646567209);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1646567209).unwrap());
         let mut r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -337,7 +337,7 @@ async fn stapled_mix_async() {
     }
     #[cfg(feature = "remote")]
     {
-        cps.set_time_of_interest(1646567209);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1646567209).unwrap());
         let mut r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -349,7 +349,7 @@ async fn stapled_mix_async() {
     }
     #[cfg(not(feature = "remote"))]
     {
-        cps.set_time_of_interest(1649245609);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1649245609).unwrap());
         let r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -392,7 +392,10 @@ async fn cached_crl_async() {
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("tests/examples/makaan.com/crls");
     let crl_source = CrlSourceFolders::new(d.as_path().to_str().unwrap());
-    if crl_source.index_crls(1647011592).is_err() {
+    if crl_source
+        .index_crls(TimeOfInterest::from_unix_secs(1647011592).unwrap())
+        .is_err()
+    {
         panic!("Failed to index CRLs")
     }
 
@@ -415,7 +418,7 @@ async fn cached_crl_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1647011592);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1647011592).unwrap());
         let mut r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -431,7 +434,7 @@ async fn cached_crl_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1647011592);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1647011592).unwrap());
         let mut r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -471,7 +474,10 @@ async fn cached_crl_revoked_async() {
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("tests/examples/intel.com/crls");
     let crl_source = CrlSourceFolders::new(d.as_path().to_str().unwrap());
-    if crl_source.index_crls(1647011592).is_err() {
+    if crl_source
+        .index_crls(TimeOfInterest::from_unix_secs(1647011592).unwrap())
+        .is_err()
+    {
         panic!("Failed to index CRLs")
     }
 
@@ -491,7 +497,7 @@ async fn cached_crl_revoked_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1647011592);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1647011592).unwrap());
         let r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -510,7 +516,7 @@ async fn cached_crl_revoked_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1647011592);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1647011592).unwrap());
         let r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -553,7 +559,10 @@ async fn cached_crl_revoked_remote_async() {
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("tests/examples/intel.com/crls2");
     let crl_source = CrlSourceFolders::new(d.as_path().to_str().unwrap());
-    if crl_source.index_crls(1647011592).is_err() {
+    if crl_source
+        .index_crls(TimeOfInterest::from_unix_secs(1647011592).unwrap())
+        .is_err()
+    {
         panic!("Failed to index CRLs")
     }
 
@@ -572,7 +581,7 @@ async fn cached_crl_revoked_remote_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1647011592);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1647011592).unwrap());
         let r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -592,7 +601,7 @@ async fn cached_crl_revoked_remote_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1647011592);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1647011592).unwrap());
         let r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -635,7 +644,10 @@ async fn cached_crl_remote_async() {
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("tests/examples/makaan.com/crls2");
     let crl_source = CrlSourceFolders::new(d.as_path().to_str().unwrap());
-    if crl_source.index_crls(1647011592).is_err() {
+    if crl_source
+        .index_crls(TimeOfInterest::from_unix_secs(1647011592).unwrap())
+        .is_err()
+    {
         panic!("Failed to index CRLs")
     }
 
@@ -654,7 +666,7 @@ async fn cached_crl_remote_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1647011592);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1647011592).unwrap());
         let mut r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");
@@ -670,7 +682,7 @@ async fn cached_crl_remote_async() {
     let mut cpr = CertificationPathResults::new();
 
     {
-        cps.set_time_of_interest(1647011592);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1647011592).unwrap());
         let mut r = pe.validate_path(&pe, &cps, &mut cert_path, &mut cpr);
         if r.is_err() {
             panic!("Failed to successfully validate path");

--- a/pittv3/src/options_std.rs
+++ b/pittv3/src/options_std.rs
@@ -209,7 +209,12 @@ pub async fn options_std(args: &Pittv3Args) {
         // Load up the trust anchors. This occurs once and is not effected by the dynamic_build flag.
         if let Some(ta_folder) = &args.ta_folder {
             let mut ta_store = TaSource::new();
-            let r = ta_folder_to_vec(&pe, ta_folder, &mut ta_store, args.time_of_interest);
+            let r = ta_folder_to_vec(
+                &pe,
+                ta_folder,
+                &mut ta_store,
+                TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
+            );
             if let Err(e) = r {
                 println!(
                     "Failed to load trust anchors from {} with error {:?}",
@@ -276,7 +281,7 @@ pub async fn options_std(args: &Pittv3Args) {
         };
 
         let mut cps = CertificationPathSettings::new();
-        cps.set_time_of_interest(args.time_of_interest);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap());
 
         let mut pe = PkiEnvironment::default();
 
@@ -323,7 +328,12 @@ pub async fn options_std(args: &Pittv3Args) {
         let mut ta_store = TaSource::new();
 
         if let Some(ta_folder) = &args.ta_folder {
-            let r = ta_folder_to_vec(&pe, ta_folder, &mut ta_store, args.time_of_interest);
+            let r = ta_folder_to_vec(
+                &pe,
+                ta_folder,
+                &mut ta_store,
+                TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
+            );
             if let Err(e) = r {
                 println!(
                     "Failed to load trust anchors from {} with error {:?}",
@@ -398,7 +408,7 @@ pub async fn options_std(args: &Pittv3Args) {
                         0,
                         &mut lmm,
                         &mut blocklist,
-                        args.time_of_interest,
+                        TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
                     )
                     .await;
                     if let Err(e) = r {
@@ -455,7 +465,10 @@ pub async fn options_std(args: &Pittv3Args) {
 
             let parsed_cert = parse_cert(target.as_slice(), cert_filename.as_str());
             if let Ok(target_cert) = parsed_cert {
-                cert_source.log_paths_for_target(&target_cert, args.time_of_interest);
+                cert_source.log_paths_for_target(
+                    &target_cert,
+                    TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
+                );
             }
         }
         if let Some(leaf_ca_index) = args.list_partial_paths_for_leaf_ca {
@@ -612,7 +625,7 @@ async fn generate_and_validate(args: &Pittv3Args) {
     };
 
     if !cps.0.contains_key(PS_TIME_OF_INTEREST) {
-        cps.set_time_of_interest(args.time_of_interest);
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap());
     }
 
     #[cfg(feature = "remote")]
@@ -646,7 +659,12 @@ async fn generate_and_validate(args: &Pittv3Args) {
     // Load up the trust anchors. This occurs once and is not effected by the dynamic_build flag.
     if let Some(ta_folder) = &args.ta_folder {
         let mut ta_store = TaSource::new();
-        let r = ta_folder_to_vec(&pe, ta_folder, &mut ta_store, args.time_of_interest);
+        let r = ta_folder_to_vec(
+            &pe,
+            ta_folder,
+            &mut ta_store,
+            TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
+        );
         if let Err(e) = r {
             println!(
                 "Failed to load trust anchors from {} with error {:?}",
@@ -800,7 +818,7 @@ async fn generate_and_validate(args: &Pittv3Args) {
                         &pe,
                         download_folder,
                         &mut cert_source,
-                        args.time_of_interest,
+                        TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
                     )
                     .is_err()
                     {
@@ -822,7 +840,7 @@ async fn generate_and_validate(args: &Pittv3Args) {
                     },
                     &mut lmm,
                     &mut blocklist,
-                    args.time_of_interest,
+                    TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
                 )
                 .await;
 

--- a/pittv3/src/pitt_log.rs
+++ b/pittv3/src/pitt_log.rs
@@ -783,8 +783,6 @@ fn test_cps_log() {
     use certval::validator::path_settings::*;
 
     #[cfg(feature = "std_app")]
-    use std::time::{SystemTime, UNIX_EPOCH};
-
     let mut cps = CertificationPathSettings::new();
     cps.set_initial_explicit_policy_indicator(true);
     cps.set_initial_policy_mapping_inhibit_indicator(true);
@@ -811,12 +809,7 @@ fn test_cps_log() {
         not_supported: None,
     };
     cps.set_initial_excluded_subtrees(excl);
-    let toi = if let Ok(n) = SystemTime::now().duration_since(UNIX_EPOCH) {
-        n.as_secs()
-    } else {
-        0
-    };
-    cps.set_time_of_interest(toi);
+    cps.set_time_of_interest(TimeOfInterest::default());
     let ekus = vec![ID_KP_SERVER_AUTH.to_string()];
     cps.set_extended_key_usage(ekus);
     cps.set_extended_key_usage_path(false);

--- a/pittv3/src/std_utils.rs
+++ b/pittv3/src/std_utils.rs
@@ -294,7 +294,7 @@ pub fn cleanup_certs(
     certs_folder: &str,
     error_folder: &str,
     report_only: bool,
-    t: u64,
+    t: TimeOfInterest,
 ) {
     for entry in WalkDir::new(certs_folder) {
         match entry {
@@ -332,7 +332,7 @@ pub fn cleanup_certs(
                     let mut delete_file = false;
                     match parse_cert(target.as_slice(), filename) {
                         Ok(tc) => {
-                            if t > 0 {
+                            if !t.is_disabled() {
                                 let r = valid_at_time(&tc.decoded_cert.tbs_certificate, t, true);
                                 if let Err(_e) = r {
                                     delete_file = true;
@@ -392,7 +392,7 @@ pub fn cleanup_tas(
     tas_folder: &str,
     error_folder: &str,
     report_only: bool,
-    t: u64,
+    t: TimeOfInterest,
 ) {
     for entry in WalkDir::new(tas_folder) {
         match entry {
@@ -495,7 +495,7 @@ pub fn cleanup(pe: &PkiEnvironment, args: &Pittv3Args) {
         ca_folder,
         error_folder,
         args.report_only,
-        args.time_of_interest,
+        TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
     );
 }
 
@@ -519,6 +519,6 @@ pub fn ta_cleanup(pe: &PkiEnvironment, args: &Pittv3Args) {
         ta_folder,
         error_folder,
         args.report_only,
-        args.time_of_interest,
+        TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
     );
 }

--- a/support/x509-limbo-tests/src/main.rs
+++ b/support/x509-limbo-tests/src/main.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::BTreeMap,
-    time::{Duration, Instant, SystemTime, UNIX_EPOCH},
+    time::{Duration, Instant},
 };
 
 use std::net::{Ipv4Addr, Ipv6Addr};
@@ -33,7 +33,7 @@ use certval::{
     enforce_trust_anchor_constraints, name_constraints_settings_to_name_constraints_set, CertFile,
     CertSource, CertVector, CertificationPath, CertificationPathResults, CertificationPathSettings,
     ExtensionProcessing, NameConstraintsSettings, PDVCertificate, PDVExtension, PkiEnvironment,
-    TaSource,
+    TaSource, TimeOfInterest,
 };
 
 type Certificate = CertificateInner<Raw>;
@@ -351,11 +351,8 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
     cps.set_enforce_trust_anchor_constraints(true);
 
     let time_of_interest = match tc.validation_time {
-        Some(toi) => toi.timestamp() as u64,
-        None => SystemTime::now()
-            .duration_since(UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
+        Some(toi) => TimeOfInterest::from_unix_secs(toi.timestamp() as u64).unwrap(),
+        None => TimeOfInterest::now(),
     };
     cps.set_time_of_interest(time_of_interest);
 


### PR DESCRIPTION
By having a dedicated type, we can add specific methods like `now`, `disabled`, ... and we also make sure we can't mix up or do bad operations on our time of interest.