### PR TITLE
certval: `pe` argument to `get_paths_for_target` is not required

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -481,7 +481,6 @@ impl PkiEnvironment {
     /// a vector of [`CertificationPath`] objects.
     pub fn get_paths_for_target(
         &self,
-        pe: &PkiEnvironment,
         target: &PDVCertificate,
         paths: &mut Vec<CertificationPath>,
         threshold: usize,
@@ -489,14 +488,15 @@ impl PkiEnvironment {
     ) -> Result<()> {
         let mut some_valid = false;
         for f in &self.certificate_sources {
-            if f.get_paths_for_target(pe, target, paths, threshold, time_of_interest).is_ok() {
+            if f.get_paths_for_target(self, target, paths, threshold, time_of_interest)
+                .is_ok()
+            {
                 some_valid = true;
             }
         }
         if some_valid {
             Ok(())
-        }
-        else {
+        } else {
             Err(Error::Unrecognized)
         }
     }

--- a/pittv3/src/no_std_utils.rs
+++ b/pittv3/src/no_std_utils.rs
@@ -32,7 +32,7 @@ pub(crate) fn validate_cert(
     stats.files_processed += 1;
 
     let mut paths: Vec<CertificationPath> = vec![];
-    let r = pe.get_paths_for_target(pe, &target_cert, &mut paths, 0, time_of_interest);
+    let r = pe.get_paths_for_target(&target_cert, &mut paths, 0, time_of_interest);
     if let Err(e) = r {
         println!(
             "Failed to find certification paths for target with error {:?}",

--- a/pittv3/src/std_utils.rs
+++ b/pittv3/src/std_utils.rs
@@ -64,7 +64,7 @@ pub(crate) async fn validate_cert_file(
     stats.files_processed += 1;
 
     let mut paths: Vec<CertificationPath> = vec![];
-    let r = pe.get_paths_for_target(pe, &target_cert, &mut paths, threshold, time_of_interest);
+    let r = pe.get_paths_for_target(&target_cert, &mut paths, threshold, time_of_interest);
     if let Err(e) = r {
         println!(
             "Failed to find certification paths for target with error {:?}",

--- a/support/x509-limbo-tests/src/main.rs
+++ b/support/x509-limbo-tests/src/main.rs
@@ -420,7 +420,7 @@ fn evaluate_testcase(tc: &Testcase) -> TestcaseResult {
 
     // find all paths in the graph built above
     let mut paths: Vec<CertificationPath> = vec![];
-    pe.get_paths_for_target(&pe, &leaf, &mut paths, 0, time_of_interest)
+    pe.get_paths_for_target(&leaf, &mut paths, 0, time_of_interest)
         .unwrap();
 
     let mut observed_status_values = vec![];


### PR DESCRIPTION
`get_paths_for_target` already takes a reference to the `PkiEnvironment` while it's already an object method.