### PR TITLE
Adds an optional signature verification cache.

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -97,6 +97,9 @@ pub struct PkiEnvironment {
     /// List of trait objects that provide access to cached revocation status determinations
     revocation_cache: Vec<Box<dyn RevocationStatusCache + Send + Sync>>,
 
+    /// List of trait objects that cache successful certificate signature verifications
+    signature_cache: Vec<Box<dyn SignatureVerificationCache + Send + Sync>>,
+
     /// List of trait objects that provide access to blocklist and last modified info
     check_remote: Vec<Box<dyn CheckRemoteResource + Send + Sync>>,
 
@@ -123,6 +126,7 @@ impl Default for PkiEnvironment {
             oid_lookups: vec![oid_lookup],
             crl_sources: vec![],
             revocation_cache: vec![],
+            signature_cache: vec![],
             check_remote: vec![],
         }
     }
@@ -143,6 +147,7 @@ impl PkiEnvironment {
             oid_lookups: vec![],
             crl_sources: vec![],
             revocation_cache: vec![],
+            signature_cache: vec![],
             check_remote: vec![],
         }
     }
@@ -153,6 +158,7 @@ impl PkiEnvironment {
         self.clear_crl_sources();
         self.clear_oid_lookups();
         self.clear_revocation_cache();
+        self.clear_signature_cache();
         self.clear_certificate_sources();
         self.clear_calculate_hash_callbacks();
         self.clear_trust_anchor_sources();
@@ -543,6 +549,40 @@ impl PkiEnvironment {
         self.revocation_cache.clear();
     }
 
+    /// add_signature_cache adds a [`SignatureVerificationCache`] object to the list. Adding one opts
+    /// the environment into memoizing successful certificate signature verifications; with none
+    /// added, signatures are verified on every path validation as usual.
+    pub fn add_signature_cache(&mut self, c: Box<dyn SignatureVerificationCache + Send + Sync>) {
+        self.signature_cache.push(c);
+    }
+
+    /// clear_signature_cache clears the list of [`SignatureVerificationCache`] objects.
+    pub fn clear_signature_cache(&mut self) {
+        self.signature_cache.clear();
+    }
+
+    /// has_signature_cache returns true if at least one [`SignatureVerificationCache`] is configured.
+    /// Callers use this to avoid computing cache keys when memoization is not in use.
+    pub fn has_signature_cache(&self) -> bool {
+        !self.signature_cache.is_empty()
+    }
+
+    /// is_signature_verified returns true if any configured [`SignatureVerificationCache`] reports the
+    /// signature over `cert_hash` by the key identified by `issuer_spki_hash` as already verified.
+    pub fn is_signature_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
+        self.signature_cache
+            .iter()
+            .any(|c| c.is_verified(cert_hash, issuer_spki_hash))
+    }
+
+    /// add_verified_signature records a successful signature verification in each configured
+    /// [`SignatureVerificationCache`]. It is a no-op when no cache has been added.
+    pub fn add_verified_signature(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) {
+        for c in &self.signature_cache {
+            c.add_verified(cert_hash, issuer_spki_hash);
+        }
+    }
+
     /// Retrieves cached revocation status determination for given certificate from store
     pub fn get_status(
         &self,
@@ -688,5 +728,104 @@ impl PkiEnvironment {
         self.add_verify_signature_message_ctx_callback(verify_signature_message_ctx_rustcrypto);
         #[cfg(feature = "pqc")]
         self.add_verify_signature_message_callback(verify_signature_message_composite_rustcrypto);
+    }
+}
+
+/// Computes the hash used to key a [`SignatureVerificationCache`] entry from a certificate DER or an
+/// issuer subject-public-key-info DER. SHA-256 uniquely identifies the input for this purpose.
+pub(crate) fn signature_cache_hash(bytes: &[u8]) -> Vec<u8> {
+    use sha2::{Digest, Sha256};
+    Sha256::digest(bytes).to_vec()
+}
+
+/// A bounded, thread-safe [`SignatureVerificationCache`] backed by an in-memory set. Recording stops
+/// once the cap is reached so a long-lived environment that validates many distinct certificates
+/// cannot grow it without bound; the graph builder records certificate-authority edges first, so the
+/// frequently reused entries are retained.
+#[cfg(feature = "std")]
+pub struct DefaultSignatureVerificationCache {
+    verified: std::sync::RwLock<alloc::collections::BTreeSet<(Vec<u8>, Vec<u8>)>>,
+    cap: usize,
+}
+
+#[cfg(feature = "std")]
+impl DefaultSignatureVerificationCache {
+    /// Default maximum number of cached verifications.
+    pub const DEFAULT_CAP: usize = 8192;
+
+    /// Creates a cache with the default cap ([`DefaultSignatureVerificationCache::DEFAULT_CAP`]).
+    pub fn new() -> Self {
+        Self::with_capacity(Self::DEFAULT_CAP)
+    }
+
+    /// Creates a cache that stops recording new entries once `cap` have accumulated.
+    pub fn with_capacity(cap: usize) -> Self {
+        DefaultSignatureVerificationCache {
+            verified: std::sync::RwLock::new(alloc::collections::BTreeSet::new()),
+            cap,
+        }
+    }
+}
+
+#[cfg(feature = "std")]
+impl Default for DefaultSignatureVerificationCache {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+#[cfg(feature = "std")]
+impl SignatureVerificationCache for DefaultSignatureVerificationCache {
+    fn is_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
+        match self.verified.read() {
+            Ok(set) => set.contains(&(cert_hash.to_vec(), issuer_spki_hash.to_vec())),
+            Err(_) => false,
+        }
+    }
+
+    fn add_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) {
+        if let Ok(mut set) = self.verified.write() {
+            if set.len() < self.cap {
+                set.insert((cert_hash.to_vec(), issuer_spki_hash.to_vec()));
+            }
+        }
+    }
+}
+
+/// Delegating implementation so a caller can retain a shared handle to a cache (for example to
+/// inspect it) while also handing it to a [`PkiEnvironment`] via `add_signature_cache`.
+#[cfg(feature = "std")]
+impl<T: SignatureVerificationCache + ?Sized> SignatureVerificationCache for alloc::sync::Arc<T> {
+    fn is_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
+        (**self).is_verified(cert_hash, issuer_spki_hash)
+    }
+
+    fn add_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) {
+        (**self).add_verified(cert_hash, issuer_spki_hash)
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod signature_cache_tests {
+    use super::*;
+
+    #[test]
+    fn default_signature_cache_records_queries_and_caps() {
+        let cache = DefaultSignatureVerificationCache::with_capacity(2);
+        assert!(!cache.is_verified(b"cert-a", b"key-1"));
+
+        cache.add_verified(b"cert-a", b"key-1");
+        assert!(cache.is_verified(b"cert-a", b"key-1"));
+        // The issuer key is part of the key, so the same certificate against a different key is
+        // still unknown.
+        assert!(!cache.is_verified(b"cert-a", b"key-2"));
+
+        // Fill the cache to its cap; the second entry is recorded.
+        cache.add_verified(b"cert-b", b"key-1");
+        assert!(cache.is_verified(b"cert-b", b"key-1"));
+
+        // At the cap, further entries are dropped, so they report as not verified.
+        cache.add_verified(b"cert-c", b"key-1");
+        assert!(!cache.is_verified(b"cert-c", b"key-1"));
     }
 }

--- a/certval/src/environment/pki_environment_traits.rs
+++ b/certval/src/environment/pki_environment_traits.rs
@@ -206,3 +206,19 @@ pub trait RevocationStatusCache {
     fn add_status(&self, cert: &PDVCertificate, next_update: u64, status: PathValidationStatus);
 }
 // TODO add allowlist and blocklist as RevocationStatusCache implementations
+
+/// The [`SignatureVerificationCache`] trait defines an interface for caching successful certificate
+/// signature verifications so a signature verified once (for example while building the partial-path
+/// graph) need not be re-verified on every subsequent path validation. Entries are keyed by a hash
+/// of the certificate and a hash of the issuer's subject public key, which together fully determine
+/// the verification, so a positive result is always sound to trust. An absent entry means the
+/// signature is verified as usual, so correctness never depends on the cache being present or
+/// populated.
+pub trait SignatureVerificationCache {
+    /// Returns true if a signature over the certificate identified by `cert_hash` by the key
+    /// identified by `issuer_spki_hash` has already been verified successfully.
+    fn is_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) -> bool;
+
+    /// Records a successful signature verification.
+    fn add_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]);
+}

