### PR TITLE
A few minor changes

### DIFF
--- a/certval/src/source/ta_source.rs
+++ b/certval/src/source/ta_source.rs
@@ -240,9 +240,7 @@ impl TaSource {
         // todo - change serialization?
         let bap: BuffersAndPaths = match from_reader(cbor) {
             Ok(cbor_data) => cbor_data,
-            Err(e) => {
-                panic!("Failed to parse embedded EE CBOR with: {e}")
-            }
+            Err(_e) => return Err(Error::ParseError),
         };
 
         Ok(Self {
@@ -490,4 +488,15 @@ fn get_trust_anchor_test() {
     let good = hex!("6C8A94A277B180721D817A16AAF2DCCE66EE45C0");
     assert!(pe.get_trust_anchor(&bad).is_err());
     assert!(pe.get_trust_anchor(&good).is_ok());
+}
+
+// Malformed CBOR must be reported as an error rather than panicking, matching
+// CertSource::new_from_cbor. Here 0x00 is well-formed CBOR (the integer 0) but not a serialized
+// BuffersAndPaths, so deserialization fails.
+#[test]
+fn new_from_cbor_rejects_malformed_input() {
+    assert_eq!(
+        TaSource::new_from_cbor(&[0x00]).err(),
+        Some(Error::ParseError)
+    );
 }

--- a/certval/src/validator/name_constraints_set.rs
+++ b/certval/src/validator/name_constraints_set.rs
@@ -427,21 +427,20 @@ impl NameConstraintsSet {
 
                         let mut uri_ok = false;
 
+                        // Parse the SAN URI's host once; it does not vary across the permitted
+                        // subtrees compared below.
                         #[cfg(feature = "std")]
-                        for gn_state in &self.uniform_resource_identifier {
-                            if let GeneralName::UniformResourceIdentifier(uri_state) =
-                                &gn_state.base
-                            {
-                                if let Ok(url) = Url::parse(uri_san.as_str()) {
-                                    if let Some(host) = url.host() {
-                                        if descended_from_host(
-                                            uri_state,
-                                            host.to_string().as_str(),
-                                            true,
-                                        ) {
-                                            uri_ok = true;
-                                            break;
-                                        }
+                        if let Some(host) = Url::parse(uri_san.as_str())
+                            .ok()
+                            .and_then(|url| url.host().map(|h| h.to_string()))
+                        {
+                            for gn_state in &self.uniform_resource_identifier {
+                                if let GeneralName::UniformResourceIdentifier(uri_state) =
+                                    &gn_state.base
+                                {
+                                    if descended_from_host(uri_state, host.as_str(), true) {
+                                        uri_ok = true;
+                                        break;
                                     }
                                 }
                             }
@@ -651,20 +650,19 @@ impl NameConstraintsSet {
                             continue;
                         }
 
+                        // Parse the SAN URI's host once; it does not vary across the excluded
+                        // subtrees compared below.
                         #[cfg(feature = "std")]
-                        for gn_state in &self.uniform_resource_identifier {
-                            if let GeneralName::UniformResourceIdentifier(uri_state) =
-                                &gn_state.base
-                            {
-                                if let Ok(url) = Url::parse(uri_san.as_str()) {
-                                    if let Some(host) = url.host() {
-                                        if descended_from_host(
-                                            uri_state,
-                                            host.to_string().as_str(),
-                                            true,
-                                        ) {
-                                            return true;
-                                        }
+                        if let Some(host) = Url::parse(uri_san.as_str())
+                            .ok()
+                            .and_then(|url| url.host().map(|h| h.to_string()))
+                        {
+                            for gn_state in &self.uniform_resource_identifier {
+                                if let GeneralName::UniformResourceIdentifier(uri_state) =
+                                    &gn_state.base
+                                {
+                                    if descended_from_host(uri_state, host.as_str(), true) {
+                                        return true;
                                     }
                                 }
                             }

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -227,12 +227,22 @@ pub static PS_EXTENDED_KEY_USAGE: &str = "psExtendedKeyUsage";
 pub static PS_EXTENDED_KEY_USAGE_PATH: &str = "psExtendedKeyUsagePath";
 
 /// `PS_INITIAL_PATH_LENGTH_CONSTRAINT` is used to retrieve a u8 value from a [`CertificationPathSettings`]
-/// object. This value is used in concert with BasicConstraints extensions during certification
-/// path validation by establishing the maximum path length that will be accepted. By default, the
-/// value is set to 15, as defined by `PS_MAX_PATH_LENGTH_CONSTRAINT`.
+/// object. It seeds RFC 5280's `max_path_length` state variable, which is decremented for each
+/// non-self-issued certificate in the path and further reduced by any basicConstraints
+/// `pathLenConstraint`. RFC 5280 6.1.2 initializes that variable to the path length itself; this
+/// implementation instead defaults it to the fixed ceiling [`PS_MAX_PATH_LENGTH_CONSTRAINT`] (15), so
+/// a path with more than that many non-self-issued certificates is rejected with `InvalidPathLength`
+/// even when no certificate asserts a `pathLenConstraint`. Raise this value to validate a longer
+/// caller-supplied path; note that dynamically built paths are additionally limited by the builder's
+/// search depth, which is bounded by [`PS_MAX_PATH_LENGTH_CONSTRAINT`] independently of this setting.
 pub static PS_INITIAL_PATH_LENGTH_CONSTRAINT: &str = "psInitialPathLengthConstraint";
 
-/// `PS_MAX_PATH_LENGTH_CONSTRAINT` sets the maximum length path accepted by validation implementation
+/// `PS_MAX_PATH_LENGTH_CONSTRAINT` is the maximum number of non-self-issued certificates accepted in a
+/// certification path. It is a deliberate system-wide resource ceiling rather than merely the default
+/// for [`PS_INITIAL_PATH_LENGTH_CONSTRAINT`]: it also bounds the depth to which the path builder
+/// searches for candidate paths and scales the per-validation policy-node pool. Paths exceeding it are
+/// rejected with `InvalidPathLength` even absent any certificate-asserted `pathLenConstraint`, which
+/// RFC 5280 permits as local policy.
 pub const PS_MAX_PATH_LENGTH_CONSTRAINT: u8 = 15;
 
 /// `PS_CRL_TIMEOUT_DEFAULT` sets the maximum amount of time to spend downloading a CRL expressed in seconds.

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -140,6 +140,11 @@ pub fn check_basic_constraints(
     cpr: &mut CertificationPathResults,
 ) -> Result<()> {
     cpr.add_processed_extension(ID_CE_BASIC_CONSTRAINTS);
+
+    // Seeds RFC 5280's max_path_length state variable. PS_INITIAL_PATH_LENGTH_CONSTRAINT defaults to
+    // the PS_MAX_PATH_LENGTH_CONSTRAINT ceiling rather than to the path length as in RFC 5280 6.1.2,
+    // so a path with more non-self-issued certificates than the ceiling is rejected below even absent
+    // any certificate-asserted pathLenConstraint. That fixed ceiling is a deliberate resource bound.
     let mut path_len_constraint = cps.get_initial_path_length_constraint();
 
     for ca_cert in cp.intermediates.iter() {


### PR DESCRIPTION
Improved documentation for path length constraints. Parse SAN URI once when processing name constraints (instead of inside loop). Return an error when invalid CBOR is presented to TaSource::new_from_cbor (instead of panic!). 