### PR TITLE
Define upper bounds for certificate store and certificate policy pool and refactor name constraints throttle

### DIFF
--- a/certval/src/builder/graph_builder.rs
+++ b/certval/src/builder/graph_builder.rs
@@ -61,6 +61,7 @@ pub async fn build_graph(pe: &PkiEnvironment, cps: &CertificationPathSettings) -
         let mut uris = Vec::new();
         let mut certs_count = 0;
         let mut uris_count = 0;
+        let max_certs = cps.get_max_aia_sia_certs();
 
         let p = Path::new(&download_folder);
         let blp = p.join("last_modified_map.json");
@@ -123,6 +124,15 @@ pub async fn build_graph(pe: &PkiEnvironment, cps: &CertificationPathSettings) -
             }
 
             if certs_count == cert_store.num_buffers() {
+                break;
+            }
+            // Bound the AIA/SIA fetch loop: a responder that serves a fresh certificate on every hop
+            // never lets the store converge. Stop collecting once the store reaches the configured
+            // ceiling and build the graph from what has been gathered.
+            if cert_store.num_buffers() as u64 >= max_certs {
+                error!(
+                    "AIA/SIA collection reached the configured maximum certificate count ({max_certs}); halting collection to bound resource use"
+                );
                 break;
             }
             certs_count = cert_store.num_buffers();

--- a/certval/src/source/cert_source.rs
+++ b/certval/src/source/cert_source.rs
@@ -1071,7 +1071,6 @@ impl CertSource {
     fn check_names_in_partial_path(&self, path: &[usize]) -> bool {
         let mut permitted_subtrees = NameConstraintsSet::default();
         let mut excluded_subtrees = NameConstraintsSet::default();
-        let mut perm_names_set = false;
 
         // Iterate over the list of intermediate CA certificates plus target to check name chaining
         for (pos, i) in path.iter().enumerate() {
@@ -1119,11 +1118,10 @@ impl CertSource {
                             permitted_subtrees.calculate_intersection(perm);
                         }
 
-                        if perm_names_set && permitted_subtrees.are_any_empty() {
-                            return false;
-                        } else if !perm_names_set && permitted_subtrees.are_any_empty() {
-                            perm_names_set = true;
-                        }
+                        // An empty permitted subtree for some name form does not prune the partial
+                        // path: names are checked per form against the operative subtrees above, so
+                        // a form no certificate in the path presents is vacuously satisfied. This
+                        // filter is approximate and never rejects a path the full validator accepts.
                     }
                 }
             }

--- a/certval/src/util/error.rs
+++ b/certval/src/util/error.rs
@@ -91,6 +91,10 @@ pub enum PathValidationStatus {
     /// and the presented trust anchor shares its public key with an anchor in the trust store but
     /// carries different constraints than the stored (authoritative) copy.
     TrustAnchorConstraintsMismatch,
+    /// ProcessingLimitExceeded occurs when path processing exceeds an internal resource limit, for
+    /// example when a certificate presents a policies-by-mappings graph large enough to exhaust the
+    /// policy node pool. It is raised to fail closed rather than allow unbounded resource use.
+    ProcessingLimitExceeded,
 }
 
 /// Error type
@@ -206,6 +210,9 @@ impl fmt::Display for PathValidationStatus {
             PathValidationStatus::SelfSignedEndIdentity => write!(f, "SelfSignedEndIdentity"),
             PathValidationStatus::TrustAnchorConstraintsMismatch => {
                 write!(f, "TrustAnchorConstraintsMismatch")
+            }
+            PathValidationStatus::ProcessingLimitExceeded => {
+                write!(f, "ProcessingLimitExceeded")
             }
         }
     }

--- a/certval/src/validator/name_constraints_set.rs
+++ b/certval/src/validator/name_constraints_set.rs
@@ -1625,6 +1625,40 @@ fn intersection_keeps_narrower_subtree() {
     assert_eq!(result2.ip_address, narrow.ip_address);
 }
 
