### PR TITLE
Edits to name intersection processing

### DIFF
--- a/certval/src/validator/name_constraints_set.rs
+++ b/certval/src/validator/name_constraints_set.rs
@@ -644,6 +644,8 @@ impl NameConstraintsSet {
                                 if new_name == prev_name
                                     || descended_from_rfc822(prev_rfc822, new_rfc822)
                                 {
+                                    new_set.push(new_name.clone());
+                                } else if descended_from_rfc822(new_rfc822, prev_rfc822) {
                                     new_set.push(prev_name.clone());
                                 }
                             }
@@ -685,6 +687,8 @@ impl NameConstraintsSet {
                                 if new_name == prev_name
                                     || descended_from_host(prev_dns, new_dns.as_str(), false)
                                 {
+                                    new_set.push(new_name.clone());
+                                } else if descended_from_host(new_dns, prev_dns.as_str(), false) {
                                     new_set.push(prev_name.clone());
                                 }
                             }
@@ -725,6 +729,13 @@ impl NameConstraintsSet {
                                 prev_name.maximum,
                             ) {
                                 new_set.push(new_name.clone());
+                            } else if descended_from_dn(
+                                new_dn,
+                                prev_dn,
+                                new_name.minimum,
+                                new_name.maximum,
+                            ) {
+                                new_set.push(prev_name.clone());
                             }
                         }
                     }
@@ -766,6 +777,8 @@ impl NameConstraintsSet {
                                 if new_name == prev_name
                                     || descended_from_host(prev_uri, new_uri.as_str(), true)
                                 {
+                                    new_set.push(new_name.clone());
+                                } else if descended_from_host(new_uri, prev_uri.as_str(), true) {
                                     new_set.push(prev_name.clone());
                                 }
                             }
@@ -825,6 +838,11 @@ impl NameConstraintsSet {
                                     {
                                         // if the new constraint falls within the old, use the new one
                                         new_set.push(new_name.clone());
+                                    } else if new_cidr.contains(&prev_cidr.first_address())
+                                        && new_cidr.contains(&prev_cidr.last_address())
+                                    {
+                                        // if the old constraint falls within the new, keep the old one
+                                        new_set.push(prev_name.clone());
                                     }
                                 }
                             }
@@ -1369,6 +1387,91 @@ pub(crate) fn name_constraints_set_to_name_constraints_settings(
     });
 }
 
