### PR TITLE
Address several open revocation age-related items

### DIFF
--- a/certval/src/revocation/crl.rs
+++ b/certval/src/revocation/crl.rs
@@ -44,8 +44,7 @@ use crate::{
     PDVExtension, PathValidationStatus, PkiEnvironment, Result, TimeOfInterest,
 };
 
-#[cfg(feature = "remote")]
-use std::time::Duration;
+use core::time::Duration;
 
 #[cfg(feature = "remote")]
 use log::debug;
@@ -954,17 +953,36 @@ fn certificate_issuer_extension_present(rc: &RevokedCert<Raw>) -> bool {
     false
 }
 
-pub(crate) fn check_crl_validity(toi: TimeOfInterest, crl: &CertificateList<Raw>) -> Result<()> {
+pub(crate) fn check_crl_validity(
+    toi: TimeOfInterest,
+    max_age: Duration,
+    crl: &CertificateList<Raw>,
+) -> Result<()> {
     if !toi.is_disabled() {
         let tu = crl.tbs_cert_list.this_update;
         if tu > toi {
             info!("Discarding CRL from {} as having this update time({}) later than time of interest ({})", name_to_string(&crl.tbs_cert_list.issuer),tu, toi);
             return Err(Error::CrlIncompatible);
         }
-        if let Some(nu) = crl.tbs_cert_list.next_update {
-            if nu.to_unix_duration().as_secs() < toi.as_unix_secs() {
-                info!("Discarding CRL from {} as having next update time({}) earlier than time of interest ({})", name_to_string(&crl.tbs_cert_list.issuer),tu, toi);
-                return Err(Error::CrlIncompatible);
+        match crl.tbs_cert_list.next_update {
+            Some(nu) => {
+                if nu.to_unix_duration().as_secs() < toi.as_unix_secs() {
+                    info!("Discarding CRL from {} as having next update time({}) earlier than time of interest ({})", name_to_string(&crl.tbs_cert_list.issuer),tu, toi);
+                    return Err(Error::CrlIncompatible);
+                }
+            }
+            None => {
+                // RFC 5280 5.1.2.5 requires conforming CRL issuers to include nextUpdate. Without it
+                // the CRL has no upper time bound and an ancient copy would be treated as fresh. Bound
+                // its age from thisUpdate by max_age (default 0 => reject as stale; a non-zero value
+                // opts into a tolerance window).
+                let age = toi
+                    .as_unix_secs()
+                    .saturating_sub(tu.to_unix_duration().as_secs());
+                if age > max_age.as_secs() {
+                    info!("Discarding CRL from {} as lacking a next update time and older than the configured maximum age", name_to_string(&crl.tbs_cert_list.issuer));
+                    return Err(Error::CrlIncompatible);
+                }
             }
         }
     }
@@ -1098,7 +1116,7 @@ pub(crate) fn process_crl(
     }
 
     let toi = cps.get_time_of_interest();
-    check_crl_validity(toi, &crl)?;
+    check_crl_validity(toi, cps.get_revocation_max_age(), &crl)?;
 
     if let Some(exts) = &crl.tbs_cert_list.crl_extensions {
         if let Err(_e) = check_crl_extensions(exts) {
@@ -1292,5 +1310,51 @@ mod tests {
         assert_eq!(Some(Error::ResourceUnchanged), r.err());
 
         let _ = tokio::fs::remove_file(f.to_str().unwrap()).await;
+    }
+
+    // A CRL that omits nextUpdate has no upper time bound. check_crl_validity caps its age
+    // from thisUpdate by the supplied max age (0 => fail closed). A CRL that carries nextUpdate is
+    // unaffected. Store indexing passes Duration::MAX here to stay lenient; path validation passes
+    // PS_REVOCATION_MAX_AGE.
+    #[cfg(feature = "std")]
+    #[test]
+    fn check_crl_validity_missing_next_update_honours_max_age() {
+        use super::check_crl_validity;
+        use crate::TimeOfInterest;
+        use core::time::Duration;
+        use der::Decode;
+        use x509_cert::{certificate::Raw, crl::CertificateList};
+
+        let mut crl = CertificateList::<Raw>::from_der(include_bytes!(
+            "../../tests/examples/PKITS_data_2048/crls/GoodCACRL.crl"
+        ))
+        .unwrap();
+        let tu_secs = crl.tbs_cert_list.this_update.to_unix_duration().as_secs();
+        // 10 days after thisUpdate (2010), well inside the original nextUpdate (2030).
+        let toi = TimeOfInterest::from_unix_secs(tu_secs + 10 * 86400).unwrap();
+
+        // nextUpdate present: valid regardless of max age (unchanged path).
+        assert!(check_crl_validity(toi, Duration::from_secs(0), &crl).is_ok());
+
+        // nextUpdate absent: fail closed by default, tolerated under a wide window, rejected once the
+        // window is shorter than the CRL's age (~10 days).
+        crl.tbs_cert_list.next_update = None;
+        assert!(
+            check_crl_validity(toi, Duration::from_secs(0), &crl).is_err(),
+            "absent nextUpdate must fail closed by default"
+        );
+        assert!(
+            check_crl_validity(toi, Duration::from_secs(30 * 86400), &crl).is_ok(),
+            "a wide max age tolerates an absent nextUpdate"
+        );
+        assert!(
+            check_crl_validity(toi, Duration::from_secs(5 * 86400), &crl).is_err(),
+            "a max age shorter than the CRL age rejects it"
+        );
+
+        // A time of interest before thisUpdate is still rejected as incompatible even with a wide
+        // max age (the future-CRL guard is independent of the nextUpdate handling).
+        let before = TimeOfInterest::from_unix_secs(tu_secs - 86400).unwrap();
+        assert!(check_crl_validity(before, Duration::MAX, &crl).is_err());
     }
 }

--- a/certval/src/revocation/ocsp_client.rs
+++ b/certval/src/revocation/ocsp_client.rs
@@ -142,19 +142,31 @@ fn check_response_time(cps: &CertificationPathSettings, sr: &SingleResponse) -> 
         return true;
     }
 
-    // TODO support grace periods?
-
     let tu = sr.this_update.0;
     if tu > time_of_interest {
         //future request
         return false;
     }
 
-    if let Some(next_update) = sr.next_update {
-        let nu = next_update.0;
-        if nu < time_of_interest {
-            //stale
-            return false;
+    match sr.next_update {
+        Some(next_update) => {
+            if next_update.0 < time_of_interest {
+                //stale
+                return false;
+            }
+        }
+        None => {
+            // No nextUpdate. RFC 6960 4.2.2.1 permits this, but without it the response carries no
+            // upper time bound and could be replayed indefinitely. Bound its age from thisUpdate by
+            // PS_REVOCATION_MAX_AGE (default 0 => reject as stale; a non-zero value opts into a
+            // tolerance window).
+            let max_age = cps.get_revocation_max_age().as_secs();
+            let age = time_of_interest
+                .as_unix_secs()
+                .saturating_sub(tu.to_unix_duration().as_secs());
+            if age > max_age {
+                return false;
+            }
         }
     }
     true
@@ -615,7 +627,18 @@ fn process_ocsp_response_internal(
         ));
     }
 
-    // Nonce is enforced below, after signature verification. TODO: producedAt freshness.
+    // Nonce is enforced below, after signature verification.
+
+    // Reject a response whose producedAt post-dates the time of interest. producedAt is when the
+    // responder signed the response; like a future thisUpdate (rejected in check_response_time), a
+    // producedAt after the time of interest indicates a clock or replay anomaly. thisUpdate/nextUpdate
+    // remain the primary freshness anchors, checked per SingleResponse below.
+    let time_of_interest = cps.get_time_of_interest();
+    if !time_of_interest.is_disabled() && bor.tbs_response_data.produced_at.0 > time_of_interest {
+        error!("OCSPResponse from {uri_to_check} carries a producedAt later than the time of interest; rejecting response as not yet valid");
+        cpr.add_failed_ocsp_response(enc_ocsp_resp.to_vec(), result_index);
+        return Err(Error::OcspResponseError);
+    }
 
     let mut sigverified = false;
     let mut authorized_responder = false;
@@ -1242,6 +1265,69 @@ mod tests {
             )
             .is_err(),
             "response past nextUpdate should not be accepted"
+        );
+
+        // (5) producedAt freshness. producedAt is 2026-07-15T09:07:34Z. With the time of
+        // interest at 2026-07-15T05:00:00Z, thisUpdate (00:00:01Z) and nextUpdate (07-22) still
+        // bracket it, so the response is otherwise fresh - only the future producedAt rejects it.
+        let producedat_future = crate::TimeOfInterest::from_unix_secs(1784091600).unwrap();
+        assert_eq!(
+            run(
+                producedat_future,
+                Some(&sent_nonce),
+                OcspNonceSetting::SendNonceRequireMatch
+            ),
+            Err(Error::OcspResponseError),
+            "producedAt later than the time of interest should be rejected"
+        );
+    }
+
+    // ------------------------------------------------------------------------------------------
+    // Freshness of a response that omits nextUpdate. RFC 6960 permits an absent nextUpdate,
+    // but without a bound an ancient response would be treated as fresh; PS_REVOCATION_MAX_AGE caps
+    // its age from thisUpdate (default 0 => fail closed).
+    // ------------------------------------------------------------------------------------------
+
+    #[cfg(all(feature = "std", feature = "revocation"))]
+    #[test]
+    fn check_response_time_missing_next_update_honours_max_age() {
+        use x509_ocsp::{BasicOcspResponse, OcspResponse};
+
+        let enc_resp = include_bytes!("../../tests/examples/ocsp_dod/47-ocsp-resp.der").as_slice();
+        let or = OcspResponse::from_der(enc_resp).unwrap();
+        let rb = or.response_bytes.unwrap();
+        let bor = BasicOcspResponse::from_der(rb.response.as_bytes()).unwrap();
+        // A real SingleResponse (thisUpdate 2026-07-15T00:00:01Z, nextUpdate 2026-07-22T01:00:00Z),
+        // so the CertId and thisUpdate are well formed; the test varies only nextUpdate and max age.
+        let base = bor.tbs_response_data.responses.into_iter().next().unwrap();
+
+        // ~1.5 days after thisUpdate (still inside the original nextUpdate window).
+        let toi = crate::TimeOfInterest::from_unix_secs(1784203200).unwrap(); // 2026-07-16T12:00:00Z
+        let cps_with = |max_age_secs: u64| {
+            let mut cps = CertificationPathSettings::new();
+            cps.set_time_of_interest(toi);
+            cps.set_revocation_max_age(core::time::Duration::from_secs(max_age_secs));
+            cps
+        };
+
+        // nextUpdate present: fresh regardless of max age (unchanged path).
+        assert!(check_response_time(&cps_with(0), &base));
+
+        // nextUpdate absent: fail closed by default, tolerated under a wide window, and rejected
+        // again once the window is shorter than the response's age (~1.5 days).
+        let mut no_nu = base.clone();
+        no_nu.next_update = None;
+        assert!(
+            !check_response_time(&cps_with(0), &no_nu),
+            "absent nextUpdate must fail closed by default"
+        );
+        assert!(
+            check_response_time(&cps_with(30 * 86400), &no_nu),
+            "a wide max age tolerates an absent nextUpdate"
+        );
+        assert!(
+            !check_response_time(&cps_with(3600), &no_nu),
+            "a max age shorter than the response age rejects it"
         );
     }
 }

--- a/certval/src/source/crl_source.rs
+++ b/certval/src/source/crl_source.rs
@@ -499,7 +499,12 @@ fn index_crls_internal(
                                 cur_crl_info.filename = Some(filename.to_string());
                             }
 
-                            if check_crl_validity(toi, &crl).is_ok() {
+                            // Store indexing is lenient about an absent nextUpdate (Duration::MAX):
+                            // the fail-closed staleness decision belongs to path validation, which
+                            // reads the operator's PS_REVOCATION_MAX_AGE. Deleting a nextUpdate-less
+                            // CRL here would discard one that a validation configured with a tolerance
+                            // could still use. A CRL with an expired nextUpdate is still pruned below.
+                            if check_crl_validity(toi, core::time::Duration::MAX, &crl).is_ok() {
                                 add_crl_info(
                                     crl_info,
                                     issuer_map,

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -302,6 +302,19 @@ pub static PS_IGNORE_EXPIRED: &str = "psIgnoreExpired";
 /// should include a nonce value.
 pub static PS_OCSP_AIA_NONCE_SETTING: &str = "psOcspAiaNonceSetting";
 
+/// `PS_REVOCATION_MAX_AGE` is used to retrieve a [`Duration`] value from a [`CertificationPathSettings`]
+/// object. It bounds how old a CRL or OCSP response that omits `nextUpdate` may be, measured from its
+/// `thisUpdate` relative to the time of interest. RFC 5280 Section 5.1.2.5 requires conforming CRL
+/// issuers to include `nextUpdate`, and RFC 6960 Section 4.2.2.1 lets an OCSP responder omit it to
+/// signal that newer information is always available; either way, an absent `nextUpdate` otherwise
+/// leaves the revocation information with no upper time bound, so an arbitrarily old artifact would be
+/// treated as fresh. The default is zero, which fails closed: revocation information that lacks
+/// `nextUpdate` is rejected as stale unless an operator configures a non-zero tolerance here.
+pub static PS_REVOCATION_MAX_AGE: &str = "psRevocationMaxAge";
+
+/// Default value for [`PS_REVOCATION_MAX_AGE`]: zero, i.e., fail closed when `nextUpdate` is absent.
+pub static PS_REVOCATION_MAX_AGE_DEFAULT: Duration = Duration::from_secs(0);
+
 /// `PS_CERTIFICATES` is used to retrieve a set of potentially useful certificates from a [`CertificationPathSettings`]
 /// object.
 pub static PS_CERTIFICATES: &str = "psCertificates";
@@ -667,6 +680,11 @@ cps_gets_and_sets_with_default!(
     PS_OCSP_AIA_NONCE_SETTING,
     OcspNonceSetting,
     OcspNonceSetting::DoNotSendNonce
+);
+cps_gets_and_sets_with_default!(
+    PS_REVOCATION_MAX_AGE,
+    Duration,
+    PS_REVOCATION_MAX_AGE_DEFAULT
 );
 // PS_MAXIMUM_PATH_DEPTH (ditch this and use PS_INITIAL_PATH_LENGTH_CONSTRAINT)
 // PS_CERTIFICATES (will need lifetime aware macro)


### PR DESCRIPTION
Add a new PS_REVOCATION_MAX_AGE settings value to bound any CRL or OCSP response that omits a next update value (with fail closed implemented as the default). Also, check the producedAt value in OCSP response to affirm it is not later than the time of interest (this was not checked at all previously).