+// A permitted subtree set whose bucket for one name form has intersected to empty (NULL) must
+// reject only certificates that actually present a name of that form; a certificate carrying names
+// of other forms is unaffected. This per-form gating is what lets path validation drop the whole
+// certificate once a permitted bucket empties: an empty form no certificate uses is vacuously
+// satisfied, and an empty form a certificate does use is still rejected here.
+#[cfg(feature = "std")]
+#[test]
+fn null_permitted_bucket_gates_only_its_own_name_form() {
+    // Model an intermediate whose permitted dNSName subtree intersected to empty.
+    let set = NameConstraintsSet {
+        dns_name_null: true,
+        ..Default::default()
+    };
+
+    // A SAN of a different form (rfc822, with no operative rfc822 constraint) is unconstrained and
+    // therefore permitted, even though the dNSName bucket is NULL.
+    let rfc822_san = SubjectAltName(vec![GeneralName::Rfc822Name(
+        Ia5String::new("user@example.test").unwrap(),
+    )]);
+    assert!(
+        set.san_within_permitted_subtrees(&Some(&rfc822_san)),
+        "a NULL dNSName bucket must not reject an rfc822 name"
+    );
+
+    // A SAN that does present a dNSName is still rejected by the NULL bucket.
+    let dns_san = SubjectAltName(vec![GeneralName::DnsName(
+        Ia5String::new("host.example.test").unwrap(),
+    )]);
+    assert!(
+        !set.san_within_permitted_subtrees(&Some(&dns_san)),
+        "a NULL dNSName bucket must still reject a dNSName"
+    );
+}
+
 #[cfg(feature = "std")]
 #[test]
 fn intersection_tests() {

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -233,7 +233,7 @@ pub static PS_EXTENDED_KEY_USAGE_PATH: &str = "psExtendedKeyUsagePath";
 pub static PS_INITIAL_PATH_LENGTH_CONSTRAINT: &str = "psInitialPathLengthConstraint";
 
 /// `PS_MAX_PATH_LENGTH_CONSTRAINT` sets the maximum length path accepted by validation implementation
-pub static PS_MAX_PATH_LENGTH_CONSTRAINT: u8 = 15;
+pub const PS_MAX_PATH_LENGTH_CONSTRAINT: u8 = 15;
 
 /// `PS_CRL_TIMEOUT_DEFAULT` sets the maximum amount of time to spend downloading a CRL expressed in seconds.
 pub static PS_CRL_TIMEOUT_DEFAULT: Duration = Duration::from_secs(60);
@@ -314,6 +314,19 @@ pub static PS_REVOCATION_MAX_AGE: &str = "psRevocationMaxAge";
 
 /// Default value for [`PS_REVOCATION_MAX_AGE`]: zero, i.e., fail closed when `nextUpdate` is absent.
 pub static PS_REVOCATION_MAX_AGE_DEFAULT: Duration = Duration::from_secs(0);
+
+/// `PS_MAX_AIA_SIA_CERTS` is used to retrieve a u64 value from a [`CertificationPathSettings`] object.
+/// It bounds the number of certificates the graph builder will accumulate while iteratively fetching
+/// AIA and SIA URIs. A hostile or misconfigured responder can serve a fresh certificate on every hop
+/// (each pointing at another URI), so the fetch loop would otherwise never reach a fixed point and
+/// would grow the certificate store without bound (which in turn feeds partial-path enumeration).
+/// When the store reaches this many certificates, collection halts and graph building proceeds with
+/// what has been gathered. The default is [`PS_MAX_AIA_SIA_CERTS_DEFAULT`].
+pub static PS_MAX_AIA_SIA_CERTS: &str = "psMaxAiaSiaCerts";
+
+/// Default value for [`PS_MAX_AIA_SIA_CERTS`]: 2000, well above any realistic store while still
+/// bounding an AIA/SIA fetch loop that never converges.
+pub static PS_MAX_AIA_SIA_CERTS_DEFAULT: u64 = 2000;
 
 /// `PS_CERTIFICATES` is used to retrieve a set of potentially useful certificates from a [`CertificationPathSettings`]
 /// object.
@@ -686,6 +699,7 @@ cps_gets_and_sets_with_default!(
     Duration,
     PS_REVOCATION_MAX_AGE_DEFAULT
 );
+cps_gets_and_sets_with_default!(PS_MAX_AIA_SIA_CERTS, u64, PS_MAX_AIA_SIA_CERTS_DEFAULT);
 // PS_MAXIMUM_PATH_DEPTH (ditch this and use PS_INITIAL_PATH_LENGTH_CONSTRAINT)
 // PS_CERTIFICATES (will need lifetime aware macro)
 cps_gets_and_sets_with_default!(PS_REQUIRE_COUNTRY_CODE_INDICATOR, bool, false);
@@ -805,6 +819,8 @@ fn test_default_gets_cps() {
         OcspNonceSetting::DoNotSendNonce,
         cps.get_ocsp_aia_nonce_setting()
     );
+    assert_eq!(Duration::from_secs(0), cps.get_revocation_max_age());
+    assert_eq!(2000, cps.get_max_aia_sia_certs());
     assert!(!cps.get_require_country_code_indicator());
 
     assert_eq!(vec![ANY_POLICY.to_string()], cps.get_initial_policy_set());
@@ -926,6 +942,11 @@ fn test_default_sets_cps() {
         OcspNonceSetting::SendNonceRequireMatch,
         cps.get_ocsp_aia_nonce_setting()
     );
+
+    cps.set_revocation_max_age(Duration::from_secs(3600));
+    assert_eq!(Duration::from_secs(3600), cps.get_revocation_max_age());
+    cps.set_max_aia_sia_certs(500);
+    assert_eq!(500, cps.get_max_aia_sia_certs());
 
     cps.set_require_country_code_indicator(true);
     assert!(cps.get_require_country_code_indicator());

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -345,7 +345,6 @@ pub fn check_names(
     v.push(cp.target.clone());
     let certs_in_cert_path = v.len();
 
-    let mut perm_names_set = initial_perm.is_some();
     let mut permitted_subtrees = initial_perm.unwrap_or_default();
     let mut excluded_subtrees = initial_excl.unwrap_or_default();
 
@@ -485,13 +484,11 @@ pub fn check_names(
                     permitted_subtrees.calculate_intersection(perm);
                 }
 
-                if perm_names_set && permitted_subtrees.are_any_empty() {
-                    return Err(Error::PathValidation(
-                        PathValidationStatus::NameConstraintsViolation,
-                    ));
-                } else if !perm_names_set && permitted_subtrees.are_any_empty() {
-                    perm_names_set = true;
-                }
+                // A permitted subtree set that intersects to empty for some name form does not fail
+                // the path here: each certificate's subject and subjectAltName are checked against
+                // the operative subtrees per name form (an empty form rejects only a certificate
+                // that actually presents a name of that form), so a form no certificate uses is
+                // vacuously satisfied.
             }
         }
     } // end for (pos, ca_cert_ref) in v.iter_mut().enumerate() {
