### PR TITLE
Detect TA collisions in PkiEnvironment

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -35,13 +35,20 @@
 //!
 
 use alloc::boxed::Box;
+use alloc::collections::{BTreeMap, BTreeSet};
 use alloc::string::{String, ToString};
 use alloc::{vec, vec::Vec};
 
 use der::asn1::ObjectIdentifier;
+use der::Encode;
+use log::error;
 use spki::{AlgorithmIdentifierOwned, SubjectPublicKeyInfoOwned};
 use x509_cert::{certificate::Raw, crl::CertificateList, name::Name};
 
+use crate::source::ta_source::{
+    buffer_to_hex, get_subject_public_key_info_from_trust_anchor, hex_skid_from_cert,
+    hex_skid_from_ta,
+};
 use crate::PathValidationStatus::RevocationStatusNotDetermined;
 use crate::{
     environment::pki_environment_traits::*, path_settings::*, util::crypto::*, util::error::*,
@@ -89,6 +96,12 @@ pub struct PkiEnvironment {
     /// List of trait objects that provide access to trust anchors
     trust_anchor_sources: Vec<Box<dyn TrustAnchorSource + Send + Sync>>,
 
+    /// Hex-encoded subject key identifiers that resolve to more than one distinct public key across
+    /// the registered `trust_anchor_sources`. Such a SKID cannot unambiguously identify a trust
+    /// anchor, so trust-anchor lookups keyed on it are refused (fail-closed). Recomputed whenever the
+    /// set of trust anchor sources changes; see `add_trust_anchor_source`.
+    poisoned_ta_skids: BTreeSet<String>,
+
     /// List of trait objects that provide access to certificates
     certificate_sources: Vec<Box<dyn CertificateSource + Send + Sync>>,
 
@@ -123,6 +136,7 @@ impl Default for PkiEnvironment {
             verify_signature_message_ctx_callbacks: vec![],
             validate_path_callbacks: vec![],
             trust_anchor_sources: vec![],
+            poisoned_ta_skids: BTreeSet::new(),
             certificate_sources: vec![],
             oid_lookups: vec![oid_lookup],
             crl_sources: vec![],
@@ -144,6 +158,7 @@ impl PkiEnvironment {
             verify_signature_message_ctx_callbacks: vec![],
             validate_path_callbacks: vec![],
             trust_anchor_sources: vec![],
+            poisoned_ta_skids: BTreeSet::new(),
             certificate_sources: vec![],
             oid_lookups: vec![],
             crl_sources: vec![],
@@ -356,18 +371,66 @@ impl PkiEnvironment {
     }
 
     /// add_trust_anchor_source adds a [`TrustAnchorSource`] object to the list used by get_trust_anchor.
+    ///
+    /// Adding a source re-evaluates subject key identifier collisions across all registered trust
+    /// anchor sources (see `poisoned_ta_skids`). A source whose membership changes after it is added
+    /// must be removed and re-added for the collision set to be recomputed; the environment does not
+    /// observe a source mutating itself in place.
     pub fn add_trust_anchor_source(&mut self, c: Box<dyn TrustAnchorSource + Send + Sync>) {
         self.trust_anchor_sources.push(c);
+        self.reindex_poisoned_ta_skids();
     }
 
     /// clear_trust_anchor_sources clears the list of [`TrustAnchorSource`] objects used by get_trust_anchor.
     pub fn clear_trust_anchor_sources(&mut self) {
         self.trust_anchor_sources.clear();
+        self.reindex_poisoned_ta_skids();
+    }
+
+    /// Recomputes [`poisoned_ta_skids`] from the current trust anchor sources. A subject key
+    /// identifier is poisoned when two trust anchors share it but carry different public keys, since
+    /// the SKID can then no longer identify a unique anchor. Same-key duplicates are benign and are
+    /// not poisoned. Runs whenever the set of sources changes; anchors are few, so the scan is cheap.
+    fn reindex_poisoned_ta_skids(&mut self) {
+        let mut first_spki: BTreeMap<String, Vec<u8>> = BTreeMap::new();
+        let mut poisoned: BTreeSet<String> = BTreeSet::new();
+        for ta in self.get_trust_anchors() {
+            let hex_skid = hex_skid_from_ta(ta);
+            if hex_skid.is_empty() || poisoned.contains(&hex_skid) {
+                continue;
+            }
+            let spki_der =
+                match get_subject_public_key_info_from_trust_anchor(&ta.decoded_ta).to_der() {
+                    Ok(d) => d,
+                    Err(_e) => continue,
+                };
+            match first_spki.get(&hex_skid) {
+                Some(existing) if *existing != spki_der => {
+                    error!("Trust anchor subject key identifier {hex_skid} resolves to more than one public key across registered sources; refusing to anchor on it");
+                    first_spki.remove(&hex_skid);
+                    poisoned.insert(hex_skid);
+                }
+                Some(_) => {} // same SKID, same key: benign duplicate
+                None => {
+                    first_spki.insert(hex_skid, spki_der);
+                }
+            }
+        }
+        self.poisoned_ta_skids = poisoned;
+    }
+
+    /// Returns true if `hex_skid` is ambiguous across the registered trust anchor sources, i.e., it
+    /// maps to more than one public key. Trust-anchor lookups keyed on such a SKID are refused.
+    fn ta_skid_poisoned(&self, hex_skid: &str) -> bool {
+        self.poisoned_ta_skids.contains(hex_skid)
     }
 
     /// get_trust_anchor iterates over trust_anchor_sources until an authoritative answer is found
     /// or all options have been exhausted
     pub fn get_trust_anchor(&self, skid: &[u8]) -> Result<&PDVTrustAnchorChoice> {
+        if self.ta_skid_poisoned(&buffer_to_hex(skid)) {
+            return Err(Error::Unrecognized);
+        }
         for f in &self.trust_anchor_sources {
             let r = f.get_trust_anchor_by_skid(skid);
             if let Ok(r) = r {
@@ -390,6 +453,9 @@ impl PkiEnvironment {
 
     /// get_trust_anchor_by_hex_skid returns a reference to a trust anchor corresponding to the presented hexadecimal SKID.
     pub fn get_trust_anchor_by_hex_skid(&self, hex_skid: &str) -> Result<&PDVTrustAnchorChoice> {
+        if self.ta_skid_poisoned(hex_skid) {
+            return Err(Error::Unrecognized);
+        }
         for f in &self.trust_anchor_sources {
             let r = f.get_trust_anchor_by_hex_skid(hex_skid);
             if let Ok(r) = r {
@@ -406,8 +472,12 @@ impl PkiEnvironment {
         target: &PDVCertificate,
     ) -> Result<&PDVTrustAnchorChoice> {
         for f in &self.trust_anchor_sources {
-            let r = f.get_trust_anchor_for_target(target);
-            if let Ok(r) = r {
+            if let Ok(r) = f.get_trust_anchor_for_target(target) {
+                // Refuse a candidate whose SKID is ambiguous across sources rather than anchoring on
+                // a guess; the collision may be why this source matched by name in the first place.
+                if self.ta_skid_poisoned(&hex_skid_from_ta(r)) {
+                    continue;
+                }
                 return Ok(r);
             }
         }
@@ -418,6 +488,9 @@ impl PkiEnvironment {
     pub fn get_trust_anchor_by_name(&'_ self, name: &Name) -> Result<&PDVTrustAnchorChoice> {
         for f in &self.trust_anchor_sources {
             if let Ok(r) = f.get_trust_anchor_by_name(name) {
+                if self.ta_skid_poisoned(&hex_skid_from_ta(r)) {
+                    continue;
+                }
                 return Ok(r);
             }
         }
@@ -437,6 +510,11 @@ impl PkiEnvironment {
 
     /// is_cert_a_trust_anchor takes a target certificate indication if cert is a trust anchor.
     pub fn is_cert_a_trust_anchor(&self, target: &PDVCertificate) -> Result<()> {
+        // An ambiguous SKID cannot identify a unique anchor, so do not treat a cert bearing one as a
+        // trust anchor even if a source matches it.
+        if self.ta_skid_poisoned(&hex_skid_from_cert(target)) {
+            return Err(Error::NotFound);
+        }
         for f in &self.trust_anchor_sources {
             if f.is_cert_a_trust_anchor(target).is_ok() {
                 return Ok(());
@@ -447,6 +525,9 @@ impl PkiEnvironment {
 
     /// is_trust_anchor takes a [`PDVTrustAnchorChoice`] indication if cert is a trust anchor.
     pub fn is_trust_anchor(&self, target: &PDVTrustAnchorChoice) -> Result<()> {
+        if self.ta_skid_poisoned(&hex_skid_from_ta(target)) {
+            return Err(Error::NotFound);
+        }
         for f in &self.trust_anchor_sources {
             if f.is_trust_anchor(target).is_ok() {
                 return Ok(());

--- a/certval/tests/path_validator.rs
+++ b/certval/tests/path_validator.rs
@@ -412,3 +412,113 @@ fn enforce_ta_constraints_rejects_same_key_different_constraints() {
         "expected TrustAnchorConstraintsMismatch"
     );
 }
+
+// A subject key identifier shared by two trust anchors with different public keys is ambiguous:
+// the PkiEnvironment poisons that SKID and refuses trust-anchor lookups keyed on it, so neither
+// anchor can be used. A store without the collision resolves normally, and a same-key duplicate
+// under the same SKID is benign and still resolves.
+#[cfg(feature = "rsa")]
+#[test]
+fn colliding_skid_different_keys_is_refused() {
+    use der::asn1::OctetString;
+    use der::Encode;
+    use x509_cert::anchor::{TrustAnchorChoice, TrustAnchorInfo};
+
+    // This test deliberately induces a SKID collision, which the library correctly reports at ERROR.
+    // Suppress log output for the duration so the induced error does not clutter otherwise-quiet test
+    // output; no assertion depends on logging. Install the logger first (idempotent) so a sibling
+    // test's parallel try_init cannot reset the max level back after this one lowers it.
+    let _ = pretty_env_logger::try_init();
+    let prev_log_level = log::max_level();
+    log::set_max_level(log::LevelFilter::Off);
+
+    let der_root = include_bytes!("examples/TrustAnchorRootCertificate.crt");
+    let der_other = include_bytes!("examples/GoodCACert.crt");
+    let root = Certificate::from_der(der_root).unwrap();
+    let other = Certificate::from_der(der_other).unwrap();
+
+    // The SKID TrustAnchorRootCertificate.crt is indexed under.
+    let root_skid: [u8; 20] = [
+        0xE4, 0x7D, 0x5F, 0xD1, 0x5C, 0x95, 0x86, 0x08, 0x2C, 0x05, 0xAE, 0xBE, 0x75, 0xB6, 0x65,
+        0xA7, 0xD9, 0x5D, 0xA8, 0x66,
+    ];
+    let root_skid_hex = buffer_to_hex(&root_skid);
+
+    // A TaInfo trust anchor reusing root_skid as its key_id, carrying the given public key, as a DER
+    // buffer a TaSource can parse.
+    let make_tainfo = |spki: spki::SubjectPublicKeyInfoOwned| -> Vec<u8> {
+        let tai: TrustAnchorInfo<Raw> = TrustAnchorInfo {
+            version: Default::default(),
+            pub_key: spki,
+            key_id: OctetString::new(root_skid.to_vec()).unwrap(),
+            ta_title: None,
+            cert_path: None,
+            extensions: None,
+            ta_title_lang_tag: None,
+        };
+        TrustAnchorChoice::TaInfo(tai).to_der().unwrap()
+    };
+
+    let mut src_root = TaSource::new();
+    src_root.push(CertFile {
+        filename: "root".to_string(),
+        bytes: der_root.to_vec(),
+    });
+    src_root.initialize().unwrap();
+
+    let mut root_ta = PDVTrustAnchorChoice::try_from(der_root.as_slice()).unwrap();
+    root_ta.parse_extensions(EXTS_OF_INTEREST);
+
+    // Baseline: no collision, so the root resolves by its SKID and is recognized as a trust anchor.
+    {
+        let mut pe = PkiEnvironment::new();
+        pe.add_trust_anchor_source(Box::new(src_root.clone()));
+        assert!(pe.get_trust_anchor_by_hex_skid(&root_skid_hex).is_ok());
+        assert!(pe.is_trust_anchor(&root_ta).is_ok());
+    }
+
+    // Collision: a second anchor reuses the SKID with a different key -> the SKID is poisoned.
+    let mut src_collide = TaSource::new();
+    src_collide.push(CertFile {
+        filename: "collide".to_string(),
+        bytes: make_tainfo(other.tbs_certificate().subject_public_key_info().clone()),
+    });
+    src_collide.initialize().unwrap();
+    assert_eq!(
+        src_collide.get_trust_anchors().unwrap().len(),
+        1,
+        "the TaInfo buffer should have parsed into a trust anchor"
+    );
+    {
+        let mut pe = PkiEnvironment::new();
+        pe.add_trust_anchor_source(Box::new(src_root.clone()));
+        pe.add_trust_anchor_source(Box::new(src_collide.clone()));
+        assert!(
+            pe.get_trust_anchor_by_hex_skid(&root_skid_hex).is_err(),
+            "an ambiguous SKID must not resolve to a trust anchor"
+        );
+        assert!(
+            pe.is_trust_anchor(&root_ta).is_err(),
+            "a cert bearing the ambiguous SKID must not be accepted as a trust anchor"
+        );
+    }
+
+    // Same key reused under the same SKID is a benign duplicate, not a collision -> still resolves.
+    let mut src_dup = TaSource::new();
+    src_dup.push(CertFile {
+        filename: "dup".to_string(),
+        bytes: make_tainfo(root.tbs_certificate().subject_public_key_info().clone()),
+    });
+    src_dup.initialize().unwrap();
+    {
+        let mut pe = PkiEnvironment::new();
+        pe.add_trust_anchor_source(Box::new(src_root.clone()));
+        pe.add_trust_anchor_source(Box::new(src_dup.clone()));
+        assert!(
+            pe.get_trust_anchor_by_hex_skid(&root_skid_hex).is_ok(),
+            "a same-key duplicate SKID is benign and must still resolve"
+        );
+    }
+
+    log::set_max_level(prev_log_level);
+}


### PR DESCRIPTION
- Modify PkiEnvironment to detect when one or more stores provide TAs for a given SKID but with different public keys. When SKIDs collide and keys are different, all are dropped. When SKIDs collide and keys are the same, the first store to respond "wins".
- The collision set is recomputed when the source set changes (add/clear); a source that mutates its own membership must be removed and re-added for the collision set to be re-calculated.