+// Intersecting permitted subtrees must retain the narrower subtree for rfc822/dNSName/URI
+// (RFC 5280 6.1.4(g)), regardless of which side is narrower. Keeping the broader subtree
+// silently widens a subordinate CA's name constraint.
+#[cfg(feature = "std")]
+#[test]
+fn intersection_keeps_narrower_subtree() {
+    use crate::path_settings::*;
+
+    let broad = NameConstraintsSettings {
+        directory_name: Some(vec!["OU=Org Unit,O=Org,C=US".to_string()]),
+        rfc822_name: Some(vec!["example.com".to_string()]),
+        user_principal_name: None,
+        dns_name: Some(vec!["example.com".to_string()]),
+        uniform_resource_identifier: Some(vec![".example.com".to_string()]),
+        ip_address: Some(vec!["192.168.0.0/16".to_string()]),
+        not_supported: None,
+    };
+    let narrow = NameConstraintsSettings {
+        directory_name: Some(vec!["CN=Joe,OU=Org Unit,O=Org,C=US".to_string()]),
+        rfc822_name: Some(vec!["x@example.com".to_string()]),
+        user_principal_name: None,
+        dns_name: Some(vec!["sub.example.com".to_string()]),
+        uniform_resource_identifier: Some(vec!["sub.example.com".to_string()]),
+        ip_address: Some(vec!["192.168.10.0/24".to_string()]),
+        not_supported: None,
+    };
+
+    let mut cps_broad = CertificationPathSettings::default();
+    cps_broad.set_initial_permitted_subtrees(broad.clone());
+    let mut cps_narrow = CertificationPathSettings::default();
+    cps_narrow.set_initial_permitted_subtrees(narrow.clone());
+
+    // broad state intersected with narrower constraint -> narrower constraint survives
+    let mut bufs1 = BTreeMap::new();
+    let mut set_broad = cps_broad
+        .get_initial_permitted_subtrees_as_set(&mut bufs1)
+        .unwrap()
+        .unwrap();
+    let mut bufs2 = BTreeMap::new();
+    let set_narrow = cps_narrow
+        .get_initial_permitted_subtrees_as_set(&mut bufs2)
+        .unwrap()
+        .unwrap();
+    set_broad.calculate_intersection(&set_narrow.rfc822_name);
+    set_broad.calculate_intersection(&set_narrow.dns_name);
+    set_broad.calculate_intersection(&set_narrow.uniform_resource_identifier);
+    set_broad.calculate_intersection(&set_narrow.directory_name);
+    set_broad.calculate_intersection(&set_narrow.ip_address);
+    let result = name_constraints_set_to_name_constraints_settings(&set_broad).unwrap();
+    assert_eq!(result.rfc822_name, narrow.rfc822_name);
+    assert_eq!(result.dns_name, narrow.dns_name);
+    assert_eq!(
+        result.uniform_resource_identifier,
+        narrow.uniform_resource_identifier
+    );
+    assert_eq!(result.directory_name, narrow.directory_name);
+    assert_eq!(result.ip_address, narrow.ip_address);
+
+    // narrow state intersected with broader constraint -> narrower state survives
+    let mut bufs3 = BTreeMap::new();
+    let mut set_narrow2 = cps_narrow
+        .get_initial_permitted_subtrees_as_set(&mut bufs3)
+        .unwrap()
+        .unwrap();
+    let mut bufs4 = BTreeMap::new();
+    let set_broad2 = cps_broad
+        .get_initial_permitted_subtrees_as_set(&mut bufs4)
+        .unwrap()
+        .unwrap();
+    set_narrow2.calculate_intersection(&set_broad2.rfc822_name);
+    set_narrow2.calculate_intersection(&set_broad2.dns_name);
+    set_narrow2.calculate_intersection(&set_broad2.uniform_resource_identifier);
+    set_narrow2.calculate_intersection(&set_broad2.directory_name);
+    set_narrow2.calculate_intersection(&set_broad2.ip_address);
+    let result2 = name_constraints_set_to_name_constraints_settings(&set_narrow2).unwrap();
+    assert_eq!(result2.rfc822_name, narrow.rfc822_name);
+    assert_eq!(result2.dns_name, narrow.dns_name);
+    assert_eq!(
+        result2.uniform_resource_identifier,
+        narrow.uniform_resource_identifier
+    );
+    assert_eq!(result2.directory_name, narrow.directory_name);
+    assert_eq!(result2.ip_address, narrow.ip_address);
+}
+
 #[cfg(feature = "std")]
 #[test]
 fn intersection_tests() {
@@ -1565,9 +1668,11 @@ fn intersection_tests() {
         assert_eq!(1, perm_set4.ip_address.len());
         assert_eq!(perm_set4.ip_address, perm_set5.ip_address);
 
+        // intersecting the /24 state with the broader /15 retains the narrower /24
         assert!(!perm_set4.ip_address_null);
         perm_set4.calculate_intersection(&perm_set6.ip_address);
-        assert!(perm_set4.ip_address_null);
+        assert_eq!(1, perm_set4.ip_address.len());
+        assert_eq!(perm_set4.ip_address, perm_set5.ip_address);
     }
 
     let mut cps_set = CertificationPathSettings::default();

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -17,6 +17,7 @@ use const_oid::db::rfc5280::ANY_POLICY;
 use const_oid::db::rfc5912::*;
 use der::{asn1::ObjectIdentifier, Decode};
 use x509_cert::anchor::TrustAnchorChoice;
+use x509_cert::ext::pkix::constraints::name::GeneralSubtrees;
 use x509_cert::ext::pkix::KeyUsages;
 use x509_cert::ext::Extensions;
 
@@ -275,6 +276,13 @@ pub fn check_validity(
     Ok(())
 }
 
+/// `has_min_or_max` returns true if any subtree asserts a nonzero minimum or a maximum.
+fn has_min_or_max(subtrees: &Option<GeneralSubtrees>) -> bool {
+    subtrees
+        .as_ref()
+        .is_some_and(|s| s.iter().any(|gs| gs.minimum != 0 || gs.maximum.is_some()))
+}
+
 /// `check_names` ensures that subject and issuer names chain appropriately throughout the certification
 /// path and that no names violate any operative name constraints.
 ///
@@ -396,6 +404,17 @@ pub fn check_names(
             let pdv_ext: Option<&PDVExtension> = ca_cert.get_extension(&ID_CE_NAME_CONSTRAINTS)?;
             if let Some(PDVExtension::NameConstraints(nc)) = pdv_ext {
                 cpr.add_processed_extension(ID_CE_NAME_CONSTRAINTS);
+
+                // RFC 5280 4.2.1.10: minimum MUST be zero and maximum MUST be absent; an
+                // application encountering other values MUST process them or reject the
+                // certificate.
+                if has_min_or_max(&nc.permitted_subtrees) || has_min_or_max(&nc.excluded_subtrees) {
+                    log_error_for_ca(ca_cert, "unsupported minimum/maximum in name constraints");
+                    cpr.set_validation_status(PathValidationStatus::NameConstraintsViolation);
+                    return Err(Error::PathValidation(
+                        PathValidationStatus::NameConstraintsViolation,
+                    ));
+                }
 
                 if let Some(excl) = &nc.excluded_subtrees {
                     excluded_subtrees.calculate_union(excl);


### PR DESCRIPTION
Previously, name intersection operations retained the previous name when the new name was descended from it and did not handle the converse. This change retains the narrower name in both directions. Certificates asserting a non-zero minimum or a maximum in permitted or excluded subtrees are now flatly rejected per RFC 5280 4.2.1.10.