### PR TITLE
three fixes relative to pittv3-wasm

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -6,3 +6,12 @@
 # which moved to a rustc-1.86 floor) and turning the 1.85 CI leg red.
 [resolver]
 incompatible-rust-versions = "fallback"
+
+# The wasm32-unknown-unknown default stack size is 1MB, which slh-dsa signature decoding
+# exceeds for the 256-bit parameter sets (hybrid_array builds the hypertree/XMSS signature
+# through large stack temporaries, and the size-optimized wasm-release profile does little
+# inlining or copy elision). Overflow surfaces in the browser as "RuntimeError: memory access
+# out of bounds" and poisons the wasm instance. 8MB matches the native main-thread stack and
+# only reserves linear-memory pages.
+[target.wasm32-unknown-unknown]
+rustflags = ["-C", "link-arg=-zstack-size=8388608"]

--- a/.github/workflows/certval.yml
+++ b/.github/workflows/certval.yml
@@ -45,6 +45,36 @@ jobs:
       # see build job note: UI crates excluded (dioxus tree MSRV + system packages)
       - run: cargo hack test --each-feature --workspace --exclude pittv3-gui --exclude pittv3_gui_lib --exclude pittv3-wasm
 
+  # --each-feature never combines features, so the std+rsa test population
+  # (revocation.rs, rfc822_dn_name_constraints.rs, the pkits_2048 std variants)
+  # otherwise runs on dev machines only. This job executes it. Verified to need
+  # no network and no RUST_MIN_STACK override (2026-07-20).
+  test-combined:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        rust:
+          - 1.85.0 # MSRV
+          - stable
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ matrix.rust }}
+      - run: cargo test -p certval --features std,rsa,revocation,pqc
+
+  # certval is no_std-capable; prove it links for an embedded target. Build-only
+  # (no test runner on the target). thumbv7em-none-eabihf deliberately — an
+  # x86_64-unknown-none check can silently tolerate std leakage this catches.
+  build-nostd:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: thumbv7em-none-eabihf
+      - run: cargo build -p certval --no-default-features --target thumbv7em-none-eabihf
+
   x509-limbo:
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/pittv3-ui.yml
+++ b/.github/workflows/pittv3-ui.yml
@@ -1,0 +1,36 @@
+# CI for the pittv3 UI crates, which certval.yml excludes: the dioxus 0.7
+# dependency tree requires rustc >= 1.88 (home/built/image/time), above that
+# workflow's 1.85 MSRV legs, and pittv3-gui needs Linux system packages absent
+# from stock runners. Splitting them here ends the exclusion without moving
+# certval's MSRV. Build-only: the UI has no headless test surface yet.
+name: pittv3-ui
+
+on:
+  pull_request:
+  push:
+    branches: main
+  workflow_dispatch:
+
+env:
+  CARGO_INCREMENTAL: 0
+  RUSTFLAGS: "-Dwarnings"
+
+jobs:
+  gui:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      # dioxus-desktop on Linux needs webkit2gtk/gtk3/xdo development packages.
+      - run: sudo apt-get update && sudo apt-get install -y libwebkit2gtk-4.1-dev libgtk-3-dev libxdo-dev
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo check -p pittv3_gui_lib
+      - run: cargo check -p pittv3-gui
+
+  wasm:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: wasm32-unknown-unknown
+      - run: cargo build -p pittv3-wasm --target wasm32-unknown-unknown

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4617,6 +4617,7 @@ version = "0.1.3"
 dependencies = [
  "certval",
  "dioxus",
+ "getrandom 0.4.3",
  "log",
  "pem-rfc7468",
  "web-time",

--- a/pittv3-wasm/Cargo.toml
+++ b/pittv3-wasm/Cargo.toml
@@ -28,3 +28,9 @@ log = "0.4.33"
 pem-rfc7468 = { version = "1.0.0", features = ["alloc"] }
 web-time = "1.1.0"
 zip = { version = "7.2.0", default-features = false, features = ["deflate"] }
+
+# getrandom 0.4 (pulled in transitively via the RustCrypto 0.3/0.8 wave, e.g. crypto-common) has no
+# default backend on wasm32-unknown-unknown; the wasm_js feature opts into the JS (wasm-bindgen)
+# backend. Target-gated so native builds (e.g. the ziptest bin) do not pull in wasm-bindgen/js-sys.
+[target.'cfg(all(target_family = "wasm", target_os = "unknown"))'.dependencies]
+getrandom = { version = "0.4", features = ["wasm_js"] }

--- a/pittv3-wasm/src/validate.rs
+++ b/pittv3-wasm/src/validate.rs
@@ -308,7 +308,9 @@ fn validate_target(
     // reported as valid
     if pe.is_cert_a_trust_anchor(&target).is_ok() {
         if is_self_signed(pe, &target) {
-            out.push(ok(format!("{ee_name} is a trust anchor and is self-signed")));
+            out.push(ok(format!(
+                "{ee_name} is a trust anchor and is self-signed"
+            )));
         } else {
             out.push(err(format!(
                 "{ee_name} matches a trust anchor by key but is not self-signed (bad signature or unsupported algorithm)"

--- a/pittv3-wasm/src/validate.rs
+++ b/pittv3-wasm/src/validate.rs
@@ -301,6 +301,21 @@ fn validate_target(
         }
     };
 
+    // validate_path treats a target found in the TA store as trusted and returns success without
+    // verifying its signature (and TA store membership requires only a subjectKeyIdentifier and
+    // public key match, not an exact certificate match), so when the target is a trust anchor
+    // check its signature here to keep bad signatures and unsupported algorithms from being
+    // reported as valid
+    if pe.is_cert_a_trust_anchor(&target).is_ok() {
+        if is_self_signed(pe, &target) {
+            out.push(ok(format!("{ee_name} is a trust anchor and is self-signed")));
+        } else {
+            out.push(err(format!(
+                "{ee_name} matches a trust anchor by key but is not self-signed (bad signature or unsupported algorithm)"
+            )));
+        }
+    }
+
     out.push(info(format!(
         "Building and validating path(s) for {} ({})",
         ee_name,
@@ -375,23 +390,15 @@ fn validate_target(
     out
 }
 
-/// Validates a self-signed certificate as a target anchored at itself, i.e., as done for trust
-/// anchors from hackathon archives (path building declines self-signed targets, so the path is
-/// constructed directly)
-fn validate_self_signed(
-    pe: &PkiEnvironment,
-    cps: &CertificationPathSettings,
-    name: &str,
-    der: &[u8],
-) -> Vec<ResultLine> {
+/// Checks whether a certificate is self-signed, i.e., whether its signature verifies using its
+/// own public key, as done for trust anchors from hackathon archives. This mirrors the hackathon
+/// compatibility matrices and the CLI --validate-self-signed option, which check self-signed-ness
+/// only. Full path validation is deliberately not used here: with the trust anchors loaded into
+/// the TA store, validate_path treats a target found in the store as trusted and returns success
+/// without verifying the signature, reporting certificates signed with unsupported algorithms as
+/// valid.
+fn validate_self_signed(pe: &PkiEnvironment, name: &str, der: &[u8]) -> Vec<ResultLine> {
     let mut out = vec![];
-    let ta_choice = match PDVTrustAnchorChoice::create(der, name) {
-        Ok(t) => t,
-        Err(e) => {
-            out.push(err(format!("Failed to parse trust anchor {name}: {e:?}")));
-            return out;
-        }
-    };
     let target = match parse_cert(der, name) {
         Ok(t) => t,
         Err(e) => {
@@ -399,23 +406,12 @@ fn validate_self_signed(
             return out;
         }
     };
-    let mut path = CertificationPath::new(ta_choice, Default::default(), target);
-
-    // fold RFC 5914 trust anchor constraints into the settings per RFC 5937; this is a no-op
-    // clone when enforcement is disabled, and validate_path does not perform it itself
-    let path_cps = match enforce_trust_anchor_constraints(cps, &path.trust_anchor) {
-        Ok(c) => c,
-        Err(e) => {
-            out.push(err(format!(
-                "Self-signed {name}: failed to apply trust anchor constraints: {e:?}"
-            )));
-            return out;
-        }
-    };
-    let mut cpr = CertificationPathResults::new();
-    match pe.validate_path(pe, &path_cps, &mut path, &mut cpr) {
-        Ok(_) => out.push(ok(format!("Self-signed {name}: VALID"))),
-        Err(e) => out.push(err(format!("Self-signed {name}: INVALID with {e:?}"))),
+    if is_self_signed(pe, &target) {
+        out.push(ok(format!("{name} is self-signed")));
+    } else {
+        out.push(err(format!(
+            "{name} is not self-signed (bad signature or unsupported algorithm)"
+        )));
     }
     out
 }
@@ -514,10 +510,10 @@ pub fn validate_hackathon_zip(
     }
     pe.add_certificate_source(Box::new(cert_source));
 
-    // trust anchors are self-signed certificates per the R5 format, so each is also validated
-    // as a target anchored at itself
+    // trust anchors are self-signed certificates per the R5 format, so each is checked for
+    // self-signed-ness (signature verifies with the certificate's own key)
     for (name, der) in &tas {
-        out.extend(validate_self_signed(&pe, &cps, name, der));
+        out.extend(validate_self_signed(&pe, name, der));
     }
     for (name, der) in &ees {
         out.extend(validate_target(&pe, &cps, name, der, vs.validate_all));


### PR DESCRIPTION
- bump wasm stack size to 8MB: slh-dsa signature decoding for the SHA2-256 overflows at 1MB
- change getrandom features to address regression from dependency update round (CI does not check WASM build at present)
- change hackathon zip verification to only do self-signed check