@@ -1009,21 +1006,6 @@ pub fn check_country_codes(
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::validator::name_constraints_set::NameConstraintsSet;
-    use der::asn1::Ia5String;
-    use x509_cert::ext::pkix::constraints::name::GeneralSubtree;
-
-    /// Builds `n` distinct excluded dNSName subtrees, as a certificate authority contributes when it
-    /// unions name constraints into the operative state.
-    fn dns_subtrees(n: usize) -> GeneralSubtrees {
-        (0..n)
-            .map(|i| GeneralSubtree {
-                base: GeneralName::DnsName(Ia5String::new(&format!("x{i}.invalid")).unwrap()),
-                minimum: 0,
-                maximum: None,
-            })
-            .collect()
-    }
 
     #[test]
     fn budget_predicate_boundary() {
@@ -1039,9 +1021,27 @@ mod tests {
     // The budget guard must consume the constraint count that accrues as certificate authorities
     // union their excluded subtrees into the operative state, not a count captured from the initial
     // (typically empty) subtree state. A count read before accumulation is zero and never trips the
-    // budget no matter how large the subjectAltName; the count read after accumulation does.
+    // budget no matter how large the subjectAltName; the count read after accumulation does. dNSName
+    // subtree accumulation is a std-only feature, so this test is gated accordingly.
+    #[cfg(feature = "std")]
     #[test]
     fn budget_tracks_accumulated_constraints() {
+        use crate::validator::name_constraints_set::NameConstraintsSet;
+        use der::asn1::Ia5String;
+        use x509_cert::ext::pkix::constraints::name::GeneralSubtree;
+
+        // Builds `n` distinct excluded dNSName subtrees, as a certificate authority contributes when
+        // it unions name constraints into the operative state.
+        fn dns_subtrees(n: usize) -> GeneralSubtrees {
+            (0..n)
+                .map(|i| GeneralSubtree {
+                    base: GeneralName::DnsName(Ia5String::new(&format!("x{i}.invalid")).unwrap()),
+                    minimum: 0,
+                    maximum: None,
+                })
+                .collect()
+        }
+
         let san_len = 1024;
 
         // The initial state, as at the top of check_names for a path with no initial subtrees. A

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -300,6 +300,22 @@ fn has_trailing_dot(subtrees: &Option<GeneralSubtrees>) -> bool {
         .is_some_and(|s| s.iter().any(|gs| general_name_has_trailing_dot(&gs.base)))
 }
 
+/// Ceiling on the work performed matching one certificate's subjectAltName against the operative
+/// name-constraints state. Matching visits every SAN entry against every accumulated constraint, so
+/// the cost scales with the product of the two counts. A path of certificate authorities that each
+/// contribute many constraints, terminating in a certificate bearing many SAN entries, could
+/// otherwise drive that product arbitrarily high. Certificates exceeding the budget are rejected.
+const MAX_NAME_CONSTRAINT_MATCH_WORK: usize = 1_048_576;
+
+/// Returns true when matching a subjectAltName of `san_len` entries against `constraint_count`
+/// accumulated name constraints would exceed [`MAX_NAME_CONSTRAINT_MATCH_WORK`]. The count of
+/// operative constraints grows as excluded subtrees are unioned in at each certificate authority, so
+/// callers must supply the current combined count rather than a value captured before processing the
+/// path.
+fn name_constraint_matching_budget_exceeded(constraint_count: usize, san_len: usize) -> bool {
+    san_len > 0 && constraint_count > MAX_NAME_CONSTRAINT_MATCH_WORK / san_len
+}
+
 /// `check_names` ensures that subject and issuer names chain appropriately throughout the certification
 /// path and that no names violate any operative name constraints.
 ///
@@ -332,7 +348,6 @@ pub fn check_names(
     let mut perm_names_set = initial_perm.is_some();
     let mut permitted_subtrees = initial_perm.unwrap_or_default();
     let mut excluded_subtrees = initial_excl.unwrap_or_default();
-    let constraint_count = permitted_subtrees.len() + excluded_subtrees.len();
 
     let mut working_issuer_name = get_trust_anchor_name(&cp.trust_anchor.decoded_ta)?.clone();
 
@@ -393,8 +408,12 @@ pub fn check_names(
                 None
             };
 
+            // Bound name-constraints matching for this certificate against the constraints
+            // accumulated from the certificate authorities processed so far, read live rather
+            // than from the initial (typically empty) subtree state.
+            let constraint_count = permitted_subtrees.len() + excluded_subtrees.len();
             let san_len = san.map(|s| s.0.len()).unwrap_or(0);
-            if san_len > 0 && constraint_count > 1048576 / san_len {
+            if name_constraint_matching_budget_exceeded(constraint_count, san_len) {
                 return Err(Error::PathValidation(
                     PathValidationStatus::NameConstraintsViolation,
                 ));
@@ -986,3 +1005,66 @@ pub fn check_country_codes(
     Ok(())
 }
 */
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::validator::name_constraints_set::NameConstraintsSet;
+    use der::asn1::Ia5String;
+    use x509_cert::ext::pkix::constraints::name::GeneralSubtree;
+
+    /// Builds `n` distinct excluded dNSName subtrees, as a certificate authority contributes when it
+    /// unions name constraints into the operative state.
+    fn dns_subtrees(n: usize) -> GeneralSubtrees {
+        (0..n)
+            .map(|i| GeneralSubtree {
+                base: GeneralName::DnsName(Ia5String::new(&format!("x{i}.invalid")).unwrap()),
+                minimum: 0,
+                maximum: None,
+            })
+            .collect()
+    }
+
+    #[test]
+    fn budget_predicate_boundary() {
+        // No subjectAltName entries: nothing to match, so no bound applies regardless of the count.
+        assert!(!name_constraint_matching_budget_exceeded(usize::MAX, 0));
+
+        // A product exactly at the ceiling is allowed; one constraint beyond it is rejected.
+        let ceiling = MAX_NAME_CONSTRAINT_MATCH_WORK / 1024;
+        assert!(!name_constraint_matching_budget_exceeded(ceiling, 1024));
+        assert!(name_constraint_matching_budget_exceeded(ceiling + 1, 1024));
+    }
+
+    // The budget guard must consume the constraint count that accrues as certificate authorities
+    // union their excluded subtrees into the operative state, not a count captured from the initial
+    // (typically empty) subtree state. A count read before accumulation is zero and never trips the
+    // budget no matter how large the subjectAltName; the count read after accumulation does.
+    #[test]
+    fn budget_tracks_accumulated_constraints() {
+        let san_len = 1024;
+
+        // The initial state, as at the top of check_names for a path with no initial subtrees. A
+        // count captured here is what the earlier (dead) guard used, and it bounds nothing.
+        let permitted = NameConstraintsSet::default();
+        let mut excluded = NameConstraintsSet::default();
+        let stale_count = permitted.len() + excluded.len();
+        assert_eq!(stale_count, 0);
+        assert!(
+            !name_constraint_matching_budget_exceeded(stale_count, san_len),
+            "a count captured before accumulation cannot bound the matching work"
+        );
+
+        // A certificate authority unions in enough excluded subtrees to blow the budget.
+        let needed = MAX_NAME_CONSTRAINT_MATCH_WORK / san_len + 1;
+        excluded.calculate_union(&dns_subtrees(needed));
+
+        // The count read live from the current state reflects the accumulation and trips the budget.
+        let live_count = permitted.len() + excluded.len();
+        assert!(live_count >= needed);
+        assert!(
+            name_constraint_matching_budget_exceeded(live_count, san_len),
+            "the live count must trip the budget once constraints accumulate"
+        );
+    }
+}

--- a/certval/src/validator/policy_graph.rs
+++ b/certval/src/validator/policy_graph.rs
@@ -240,9 +240,8 @@ pub fn check_certificate_policies_graph(
                 }
 
                 for node in nodes_to_add {
-                    let node_index = pm.len();
                     let valid_policy = node.valid_policy;
-                    pm.push(node);
+                    let node_index = push_policy_node(pm, node)?;
                     for p in &parent_nodes[&valid_policy] {
                         let parent = &pm[*p];
                         add_child_if_not_present(pm, &parent.children, node_index);
@@ -381,8 +380,7 @@ pub fn check_certificate_policies_graph(
                             for node in nodes_to_add {
                                 let parent_index = node.parent.as_ref().map(|p| p.borrow()[0]);
 
-                                let node_index = pm.len();
-                                pm.push(node);
+                                let node_index = push_policy_node(pm, node)?;
                                 if let Some(parent_index) = parent_index {
                                     let parent = &pm[parent_index];
                                     add_child_if_not_present(pm, &parent.children, node_index);
@@ -550,8 +548,7 @@ pub fn check_certificate_policies_graph(
                 for node in nodes_to_add {
                     let parent_index = node.parent.as_ref().map(|p| p.borrow()[0]);
 
-                    let node_index = pm.len();
-                    pm.push(node);
+                    let node_index = push_policy_node(pm, node)?;
                     if let Some(parent_index) = parent_index {
                         let parent = &pm[parent_index];
                         add_child_if_not_present(pm, &parent.children, node_index);
@@ -626,8 +623,7 @@ fn make_new_policy_node_add_to_pool2_graph(
         parent: Some(RefCell::new(parents.clone())),
         children: RefCell::new(vec![]),
     };
-    let cur_index = pm.len();
-    pm.push(node);
+    let cur_index = push_policy_node(pm, node)?;
 
     for p in parents {
         let parent = &pm[p];

--- a/certval/src/validator/policy_utilities.rs
+++ b/certval/src/validator/policy_utilities.rs
@@ -8,7 +8,7 @@ use const_oid::db::rfc5280::ANY_POLICY;
 use der::asn1::ObjectIdentifier;
 
 use crate::util::error::*;
-use crate::ObjectIdentifierSet;
+use crate::{ObjectIdentifierSet, PS_MAX_PATH_LENGTH_CONSTRAINT};
 
 /// PolicyProcessingData is internally used by check_certificate_policies to perform certificate
 /// policy-related checks in support of certification path validation. This struct is used as the
@@ -45,6 +45,30 @@ impl PartialEq for PolicyProcessingData {
 /// The PolicyPool type is used to maintain a list of PolicyProcessingData instances that are used
 /// to represent a valid_policy_tree.
 pub(crate) type PolicyPool = Vec<PolicyProcessingData>;
+
+/// Upper bound on the number of nodes retained in a PolicyPool during a single path validation.
+/// Certificate policies combined with policy mappings can drive multiplicative growth of the policy
+/// graph; without a bound a crafted certificate could exhaust memory/CPU. The pool is per path, so
+/// the bound scales with the maximum path length rather than the certificate store: allow a generous
+/// high-end 20 policies per certificate across a maximum-length path. With the RFC 9618 childless-node
+/// pruning in effect a legitimate path holds on the order of tens of nodes, so this ceiling is far
+/// above any real value and only trips on abuse. Reaching it fails the validation (fail closed).
+pub(crate) const MAX_POLICY_POOL_NODES: usize = 20 * PS_MAX_PATH_LENGTH_CONSTRAINT as usize;
+
+/// push_policy_node appends a node to the policy pool, failing closed with
+/// [`PathValidationStatus::ProcessingLimitExceeded`] once the pool has reached
+/// [`MAX_POLICY_POOL_NODES`]. It returns the index of the newly added node. All policy-graph node
+/// insertions route through here so the bound cannot be bypassed.
+pub(crate) fn push_policy_node(pm: &mut PolicyPool, node: PolicyProcessingData) -> Result<usize> {
+    if pm.len() >= MAX_POLICY_POOL_NODES {
+        return Err(Error::PathValidation(
+            PathValidationStatus::ProcessingLimitExceeded,
+        ));
+    }
+    let cur_index = pm.len();
+    pm.push(node);
+    Ok(cur_index)
+}
 
 /// The PolicyTreeRow type is used to represent rows in the valid_policy_tree. Each element is an
 /// index into the PolicyPool instance that supports the valid_policy_tree.
@@ -168,9 +192,7 @@ pub(crate) fn make_new_policy_node_add_to_pool2(
         parent: parent_opt,
         children: RefCell::new(vec![]),
     };
-    let cur_index = pm.len();
-    pm.push(node);
-    Ok(cur_index)
+    push_policy_node(pm, node)
 }
 
 pub(crate) fn make_new_policy_node(
@@ -262,6 +284,35 @@ mod tests {
             parent: parent.map(RefCell::new),
             children: RefCell::new(children),
         }
+    }
+
+    // push_policy_node fails closed once the pool reaches MAX_POLICY_POOL_NODES, bounding the policy
+    // graph against a certificate crafted to drive multiplicative node growth.
+    #[test]
+    fn push_policy_node_fails_closed_at_pool_cap() {
+        let x = ObjectIdentifier::new_unwrap("1.2.3.1");
+        let mut pool: PolicyPool = Vec::new();
+
+        // Fill the pool to exactly the cap; every insert succeeds and returns the running index.
+        for expected_index in 0..MAX_POLICY_POOL_NODES {
+            let idx = push_policy_node(&mut pool, node(x, 0, None, vec![])).unwrap();
+            assert_eq!(idx, expected_index);
+        }
+        assert_eq!(pool.len(), MAX_POLICY_POOL_NODES);
+
+        // The next insert is refused: the pool is full, so it fails closed and does not grow.
+        let r = push_policy_node(&mut pool, node(x, 0, None, vec![]));
+        assert_eq!(
+            r,
+            Err(Error::PathValidation(
+                PathValidationStatus::ProcessingLimitExceeded
+            ))
+        );
+        assert_eq!(
+            pool.len(),
+            MAX_POLICY_POOL_NODES,
+            "pool must not grow past the cap"
+        );
     }
 
     // Dedup keys on the parent's actual children: pool[0] shares policy X with the candidate but is

--- a/support/x509-limbo-tests/src/main.rs
+++ b/support/x509-limbo-tests/src/main.rs
@@ -47,11 +47,10 @@ const WEAK_KEY_CHECKS: &[&str] = &[
 
 const BUG: &[&str] = &[];
 
-const PATHOLOGICAL_CHECKS: &[&str] = &[
-    "pathological::nc-dos-1",
-    "pathological::nc-dos-2",
-    "pathological::nc-dos-3",
-];
+// The name-constraints denial-of-service cases (pathological::nc-dos-1/2/3) are no longer listed
+// here: the validator now bounds name-constraints matching work and rejects them as the corpus
+// expects, so they must fail rather than be treated as a known-permissive result.
+const PATHOLOGICAL_CHECKS: &[&str] = &[];
 
 const UNSUPPORTED_APPLICATION_CHECK: &[&str] = &["webpki::san::mismatch-apex-subdomain-san"];
 


### PR DESCRIPTION
This limits certificate aggregation during AIA/SIA retrieval and certificate policy aggregation during path validation. The cert store limit is configurable via PS_MAX_AIA_SIA_CERTS (though note this limit includes certificates loaded from a local source too). The policy pool limit is fixed at 20 * PS_MAX_PATH_LENGTH_CONSTRAINT, which is a generous limit.

Re-factor name constraint throttle to be based on constraints accumulated during the path instead of values from path settings (which are often empty and are already under application control unlike values from the path). Remove the name-constraints DoS cases from the x509-limbo harness expected-failure list, since the validator now bounds and rejects them.

Correct premature name-constraints failure.