--- a/certval/src/source/cert_source.rs
+++ b/certval/src/source/cert_source.rs
@@ -42,7 +42,7 @@ use const_oid::db::rfc5912::{
     ID_CE_AUTHORITY_KEY_IDENTIFIER, ID_CE_BASIC_CONSTRAINTS, ID_CE_NAME_CONSTRAINTS,
     ID_CE_SUBJECT_ALT_NAME, ID_CE_SUBJECT_KEY_IDENTIFIER,
 };
-use der::Decode;
+use der::{Decode, Encode};
 use spki::SubjectPublicKeyInfoOwned;
 use x509_cert::certificate::CertificateInner;
 use x509_cert::ext::pkix::name::GeneralName;
@@ -50,6 +50,7 @@ use x509_cert::name::Name;
 
 use crate::{
     compare_names,
+    environment::pki_environment::signature_cache_hash,
     environment::pki_environment_traits::*,
     general_subtree_to_string, get_leaf_rdn,
     pdv_certificate::*,
@@ -1221,6 +1222,16 @@ impl CertSource {
                                         spki,
                                     );
                                     if let Ok(_r) = r {
+                                        // Cache this trust-anchor-to-CA signature so path
+                                        // validation need not re-verify it (skipped without a cache).
+                                        if pe.has_signature_cache() {
+                                            if let Ok(spki_der) = spki.to_der() {
+                                                pe.add_verified_signature(
+                                                    &signature_cache_hash(cur_cert.as_bytes()),
+                                                    &signature_cache_hash(&spki_der),
+                                                );
+                                            }
+                                        }
                                         let new_path = vec![cur_cert_index];
                                         if new_additions.contains_key(&cur_cert_hex_skid) {
                                             if !new_additions[&cur_cert_hex_skid]
@@ -1284,6 +1295,21 @@ impl CertSource {
                                                 .subject_public_key_info(),
                                         );
                                         if let Ok(_r) = r {
+                                            // Cache this CA-to-CA signature so path validation need
+                                            // not re-verify it (skipped without a cache).
+                                            if pe.has_signature_cache() {
+                                                if let Ok(spki_der) = prospective_ca_cert
+                                                    .as_ref()
+                                                    .tbs_certificate()
+                                                    .subject_public_key_info()
+                                                    .to_der()
+                                                {
+                                                    pe.add_verified_signature(
+                                                        &signature_cache_hash(cur_cert.as_bytes()),
+                                                        &signature_cache_hash(&spki_der),
+                                                    );
+                                                }
+                                            }
                                             if !self.pub_key_in_path(cur_cert, prospective_path) {
                                                 let mut new_path = prospective_path.clone();
                                                 new_path.push(cur_cert_index);
@@ -1708,4 +1734,143 @@ fn get_certificates_test() {
 
     let v = cert_store.get_encoded_certificates().unwrap();
     assert_eq!(399, v.len());
+}
+
+// Building the partial-path graph records the trust-anchor-to-CA signature it verifies into a
+// configured signature cache, so path validation can later skip re-verifying it. The cache is added
+// through a retained Arc handle so the recorded edge can be inspected afterward.
+#[cfg(all(feature = "std", feature = "rsa"))]
+#[test]
+fn build_records_verified_signatures() {
+    use crate::environment::pki_environment::{
+        signature_cache_hash, DefaultSignatureVerificationCache,
+    };
+    use crate::PDVTrustAnchorChoice;
+    use alloc::sync::Arc;
+
+    let ta_der = include_bytes!("../../tests/examples/TrustAnchorRootCertificate.crt");
+    let ca_der =
+        include_bytes!("../../tests/examples/rfc822_dn_nc/nameConstraintsRFC822CA1Cert.crt");
+
+    let mut ta_source = TaSource::new();
+    ta_source.push(CertFile {
+        filename: "ta".to_string(),
+        bytes: ta_der.to_vec(),
+    });
+    ta_source.initialize().unwrap();
+
+    let mut pe = PkiEnvironment::new();
+    pe.populate_5280_pki_environment();
+    pe.add_trust_anchor_source(Box::new(ta_source));
+
+    // Keep a shared handle to the cache so it can be inspected after the build.
+    let cache = Arc::new(DefaultSignatureVerificationCache::new());
+    pe.add_signature_cache(Box::new(cache.clone()));
+
+    let cps = CertificationPathSettings::new();
+    let mut cert_source = CertSource::new();
+    cert_source.push(CertFile {
+        filename: "ca".to_string(),
+        bytes: ca_der.to_vec(),
+    });
+    cert_source.initialize(&cps).unwrap();
+    cert_source.find_all_partial_paths(&pe, &cps);
+
+    // The build verified the trust-anchor-to-CA signature, so the cache holds that edge keyed by the
+    // CA certificate hash and the trust anchor's subject-public-key-info hash.
+    let ta = PDVTrustAnchorChoice::try_from(ta_der.as_slice()).unwrap();
+    let ta_spki = get_subject_public_key_info_from_trust_anchor(&ta.decoded_ta);
+    let cert_hash = signature_cache_hash(ca_der);
+    let spki_hash = signature_cache_hash(&ta_spki.to_der().unwrap());
+    assert!(
+        cache.is_verified(&cert_hash, &spki_hash),
+        "graph build should record the trust-anchor-to-CA signature"
+    );
+}
+
+// Building the partial-path graph over the PKITS certificates records every verified edge into a
+// configured cache; re-verifying all of those paths is then measurably faster with the cache (the
+// expensive signature verifications are skipped) than without it (every signature is verified).
+#[cfg(all(feature = "std", feature = "rsa"))]
+#[test]
+fn signature_cache_speeds_up_verification() {
+    use crate::environment::pki_environment::DefaultSignatureVerificationCache;
+    use crate::file_utils::cert_folder_to_vec;
+    use crate::validator::path_validator::verify_signatures;
+    use crate::CertificationPathResults;
+    use std::time::Instant;
+
+    let toi = TimeOfInterest::disabled();
+
+    let ta_der = include_bytes!("../../tests/examples/TrustAnchorRootCertificate.crt");
+    let mut ta_source = TaSource::new();
+    ta_source.push(CertFile {
+        filename: "ta".to_string(),
+        bytes: ta_der.to_vec(),
+    });
+    ta_source.initialize().unwrap();
+
+    let mut pe = PkiEnvironment::new();
+    pe.populate_5280_pki_environment();
+    pe.add_trust_anchor_source(Box::new(ta_source));
+    pe.add_signature_cache(Box::new(DefaultSignatureVerificationCache::with_capacity(
+        usize::MAX,
+    )));
+
+    // Load all PKITS certificates and build the partial-path graph, recording the verified edges.
+    let cps = CertificationPathSettings::new();
+    let mut cert_source = CertSource::new();
+    cert_folder_to_vec(
+        &pe,
+        "tests/examples/PKITS_data_2048/certs",
+        &mut cert_source,
+        toi,
+    )
+    .unwrap();
+    cert_source.initialize(&cps).unwrap();
+    cert_source.find_all_partial_paths(&pe, &cps);
+
+    // Collect every path the builder found across all certificates.
+    let mut paths: Vec<CertificationPath> = vec![];
+    for cert in cert_source.get_certificates().unwrap() {
+        let _ = cert_source.get_paths_for_target(&pe, cert, &mut paths, 0, toi);
+    }
+    assert!(!paths.is_empty(), "expected the PKITS graph to yield paths");
+
+    let verify_all = |pe: &PkiEnvironment, paths: &mut [CertificationPath]| {
+        for cp in paths.iter_mut() {
+            let mut cpr = CertificationPathResults::new();
+            let _ = verify_signatures(pe, &cps, cp, &mut cpr);
+        }
+    };
+
+    // A few iterations suffice: the cache skips essentially all verifications, so the gap is large
+    // (well over 10x) and the assertion is not sensitive to timing noise.
+    let iters = 3;
+
+    // With the cache populated the intermediate signatures are skipped.
+    verify_all(&pe, &mut paths);
+    let start = Instant::now();
+    for _ in 0..iters {
+        verify_all(&pe, &mut paths);
+    }
+    let cached = start.elapsed();
+
+    // Drop the cache; every signature is verified again.
+    pe.clear_signature_cache();
+    verify_all(&pe, &mut paths);
+    let start = Instant::now();
+    for _ in 0..iters {
+        verify_all(&pe, &mut paths);
+    }
+    let uncached = start.elapsed();
+
+    println!(
+        "verify_signatures over {} PKITS paths x{iters}: cached={cached:?} uncached={uncached:?}",
+        paths.len()
+    );
+    assert!(
+        cached < uncached,
+        "cached ({cached:?}) should be faster than uncached ({uncached:?})"
+    );
 }

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use const_oid::db::rfc5280::ANY_POLICY;
 use const_oid::db::rfc5912::*;
-use der::{asn1::ObjectIdentifier, Decode};
+use der::{asn1::ObjectIdentifier, Decode, Encode};
 use x509_cert::anchor::TrustAnchorChoice;
 use x509_cert::ext::pkix::constraints::name::GeneralSubtrees;
 use x509_cert::ext::pkix::name::GeneralName;
@@ -960,22 +960,40 @@ pub fn verify_signatures(
             return Err(Error::PathValidation(PathValidationStatus::EncodingError));
         }
 
-        let r = pe.verify_signature_message(
-            pe,
-            &defer_cert.tbs_field,
-            cur_cert.as_ref().signature().raw_bytes(),
-            cur_cert.as_ref().tbs_certificate().signature(),
-            &working_spki,
-        );
-        if let Err(e) = r {
-            log_error_for_ca(
-                cur_cert,
-                format!("signature verification error: {e:?}").as_str(),
+        // Skip the (expensive) signature verification when a configured signature cache reports this
+        // exact certificate-and-issuer-key pair as already verified, e.g. by the path builder. The
+        // cheap structural checks above still run, and with no cache configured this is always false,
+        // so the signature is verified as usual.
+        let verified_from_cache = pe.has_signature_cache()
+            && working_spki
+                .to_der()
+                .ok()
+                .map(|spki_der| {
+                    pe.is_signature_verified(
+                        &signature_cache_hash(cur_cert.as_bytes()),
+                        &signature_cache_hash(&spki_der),
+                    )
+                })
+                .unwrap_or(false);
+
+        if !verified_from_cache {
+            let r = pe.verify_signature_message(
+                pe,
+                &defer_cert.tbs_field,
+                cur_cert.as_ref().signature().raw_bytes(),
+                cur_cert.as_ref().tbs_certificate().signature(),
+                &working_spki,
             );
-            cpr.set_validation_status(PathValidationStatus::SignatureVerificationFailure);
-            return Err(Error::PathValidation(
-                PathValidationStatus::SignatureVerificationFailure,
-            ));
+            if let Err(e) = r {
+                log_error_for_ca(
+                    cur_cert,
+                    format!("signature verification error: {e:?}").as_str(),
+                );
+                cpr.set_validation_status(PathValidationStatus::SignatureVerificationFailure);
+                return Err(Error::PathValidation(
+                    PathValidationStatus::SignatureVerificationFailure,
+                ));
+            }
         }
 
         working_spki = cur_cert
@@ -1015,6 +1033,53 @@ pub fn check_country_codes(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // A configured signature cache that reports a signature as verified causes verify_signatures to
+    // skip the (expensive) verification. Using a target that is not signed by the trust anchor, the
+    // check fails without a cache and passes once an always-verified cache is added.
+    #[cfg(all(feature = "std", feature = "rsa"))]
+    #[test]
+    fn signature_cache_bypasses_verification() {
+        use crate::environment::pki_environment_traits::SignatureVerificationCache;
+
+        struct AlwaysVerified;
+        impl SignatureVerificationCache for AlwaysVerified {
+            fn is_verified(&self, _: &[u8], _: &[u8]) -> bool {
+                true
+            }
+            fn add_verified(&self, _: &[u8], _: &[u8]) {}
+        }
+
+        let ta_der = include_bytes!("../../tests/examples/TrustAnchorRootCertificate.crt");
+        let target_der = include_bytes!("../../tests/examples/ocsp_dod/ca63.der");
+
+        let build_path = || {
+            let mut ta = PDVTrustAnchorChoice::try_from(ta_der.as_slice()).unwrap();
+            ta.parse_extensions(EXTS_OF_INTEREST);
+            let target = PDVCertificate::try_from(target_der.as_slice()).unwrap();
+            CertificationPath::new(ta, vec![], target)
+        };
+
+        let mut pe = PkiEnvironment::new();
+        pe.populate_5280_pki_environment();
+        let cps = CertificationPathSettings::new();
+
+        // Without a cache, the mismatched signature is rejected.
+        let mut cp = build_path();
+        let mut cpr = CertificationPathResults::new();
+        assert_eq!(
+            verify_signatures(&pe, &cps, &mut cp, &mut cpr),
+            Err(Error::PathValidation(
+                PathValidationStatus::SignatureVerificationFailure
+            ))
+        );
+
+        // With an always-verified cache, the signature check is skipped.
+        pe.add_signature_cache(Box::new(AlwaysVerified));
+        let mut cp = build_path();
+        let mut cpr = CertificationPathResults::new();
+        assert!(verify_signatures(&pe, &cps, &mut cp, &mut cpr).is_ok());
+    }
 
     #[test]
     fn budget_predicate_boundary() {


### PR DESCRIPTION
When partial certification paths are built, signatures are checked for each node. However, when paths are validated, signatures are rechecked. The new SignatureVerificationCache trait addition to PkiEnvironment allows for signature verification status to be cached if desired. This is off by default and must be elected by callers to be in effect.