### PR TITLE
update get_trust_anchors to not just return the first result

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -370,16 +370,15 @@ impl PkiEnvironment {
         Err(Error::Unrecognized)
     }
 
-    /// get_trust_anchor iterates over trust_anchor_sources until an authoritative answer is found
-    /// or all options have been exhausted
-    pub fn get_trust_anchors(&self) -> Result<Vec<&PDVTrustAnchorChoice>> {
-        for f in &self.trust_anchor_sources {
-            let r = f.get_trust_anchors();
-            if let Ok(r) = r {
-                return Ok(r);
-            }
-        }
-        Err(Error::Unrecognized)
+    /// get_trust_anchors returns the trust anchors from every registered trust anchor source,
+    /// merged into a single collection. Sources that yield no anchors are skipped (previously only
+    /// the first source that returned successfully was consulted; see issue #79).
+    pub fn get_trust_anchors(&self) -> Vec<&PDVTrustAnchorChoice> {
+        self.trust_anchor_sources
+            .iter()
+            .filter_map(|src| src.get_trust_anchors().ok())
+            .flatten()
+            .collect()
     }
 
     /// get_trust_anchor_by_hex_skid returns a reference to a trust anchor corresponding to the presented hexadecimal SKID.

--- a/certval/src/util/pdv_utilities.rs
+++ b/certval/src/util/pdv_utilities.rs
@@ -332,7 +332,10 @@ pub fn descended_from_host(prev_name: &Ia5String, cand: &str, is_uri: bool) -> b
 
     let mut filter = regex::escape(base.as_str());
     filter.push('$');
-    let filter_re = Regex::new(filter.as_str());
+    // DNS names and URI hosts are case-insensitive.
+    let filter_re = regex::RegexBuilder::new(filter.as_str())
+        .case_insensitive(true)
+        .build();
     if let Ok(fe) = filter_re {
         if let Some(parts) = fe.captures(cand) {
             if cand.len() == base.len() {
@@ -375,7 +378,7 @@ pub fn descended_from_host(prev_name: &Ia5String, cand: &str, is_uri: bool) -> b
 pub(crate) fn is_email(addr: &str) -> bool {
     lazy_static! {
         static ref EMAIL_RE: Regex = Regex::new(
-            "^([a-z0-9_+]([a-z0-9_+.]*[a-z0-9_+])?)@([a-z0-9]+([-.]{1}[a-z0-9]+)*.[a-z]{2,6})"
+            "(?i)^([a-z0-9_+]([a-z0-9_+.]*[a-z0-9_+])?)@([a-z0-9]+([-.]{1}[a-z0-9]+)*.[a-z]{2,6})"
         )
         .unwrap();
     }
@@ -392,11 +395,20 @@ pub(crate) fn is_email(addr: &str) -> bool {
 #[cfg(feature = "std")]
 pub(crate) fn descended_from_rfc822(prev_name: &Ia5String, new_name: &Ia5String) -> bool {
     let cand = new_name.to_string();
+    // A candidate rfc822Name must be a single well-formed mailbox. A malformed address such as
+    // "a@b@example.com" is not within any permitted namespace even though it ends with a permitted
+    // host, so reject anything that does not contain exactly one '@'.
+    if cand.matches('@').count() != 1 {
+        return false;
+    }
     let base = prev_name.to_string();
 
     let mut filter = regex::escape(base.as_str());
     filter.push('$');
-    let filter_re = Regex::new(filter.as_str());
+    // rfc822 name matching is case-insensitive.
+    let filter_re = regex::RegexBuilder::new(filter.as_str())
+        .case_insensitive(true)
+        .build();
     if let Ok(fe) = filter_re {
         if let Some(parts) = fe.captures(cand.as_str()) {
             if is_email(base.as_str()) && cand.len() == base.len() {
@@ -497,7 +509,7 @@ pub(crate) fn descended_from_dn(subtree: &Name, name: &Name, min: u32, max: Opti
                 // diff number of attributes
                 return false;
             }
-            for (subtree_attr, name_attr) in subtree.iter().zip(name_rdn.iter()) {
+            for (subtree_attr, name_attr) in subtree_rdn.iter().zip(name_rdn.iter()) {
                 let lau = subtree_attr;
                 let rau = name_attr;
                 if lau.oid != rau.oid {
@@ -1003,4 +1015,56 @@ fn get_hash_alg_from_sig_alg_test() {
         get_hash_alg_from_sig_alg(&PKIXALG_SHA512_WITH_RSA_ENCRYPTION).unwrap(),
         ai512
     );
+}
+
+// DNS name constraints match case-insensitively (RFC 1035 Section 2.3.3, RFC 4343). Positive
+// (assert!) and negative (assert!(!...)) cases cover exact, sub-domain, and non-matching hosts.
+#[cfg(feature = "std")]
+#[test]
+fn descended_from_host_case_insensitive() {
+    let base = Ia5String::new("Example.COM").unwrap();
+    assert!(descended_from_host(&base, "example.com", false)); // exact host, differing case
+    assert!(descended_from_host(&base, "HOST.Example.com", false)); // sub-domain, differing case
+    assert!(!descended_from_host(&base, "host.notexample.com", false)); // suffix trap, not descended
+}
+
+// rfc822 name constraints match case-insensitively (RFC 5280 Section 4.1.2.6:
+// "subscriber@example.com" is the same as "SUBSCRIBER@EXAMPLE.COM").
+#[cfg(feature = "std")]
+#[test]
+fn descended_from_rfc822_case_insensitive() {
+    let ia5 = |s: &str| Ia5String::new(s).unwrap();
+    // host-part constraint
+    let host = ia5("Example.COM");
+    assert!(descended_from_rfc822(&host, &ia5("user@example.com")));
+    assert!(descended_from_rfc822(&host, &ia5("USER@EXAMPLE.COM")));
+    assert!(!descended_from_rfc822(&host, &ia5("user@notexample.com")));
+    // exact mailbox constraint
+    let mailbox = ia5("Admin@Example.COM");
+    assert!(descended_from_rfc822(&mailbox, &ia5("admin@example.com")));
+}
+
+// A malformed rfc822 name (not a single mailbox) is within no permitted namespace, even when it
+// ends with a permitted host.
+#[cfg(feature = "std")]
+#[test]
+fn descended_from_rfc822_rejects_malformed() {
+    let ia5 = |s: &str| Ia5String::new(s).unwrap();
+    let host = ia5("example.com");
+    assert!(!descended_from_rfc822(
+        &host,
+        &ia5("invalid@address@example.com")
+    )); // two '@'
+    assert!(!descended_from_rfc822(&host, &ia5("example.com"))); // no '@', not a mailbox
+}
+
+// descended_from_dn's char-set/case tolerance must compare the current subtree RDN's attributes,
+// not the whole subtree name flattened: a non-leading RDN that differs only by case must still be
+// recognized as descended.
+#[cfg(feature = "std")]
+#[test]
+fn descended_from_dn_uses_current_rdn_attributes() {
+    let subtree = Name::from_str("CN=Example,O=Org").unwrap();
+    let name = Name::from_str("CN=example,O=Org").unwrap();
+    assert!(descended_from_dn(&subtree, &name, 0, None));
 }

--- a/certval/tests/path_validator.rs
+++ b/certval/tests/path_validator.rs
@@ -143,6 +143,43 @@ fn is_trust_anchor_test() {
     assert!(pe.is_trust_anchor(&ta).is_ok());
 }
 
+// Regression test for issue #79: get_trust_anchors must merge anchors from every registered
+// source, not return only the first source's anchors.
+#[test]
+fn get_trust_anchors_merges_all_sources() {
+    let mut pe = PkiEnvironment::default();
+
+    let der_ta1 = include_bytes!("../tests/examples/TrustAnchorRootCertificate.crt");
+    let mut src1 = TaSource::new();
+    src1.push(CertFile {
+        bytes: der_ta1.to_vec(),
+        filename: "TrustAnchorRootCertificate.crt".to_string(),
+    });
+    src1.initialize().unwrap();
+
+    let der_ta2 = include_bytes!("../tests/examples/GoodCACert.crt");
+    let mut src2 = TaSource::new();
+    src2.push(CertFile {
+        bytes: der_ta2.to_vec(),
+        filename: "GoodCACert.crt".to_string(),
+    });
+    src2.initialize().unwrap();
+
+    // Each source individually exposes one anchor.
+    assert_eq!(src1.get_trust_anchors().unwrap().len(), 1);
+    assert_eq!(src2.get_trust_anchors().unwrap().len(), 1);
+
+    pe.add_trust_anchor_source(Box::new(src1));
+    pe.add_trust_anchor_source(Box::new(src2));
+
+    // The environment must surface anchors from both sources (pre-#79 returned only the first).
+    assert_eq!(
+        pe.get_trust_anchors().len(),
+        2,
+        "get_trust_anchors should merge anchors from all registered sources"
+    );
+}
+
 #[test]
 fn denies_self_signed_ee() {
     let _ = pretty_env_logger::try_init();

--- a/support/x509-limbo-tests/rust-certval.json
+++ b/support/x509-limbo-tests/rust-certval.json
@@ -315,7 +315,7 @@
     {
       "id": "rfc5280::nc::nc-permits-invalid-email-san",
       "actual_result": "FAILURE",
-      "context": "peer name check failed"
+      "context": "[]: [\"validate_path failed with PathValidation(NameConstraintsViolation)\"]"
     },
     {
       "id": "rfc5280::nc::nc-forbids-alternate-chain-ica",

--- a/support/x509-limbo-tests/src/main.rs
+++ b/support/x509-limbo-tests/src/main.rs
@@ -45,7 +45,7 @@ const WEAK_KEY_CHECKS: &[&str] = &[
     "webpki::forbidden-rsa-key-not-divisable-by-8-in-leaf",
 ];
 
-const BUG: &[&str] = &["rfc5280::nc::nc-permits-invalid-email-san"];
+const BUG: &[&str] = &[];
 
 const PATHOLOGICAL_CHECKS: &[&str] = &[
     "pathological::nc-dos-1",


### PR DESCRIPTION
per the suggestion in #79

Also:
- make regex used for name comparisons during name constraints processing case insensitive
- fix a deferred cert-limbo test by adding a valid email address check.
- fix DN name-constraint matching to compare the current RDN's attributes of the constraint (subtree) instead of the constraint's leading attributes (due to the wrong iterator being used)
- added some related unit tests