### PR TITLE
Support name+SPKI trust anchors in revocation checking and bump a few dependencies

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -561,7 +561,7 @@ dependencies = [
  "ed25519-dalek",
  "flagset",
  "fn-dsa-vrfy",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hex-literal",
  "log",
  "ml-dsa",
@@ -8092,9 +8092,9 @@ dependencies = [
 
 [[package]]
 name = "zip"
-version = "7.2.0"
+version = "8.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c42e33efc22a0650c311c2ef19115ce232583abbe80850bc8b66509ebef02de0"
+checksum = "2d04a6b5381502aa6087c94c669499eb1602eb9c5e8198e534de571f7154809b"
 dependencies = [
  "crc32fast",
  "flate2",

--- a/certval/Cargo.toml
+++ b/certval/Cargo.toml
@@ -53,7 +53,7 @@ ciborium = {version = "0.2.2", default-features = false }
 cidr = { version = "0.3.2", default-features = false }
 log = {version = "0.4.33", default-features = false}
 reqwest = { version = "0.13.4", features = ["blocking"], optional = true}
-getrandom = { version = "0.3", optional = true}
+getrandom = { version = "0.4", optional = true}
 serde_json = {version = "1.0.150", optional = true, default-features = false, features = ["alloc"] }
 walkdir = { version = "2.5.0", optional = true}
 

--- a/certval/src/revocation.rs
+++ b/certval/src/revocation.rs
@@ -62,6 +62,7 @@
 //! - [`PS_OCSP_AIA_NONCE_SETTING`](../validator/path_settings/static.PS_OCSP_AIA_NONCE_SETTING.html)
 //!
 pub mod check_revocation;
+pub mod subject_name_and_key;
 
 #[cfg(feature = "revocation")]
 pub mod crl;
@@ -69,6 +70,7 @@ pub mod crl;
 pub mod ocsp_client;
 
 pub use crate::check_revocation::*;
+pub use crate::revocation::subject_name_and_key::*;
 
 #[cfg(feature = "revocation")]
 pub use crate::crl::*;

--- a/certval/src/revocation/check_revocation.rs
+++ b/certval/src/revocation/check_revocation.rs
@@ -17,13 +17,13 @@ extern crate alloc;
 
 use alloc::vec;
 use const_oid::db::rfc6960::ID_PKIX_OCSP_NOCHECK;
-use log::{error, info};
+use log::info;
 
 use crate::name_to_string;
+use crate::revocation::subject_name_and_key::SubjectNameAndKey;
 use crate::{
-    get_certificate_from_trust_anchor, CertificationPath, CertificationPathResults,
-    CertificationPathSettings, Error, ExtensionProcessing, PDVExtension, PathValidationStatus::*,
-    PkiEnvironment, Result,
+    CertificationPath, CertificationPathResults, CertificationPathSettings, Error,
+    ExtensionProcessing, PDVExtension, PathValidationStatus::*, PkiEnvironment, Result,
 };
 
 #[cfg(feature = "revocation")]
@@ -85,14 +85,6 @@ pub async fn check_revocation(
 
     cpr.prepare_revocation_results(v.len())?;
 
-    let mut issuer_cert =
-        if let Some(cert) = get_certificate_from_trust_anchor(&cp.trust_anchor.decoded_ta) {
-            cert.clone()
-        } else {
-            error!("Failed to retrieve certificate from trust anchor object");
-            return Err(Error::Unrecognized);
-        };
-
     let max_index = v.len() - 1;
 
     let toi = cps.get_time_of_interest();
@@ -101,6 +93,15 @@ pub async fn check_revocation(
     let mut statuses = vec![];
     for (pos, ca_cert_ref) in v.iter().enumerate() {
         let cur_cert = ca_cert_ref;
+        // The issuer of the current certificate is the trust anchor (for the first certificate) or
+        // the preceding certificate in the path. A trust anchor expressed as a name plus public key
+        // has no wrapped certificate, so use the SubjectNameAndKey abstraction rather than requiring a
+        // CertificateInner (which previously made revocation hard-fail on such anchors).
+        let issuer: &dyn SubjectNameAndKey = if pos == 0 {
+            &cp.trust_anchor.decoded_ta
+        } else {
+            v[pos - 1].as_ref()
+        };
         let cur_cert_subject = name_to_string(ca_cert_ref.as_ref().tbs_certificate().subject());
         let revoked_error = if pos == max_index {
             CertificateRevokedEndEntity
@@ -131,7 +132,7 @@ pub async fn check_revocation(
                     cps,
                     cpr,
                     enc_ocsp_resp,
-                    &issuer_cert,
+                    issuer,
                     pos,
                     "stapled",
                     cur_cert,
@@ -152,7 +153,7 @@ pub async fn check_revocation(
                     }
                 }
             } else if let Some(crl) = &cp.crls[pos] {
-                match process_crl(pe, cps, cpr, cur_cert, &issuer_cert, pos, crl, None) {
+                match process_crl(pe, cps, cpr, cur_cert, issuer, pos, crl, None) {
                     Ok(_ok) => {
                         info!("Determined revocation status (valid) using stapled CRL for certificate issued to {cur_cert_subject}");
                         cpr.add_crl(crl, pos);
@@ -176,16 +177,7 @@ pub async fn check_revocation(
         if cur_status == RevocationStatusNotDetermined && check_crls {
             if let Ok(crls) = pe.get_crls(cur_cert) {
                 for crl in crls {
-                    match process_crl(
-                        pe,
-                        cps,
-                        cpr,
-                        cur_cert,
-                        &issuer_cert,
-                        pos,
-                        crl.as_slice(),
-                        None,
-                    ) {
+                    match process_crl(pe, cps, cpr, cur_cert, issuer, pos, crl.as_slice(), None) {
                         Ok(_ok) => {
                             cpr.add_crl(crl.as_slice(), pos);
                             info!("Determined revocation status (valid) using cached CRL for certificate issued to {cur_cert_subject}");
@@ -211,7 +203,7 @@ pub async fn check_revocation(
         #[cfg(feature = "remote")]
         if cur_status == RevocationStatusNotDetermined && check_ocsp_from_aia {
             // check_revocation_ocsp emits log message that includes which AIA was used to determine status
-            cur_status = check_revocation_ocsp(pe, cps, cpr, cur_cert, &issuer_cert, pos).await;
+            cur_status = check_revocation_ocsp(pe, cps, cpr, cur_cert, issuer, pos).await;
             if CertificateRevoked == cur_status {
                 cpr.set_validation_status(revoked_error);
                 cpr.set_failure_index(pos as u32 + 1);
@@ -221,8 +213,7 @@ pub async fn check_revocation(
 
         #[cfg(feature = "remote")]
         if cur_status == RevocationStatusNotDetermined && check_crldp_http {
-            cur_status =
-                check_revocation_crl_remote(pe, cps, cpr, cur_cert, &issuer_cert, pos).await;
+            cur_status = check_revocation_crl_remote(pe, cps, cpr, cur_cert, issuer, pos).await;
             if CertificateRevoked == cur_status {
                 cpr.set_validation_status(revoked_error);
                 cpr.set_failure_index(pos as u32 + 1);
@@ -235,7 +226,6 @@ pub async fn check_revocation(
         }
 
         statuses.push(cur_status);
-        issuer_cert = cur_cert.as_ref().clone();
     }
 
     if statuses.contains(&RevocationStatusNotDetermined) {
@@ -294,14 +284,6 @@ pub fn check_revocation(
 
     cpr.prepare_revocation_results(v.len())?;
 
-    let mut issuer_cert =
-        if let Some(cert) = get_certificate_from_trust_anchor(&cp.trust_anchor.decoded_ta) {
-            cert.clone()
-        } else {
-            error!("Failed to retrieve certificate from trust anchor object",);
-            return Err(Error::Unrecognized);
-        };
-
     let max_index = v.len() - 1;
 
     let toi = cps.get_time_of_interest();
@@ -310,6 +292,15 @@ pub fn check_revocation(
     let mut statuses = vec![];
     for (pos, ca_cert_ref) in v.iter().enumerate() {
         let cur_cert = ca_cert_ref;
+        // The issuer of the current certificate is the trust anchor (for the first certificate) or
+        // the preceding certificate in the path. A trust anchor expressed as a name plus public key
+        // has no wrapped certificate, so use the SubjectNameAndKey abstraction rather than requiring a
+        // CertificateInner (which previously made revocation hard-fail on such anchors).
+        let issuer: &dyn SubjectNameAndKey = if pos == 0 {
+            &cp.trust_anchor.decoded_ta
+        } else {
+            v[pos - 1].as_ref()
+        };
         let cur_cert_subject = name_to_string(&ca_cert_ref.as_ref().tbs_certificate().subject());
         let revoked_error = if pos == max_index {
             CertificateRevokedEndEntity
@@ -341,7 +332,7 @@ pub fn check_revocation(
                     cps,
                     cpr,
                     enc_ocsp_resp,
-                    &issuer_cert,
+                    issuer,
                     pos,
                     "stapled",
                     cur_cert,
@@ -363,7 +354,7 @@ pub fn check_revocation(
                     }
                 }
             } else if let Some(crl) = &cp.crls[pos] {
-                match process_crl(pe, cps, cpr, cur_cert, &issuer_cert, pos, crl, None) {
+                match process_crl(pe, cps, cpr, cur_cert, issuer, pos, crl, None) {
                     Ok(_ok) => {
                         info!("Determined revocation status (valid) using stapled CRL for certificate issued to {}", cur_cert_subject);
                         cpr.add_crl(crl, pos);
@@ -387,16 +378,7 @@ pub fn check_revocation(
         if cur_status == RevocationStatusNotDetermined && check_crls {
             if let Ok(crls) = pe.get_crls(cur_cert) {
                 for crl in crls {
-                    match process_crl(
-                        pe,
-                        cps,
-                        cpr,
-                        cur_cert,
-                        &issuer_cert,
-                        pos,
-                        crl.as_slice(),
-                        None,
-                    ) {
+                    match process_crl(pe, cps, cpr, cur_cert, issuer, pos, crl.as_slice(), None) {
                         Ok(_ok) => {
                             cpr.add_crl(crl.as_slice(), pos);
                             info!("Determined revocation status (valid) using cached CRL for certificate issued to {}", cur_cert_subject);
@@ -425,7 +407,6 @@ pub fn check_revocation(
         }
 
         statuses.push(cur_status);
-        issuer_cert = cur_cert.as_ref().clone();
     }
 
     if statuses.contains(&RevocationStatusNotDetermined) {

--- a/certval/src/revocation/crl.rs
+++ b/certval/src/revocation/crl.rs
@@ -3,7 +3,6 @@
 
 extern crate alloc;
 use alloc::{
-    format,
     string::{String, ToString},
     vec::Vec,
 };
@@ -15,7 +14,7 @@ use const_oid::db::rfc5912::{
     ID_CE_AUTHORITY_KEY_IDENTIFIER, ID_CE_BASIC_CONSTRAINTS, ID_CE_CERTIFICATE_ISSUER,
     ID_CE_CRL_DISTRIBUTION_POINTS, ID_CE_CRL_NUMBER, ID_CE_CRL_REASONS, ID_CE_DELTA_CRL_INDICATOR,
     ID_CE_FRESHEST_CRL, ID_CE_HOLD_INSTRUCTION_CODE, ID_CE_INVALIDITY_DATE,
-    ID_CE_ISSUING_DISTRIBUTION_POINT, ID_CE_KEY_USAGE,
+    ID_CE_ISSUING_DISTRIBUTION_POINT,
 };
 use der::{Decode, DerOrd, Encode};
 use x509_cert::ext::pkix::crl::dp::ReasonFlags;
@@ -25,21 +24,22 @@ use x509_cert::ext::pkix::{
     KeyUsages,
 };
 use x509_cert::ext::pkix::{
-    AuthorityKeyIdentifier, CrlDistributionPoints, IssuingDistributionPoint, KeyUsage,
+    AuthorityKeyIdentifier, CrlDistributionPoints, IssuingDistributionPoint,
 };
 use x509_cert::name::Name;
 use x509_cert::{
-    certificate::{CertificateInner, Raw},
+    certificate::Raw,
     crl::{CertificateList, RevokedCert},
     ext::Extensions,
 };
 
 use crate::crl::CrlReasons::AllReasons;
+use crate::revocation::subject_name_and_key::SubjectNameAndKey;
 use crate::Error::CrlIncompatible;
 use crate::{
-    compare_names, log_error_for_subject, name_to_string, CertificationPathResults,
-    CertificationPathSettings, DeferDecodeSigned, Error, ExtensionProcessing, PDVCertificate,
-    PDVExtension, PathValidationStatus, PkiEnvironment, Result, TimeOfInterest,
+    compare_names, name_to_string, CertificationPathResults, CertificationPathSettings,
+    DeferDecodeSigned, Error, ExtensionProcessing, PDVCertificate, PDVExtension,
+    PathValidationStatus, PkiEnvironment, Result, TimeOfInterest,
 };
 
 use core::time::Duration;
@@ -873,7 +873,7 @@ fn validate_crl_authority(target_cert: &PDVCertificate, crl_info: &CrlInfo) -> R
 fn verify_crl(
     pe: &PkiEnvironment,
     crl_buf: &[u8],
-    issuer_cert: &CertificateInner<Raw>,
+    issuer: &dyn SubjectNameAndKey,
     cpr: &mut CertificationPathResults,
 ) -> Result<()> {
     let Ok(defer_crl) = DeferDecodeSigned::from_der(crl_buf) else {
@@ -885,13 +885,14 @@ fn verify_crl(
         &defer_crl.tbs_field,
         defer_crl.signature.raw_bytes(),
         &defer_crl.signature_algorithm,
-        issuer_cert.tbs_certificate().subject_public_key_info(),
+        issuer.spki(),
     );
     if let Err(e) = r {
-        log_error_for_subject(
-            issuer_cert,
-            format!("CRL signature verification error: {e:?}").as_str(),
-        );
+        let subject = issuer
+            .subject_name()
+            .map(name_to_string)
+            .unwrap_or_default();
+        error!("CRL signature verification error for issuer {subject}: {e:?}");
         cpr.set_validation_status(PathValidationStatus::SignatureVerificationFailure);
         return Err(Error::PathValidation(
             PathValidationStatus::SignatureVerificationFailure,
@@ -985,31 +986,32 @@ pub(crate) fn check_crl_validity(
     Ok(())
 }
 
-fn check_crl_sign(cert: &CertificateInner<Raw>) -> Result<()> {
-    if let Some(exts) = &cert.tbs_certificate().extensions() {
-        for ext in exts.as_slice() {
-            if ext.extn_id == ID_CE_KEY_USAGE {
-                if let Ok(ku) = KeyUsage::from_der(ext.extn_value.as_bytes()) {
-                    // RFC 5280 6.3.3(f): if a key usage extension is present, the cRLSign bit must
-                    // be set for the certificate to be a valid CRL issuer.
-                    if !ku.0.contains(KeyUsages::CRLSign) {
-                        error!("crlSign is not set in key usage extension");
-                        return Err(Error::PathValidation(PathValidationStatus::InvalidKeyUsage));
-                    } else {
-                        return Ok(());
-                    }
-                } else {
-                    error!("key usage extension could not be parsed");
-                    return Err(Error::PathValidation(PathValidationStatus::InvalidKeyUsage));
-                }
+fn check_crl_sign(issuer: &dyn SubjectNameAndKey) -> Result<()> {
+    match issuer.key_usage() {
+        Some(ku) => {
+            // RFC 5280 6.3.3(f): if a key usage extension is present, the cRLSign bit must be set
+            // for the issuer to be a valid CRL issuer.
+            if ku.0.contains(KeyUsages::CRLSign) {
+                Ok(())
+            } else {
+                error!("crlSign is not set in key usage extension");
+                Err(Error::PathValidation(PathValidationStatus::InvalidKeyUsage))
+            }
+        }
+        None => {
+            // A trust anchor is implicitly trusted to issue CRLs even without a key usage extension
+            // (a name+SPKI anchor carries none). For an ordinary certificate, RFC 5280 6.3.3(f)
+            // gates the cRLSign check on the key usage extension being present, but we reject an
+            // absent one as a deliberate fail-closed choice: a modern CRL issuer always asserts
+            // cRLSign.
+            if issuer.is_implicitly_trusted() {
+                Ok(())
+            } else {
+                error!("key usage extension is missing");
+                Err(Error::PathValidation(PathValidationStatus::InvalidKeyUsage))
             }
         }
     }
-    // RFC 5280 6.3.3(f) gates the cRLSign check on the key usage extension being present, so a CRL
-    // issuer lacking one is not a conformance failure; rejecting it is a deliberate fail-closed
-    // choice, since a modern CRL issuer always carries key usage asserting cRLSign.
-    error!("key usage extension is missing");
-    Err(Error::PathValidation(PathValidationStatus::InvalidKeyUsage))
 }
 
 /// process_crl takes a CRL that is processed relative to a given target certificate and issuer
@@ -1020,14 +1022,14 @@ pub(crate) fn process_crl(
     cps: &CertificationPathSettings,
     cpr: &mut CertificationPathResults,
     target_cert: &PDVCertificate,
-    issuer_cert: &CertificateInner<Raw>,
+    issuer: &dyn SubjectNameAndKey,
     result_index: usize,
     crl_buf: &[u8],
     uri: Option<&str>,
 ) -> Result<()> {
     // Verify then parse and classify the CRL
-    verify_crl(pe, crl_buf, issuer_cert, cpr)?;
-    check_crl_sign(issuer_cert)?;
+    verify_crl(pe, crl_buf, issuer, cpr)?;
+    check_crl_sign(issuer)?;
 
     let crl = match CertificateList::<Raw>::from_der(crl_buf) {
         Ok(crl) => crl,
@@ -1199,7 +1201,7 @@ pub(crate) async fn check_revocation_crl_remote(
     cps: &CertificationPathSettings,
     cpr: &mut CertificationPathResults,
     target_cert: &PDVCertificate,
-    issuer_cert: &CertificateInner<Raw>,
+    issuer: &dyn SubjectNameAndKey,
     pos: usize,
 ) -> PathValidationStatus {
     let mut target_status = PathValidationStatus::RevocationStatusNotDetermined;
@@ -1226,7 +1228,7 @@ pub(crate) async fn check_revocation_crl_remote(
                 cps,
                 cpr,
                 target_cert,
-                issuer_cert,
+                issuer,
                 pos,
                 &crl,
                 Some(crl_dp.as_str()),

--- a/certval/src/revocation/ocsp_client.rs
+++ b/certval/src/revocation/ocsp_client.rs
@@ -14,6 +14,7 @@ use log::{error, warn};
 #[cfg(feature = "remote")]
 use log::{debug, info};
 
+use crate::revocation::subject_name_and_key::SubjectNameAndKey;
 use crate::{
     crl::process_crl, util::pdv_utilities::compare_names, valid_at_time, CertificationPathResults,
     CertificationPathSettings, DeferDecodeSigned, Error, OcspNonceSetting, PDVCertificate,
@@ -64,18 +65,12 @@ use x509_cert::ext::Extension;
 #[cfg(feature = "remote")]
 use x509_ocsp::ext::Nonce;
 
-fn get_key_hash(cert: &CertificateInner<Raw>) -> Result<Vec<u8>> {
-    Ok(Sha1::digest(
-        cert.tbs_certificate()
-            .subject_public_key_info()
-            .subject_public_key
-            .raw_bytes(),
-    )
-    .to_vec())
+fn get_key_hash(issuer: &dyn SubjectNameAndKey) -> Result<Vec<u8>> {
+    Ok(Sha1::digest(issuer.spki().subject_public_key.raw_bytes()).to_vec())
 }
 
-fn get_subject_name_hash(cert: &CertificateInner<Raw>) -> Result<Vec<u8>> {
-    let enc_subject = match cert.tbs_certificate().subject().to_der() {
+fn get_subject_name_hash(issuer: &dyn SubjectNameAndKey) -> Result<Vec<u8>> {
+    let enc_subject = match issuer.subject_name()?.to_der() {
         Ok(enc_spki) => enc_spki,
         Err(e) => return Err(Error::Asn1Error(e)),
     };
@@ -407,7 +402,7 @@ fn has_ocsp_signing_eku(exts: &Option<&Extensions>) -> bool {
 
 fn verify_response_signature(
     pe: &PkiEnvironment,
-    signers_cert: &CertificateInner<Raw>,
+    signer: &dyn SubjectNameAndKey,
     enc_ocsp_resp: &[u8],
     bor: &BasicOcspResponse,
 ) -> Result<()> {
@@ -427,7 +422,7 @@ fn verify_response_signature(
         &ddbor.tbs_response_data,
         signature,
         &bor.signature_algorithm,
-        signers_cert.tbs_certificate().subject_public_key_info(),
+        signer.spki(),
     )
 }
 
@@ -449,7 +444,7 @@ pub async fn send_ocsp_request(
     cps: &CertificationPathSettings,
     uri_to_check: &str,
     target_cert: &PDVCertificate,
-    issuers_cert: &CertificateInner<Raw>,
+    issuer: &dyn SubjectNameAndKey,
     cpr: &mut CertificationPathResults,
     result_index: usize,
 ) -> Result<()> {
@@ -467,8 +462,8 @@ pub async fn send_ocsp_request(
     };
 
     // Prepare info for request
-    let key_hash = get_key_hash(issuers_cert)?;
-    let name_hash = get_subject_name_hash(issuers_cert)?;
+    let key_hash = get_key_hash(issuer)?;
+    let name_hash = get_subject_name_hash(issuer)?;
 
     let enc_ocsp_req = prepare_ocsp_request(
         target_cert.as_ref(),
@@ -491,7 +486,7 @@ pub async fn send_ocsp_request(
         cps,
         cpr,
         &enc_ocsp_resp,
-        issuers_cert,
+        issuer,
         result_index,
         uri_to_check,
         target_cert,
@@ -532,13 +527,13 @@ pub fn process_ocsp_response(
     cps: &CertificationPathSettings,
     cpr: &mut CertificationPathResults,
     enc_ocsp_resp: &[u8],
-    issuers_cert: &CertificateInner<Raw>,
+    issuer: &dyn SubjectNameAndKey,
     result_index: usize,
     uri_to_check: &str,
     target_cert: &PDVCertificate,
 ) -> Result<()> {
-    let key_hash = get_key_hash(issuers_cert)?;
-    let name_hash = get_subject_name_hash(issuers_cert)?;
+    let key_hash = get_key_hash(issuer)?;
+    let name_hash = get_subject_name_hash(issuer)?;
     // A stapled/externally-supplied response was not solicited by this library, so no nonce was
     // sent and none is enforced.
     process_ocsp_response_internal(
@@ -546,7 +541,7 @@ pub fn process_ocsp_response(
         cps,
         cpr,
         enc_ocsp_resp,
-        issuers_cert,
+        issuer,
         result_index,
         uri_to_check,
         target_cert,
@@ -563,7 +558,7 @@ fn process_ocsp_response_internal(
     cps: &CertificationPathSettings,
     cpr: &mut CertificationPathResults,
     enc_ocsp_resp: &[u8],
-    issuers_cert: &CertificateInner<Raw>,
+    issuer: &dyn SubjectNameAndKey,
     result_index: usize,
     uri_to_check: &str,
     target_cert: &PDVCertificate,
@@ -572,6 +567,9 @@ fn process_ocsp_response_internal(
     expected_nonce: Option<&[u8]>,
     nonce_setting: OcspNonceSetting,
 ) -> Result<()> {
+    // The issuer's subject name, used to match delegated responder certificates below. Resolved once
+    // (a trust anchor lookup can fail); a failure here means we cannot identify the issuer at all.
+    let issuer_subject = issuer.subject_name()?;
     let or = match OcspResponse::from_der(enc_ocsp_resp) {
         Ok(or) => or,
         Err(e) => {
@@ -663,10 +661,7 @@ fn process_ocsp_response_internal(
             // A delegated responder is issued by the same CA as the target, so its issuer must match
             // that CA's subject. This is a necessary condition for the signature verification below,
             // so a name mismatch lets us skip that verification entirely.
-            if !compare_names(
-                cert.tbs_certificate().issuer(),
-                issuers_cert.tbs_certificate().subject(),
-            ) {
+            if !compare_names(cert.tbs_certificate().issuer(), issuer_subject) {
                 continue;
             }
 
@@ -699,7 +694,7 @@ fn process_ocsp_response_internal(
                     &defer_cert.tbs_field,
                     defer_cert.signature.raw_bytes(),
                     &defer_cert.signature_algorithm,
-                    issuers_cert.tbs_certificate().subject_public_key_info(),
+                    issuer.spki(),
                 )
                 .is_err()
             {
@@ -728,7 +723,7 @@ fn process_ocsp_response_internal(
                                 cps,
                                 cpr,
                                 &responder,
-                                issuers_cert,
+                                issuer,
                                 result_index,
                                 crl.as_slice(),
                                 None,
@@ -760,14 +755,14 @@ fn process_ocsp_response_internal(
         // is not a delegated responder (it does not assert the id-kp-OCSPSigning EKU), so if none of
         // the echoed certificates authorized the response, fall back to the issuing CA's own key.
         if !sigverified
-            && verify_response_signature(pe, issuers_cert, rb.response.as_bytes(), &bor).is_ok()
+            && verify_response_signature(pe, issuer, rb.response.as_bytes(), &bor).is_ok()
         {
             authorized_responder = true;
             sigverified = true;
         }
     } else {
         // try the issuer's cert
-        let r = verify_response_signature(pe, issuers_cert, rb.response.as_bytes(), &bor);
+        let r = verify_response_signature(pe, issuer, rb.response.as_bytes(), &bor);
         if r.is_err() {
             error!("OCSPResponse from {uri_to_check} featured no candidate certificate but response signature verification failed using issuing CA certificate");
             cpr.add_failed_ocsp_response(enc_ocsp_resp.to_vec(), result_index);
@@ -892,7 +887,7 @@ pub(crate) async fn check_revocation_ocsp(
     cps: &CertificationPathSettings,
     cpr: &mut CertificationPathResults,
     target_cert: &PDVCertificate,
-    issuer_cert: &CertificateInner<Raw>,
+    issuer: &dyn SubjectNameAndKey,
     pos: usize,
 ) -> PathValidationStatus {
     let mut target_status = PathValidationStatus::RevocationStatusNotDetermined;
@@ -904,8 +899,7 @@ pub(crate) async fn check_revocation_ocsp(
         );
     } else {
         for aia in ocsp_aias {
-            match send_ocsp_request(pe, cps, aia.as_str(), target_cert, issuer_cert, cpr, pos).await
-            {
+            match send_ocsp_request(pe, cps, aia.as_str(), target_cert, issuer, cpr, pos).await {
                 Ok(_r) => target_status = PathValidationStatus::Valid,
                 Err(e) => {
                     if let Error::PathValidation(pvs) = e {

--- a/certval/src/revocation/subject_name_and_key.rs
+++ b/certval/src/revocation/subject_name_and_key.rs
@@ -1,0 +1,93 @@
+//! The [`SubjectNameAndKey`] trait exposes the subject identity — a name and public key, plus the
+//! key usage and trust status needed alongside them — of either a full certificate or a trust anchor.
+//! Revocation checking is its first consumer: it lets a trust anchor expressed as a name plus public
+//! key (e.g. a webpki root that carries no wrapped certificate) act as a CRL/OCSP issuer alongside a
+//! full certificate.
+//!
+//! Before this abstraction, revocation checking demanded a `CertificateInner` for the issuer and
+//! obtained it via `get_certificate_from_trust_anchor`, which returns `None` for a name+SPKI trust
+//! anchor — so revocation hard-failed with `Error::Unrecognized` on such anchors. Implementing the
+//! trait for both `CertificateInner<Raw>` and `TrustAnchorChoice<Raw>` lets the same code path accept
+//! either.
+
+use const_oid::db::rfc5912::ID_CE_KEY_USAGE;
+use der::Decode;
+use spki::SubjectPublicKeyInfoOwned;
+use x509_cert::{
+    anchor::TrustAnchorChoice,
+    certificate::{CertificateInner, Raw},
+    ext::pkix::KeyUsage,
+    name::Name,
+};
+
+use crate::source::ta_source::{
+    get_certificate_from_trust_anchor, get_subject_public_key_info_from_trust_anchor,
+};
+use crate::validator::pdv_trust_anchor::get_trust_anchor_name;
+use crate::Result;
+
+/// A subject identity — name and public key — with the key usage and trust status that accompany it.
+/// Implemented for both a full certificate and a [`TrustAnchorChoice`], so a name+SPKI trust anchor
+/// can stand in wherever a certificate's identity is expected (e.g. as a CRL/OCSP issuer).
+///
+/// `Send + Sync` are required so that `&dyn SubjectNameAndKey` can be held across await points in the
+/// async revocation path and keep those futures `Send` (both implementors are plain DER data).
+pub trait SubjectNameAndKey: Send + Sync {
+    /// Subject public key info; used to verify CRL and OCSP signatures.
+    fn spki(&self) -> &SubjectPublicKeyInfoOwned;
+
+    /// Subject name; used to build OCSP `CertID`s and to match delegated responders.
+    fn subject_name(&self) -> Result<&Name>;
+
+    /// The key usage extension, if the subject carries one. `None` covers both a genuinely absent
+    /// extension and one that fails to parse.
+    fn key_usage(&self) -> Option<KeyUsage>;
+
+    /// True for a trust anchor. A trust anchor is implicitly trusted to issue CRLs even without a
+    /// key usage extension asserting `cRLSign`, whereas an ordinary certificate lacking one is
+    /// rejected (RFC 5280 6.3.3(f), fail-closed).
+    fn is_implicitly_trusted(&self) -> bool;
+}
+
+/// Extracts the key usage extension from a certificate, if present and parseable.
+fn key_usage_from_cert(cert: &CertificateInner<Raw>) -> Option<KeyUsage> {
+    let exts = cert.tbs_certificate().extensions()?;
+    for ext in exts.as_slice() {
+        if ext.extn_id == ID_CE_KEY_USAGE {
+            return KeyUsage::from_der(ext.extn_value.as_bytes()).ok();
+        }
+    }
+    None
+}
+
+impl SubjectNameAndKey for CertificateInner<Raw> {
+    fn spki(&self) -> &SubjectPublicKeyInfoOwned {
+        self.tbs_certificate().subject_public_key_info()
+    }
+    fn subject_name(&self) -> Result<&Name> {
+        Ok(self.tbs_certificate().subject())
+    }
+    fn key_usage(&self) -> Option<KeyUsage> {
+        key_usage_from_cert(self)
+    }
+    fn is_implicitly_trusted(&self) -> bool {
+        false
+    }
+}
+
+impl SubjectNameAndKey for TrustAnchorChoice<Raw> {
+    fn spki(&self) -> &SubjectPublicKeyInfoOwned {
+        get_subject_public_key_info_from_trust_anchor(self)
+    }
+    fn subject_name(&self) -> Result<&Name> {
+        get_trust_anchor_name(self)
+    }
+    fn key_usage(&self) -> Option<KeyUsage> {
+        // A trust anchor with a wrapped certificate can still assert key usage; a bare name+SPKI
+        // TaInfo has none, which is fine because it is implicitly trusted.
+        get_certificate_from_trust_anchor(self).and_then(key_usage_from_cert)
+    }
+    fn is_implicitly_trusted(&self) -> bool {
+        true
+    }
+}

--- a/certval/tests/revocation.rs
+++ b/certval/tests/revocation.rs
@@ -741,3 +741,76 @@ async fn live_ocsp_nonce_disa() {
         "live DoD OCSP with SendNonceRequireMatch should succeed (nonce echoed), got {r:?}"
     );
 }
+
+// A trust anchor expressed as a name plus public key with no wrapped certificate (as webpki roots
+// are) can serve as the CRL issuer during revocation checking. Before the SubjectNameAndKey trait,
+// revocation hard-failed on such an anchor: get_certificate_from_trust_anchor returned None, so
+// check_revocation returned Error::Unrecognized before checking anything. This mirrors
+// stapled_crl_async but strips the trust anchor to name+SPKI form (same name and key).
+#[cfg(all(feature = "revocation", feature = "rsa"))]
+#[tokio::test]
+async fn stapled_crl_name_and_spki_trust_anchor() {
+    use certval::environment::pki_environment::PkiEnvironment;
+    use certval::path_settings::*;
+    use certval::*;
+    use der::asn1::OctetString;
+    use der::Decode;
+    use x509_cert::anchor::{CertPathControls, TrustAnchorChoice, TrustAnchorInfo};
+    use x509_cert::certificate::{Certificate, Raw};
+
+    let der_encoded_ta = include_bytes!("examples/harvard.edu/0-ta.der");
+    let der_encoded_ca = include_bytes!("examples/harvard.edu/1.der");
+    let der_encoded_ca_crl = include_bytes!("examples/harvard.edu/1-crl.crl");
+    let der_encoded_ee = include_bytes!("examples/harvard.edu/2-target.der");
+    let der_encoded_ee_crl = include_bytes!("examples/harvard.edu/2-crl.crl");
+
+    // Build a name+SPKI trust anchor from the real root: same name and public key, but no wrapped
+    // certificate (cert_path.certificate = None), i.e. the shape a webpki root has.
+    let root = Certificate::from_der(der_encoded_ta.as_slice()).unwrap();
+    let cp: CertPathControls<Raw> = CertPathControls {
+        ta_name: root.tbs_certificate().subject().clone(),
+        certificate: None,
+        policy_set: None,
+        policy_flags: None,
+        name_constr: None,
+        path_len_constraint: None,
+    };
+    let tai: TrustAnchorInfo<Raw> = TrustAnchorInfo {
+        version: Default::default(),
+        pub_key: root.tbs_certificate().subject_public_key_info().clone(),
+        key_id: OctetString::new(vec![0u8; 20]).unwrap(),
+        ta_title: None,
+        cert_path: Some(cp),
+        extensions: None,
+        ta_title_lang_tag: None,
+    };
+    let ta = PDVTrustAnchorChoice::try_from(TrustAnchorChoice::TaInfo(tai)).unwrap();
+    // The condition that used to break revocation: this anchor has no embedded certificate.
+    assert!(get_certificate_from_trust_anchor(&ta.decoded_ta).is_none());
+
+    let mut ca = PDVCertificate::try_from(der_encoded_ca.as_slice()).unwrap();
+    ca.parse_extensions(EXTS_OF_INTEREST);
+    let mut ee = PDVCertificate::try_from(der_encoded_ee.as_slice()).unwrap();
+    ee.parse_extensions(EXTS_OF_INTEREST);
+
+    let mut pe = PkiEnvironment::new();
+    pe.populate_5280_pki_environment();
+
+    let mut cert_path = CertificationPath::new(ta, vec![ca], ee);
+    // crls[0] (CA's CRL) is signed by the root -> verified using the name+SPKI trust anchor's key.
+    cert_path.crls[0] = Some(der_encoded_ca_crl.to_vec());
+    cert_path.crls[1] = Some(der_encoded_ee_crl.to_vec());
+
+    let mut cps = CertificationPathSettings::new();
+    cps.set_check_revocation_status(true);
+    cps.set_check_ocsp_from_aia(false);
+    cps.set_require_ta_store(false);
+    cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1646567209).unwrap());
+
+    let mut cpr = CertificationPathResults::new();
+    let r = check_revocation(&pe, &cps, &mut cert_path, &mut cpr).await;
+    assert!(
+        r.is_ok(),
+        "revocation should succeed using stapled CRLs with a name+SPKI trust anchor as CRL issuer, got {r:?}"
+    );
+}

--- a/pittv3-wasm/Cargo.toml
+++ b/pittv3-wasm/Cargo.toml
@@ -31,7 +31,7 @@ pem-rfc7468 = { version = "1.0.0", features = ["alloc"] }
 serde = { version = "1.0.228", default-features = false, features = ["derive", "alloc"] }
 serde_json = { version = "1.0.150", default-features = false, features = ["alloc"] }
 web-time = "1.1.0"
-zip = { version = "7.2.0", default-features = false, features = ["deflate"] }
+zip = { version = "8.6.0", default-features = false, features = ["deflate"] }
 
 # getrandom 0.4 (pulled in transitively via the RustCrypto 0.3/0.8 wave, e.g. crypto-common) has no
 # default backend on wasm32-unknown-unknown; the wasm_js feature opts into the JS (wasm-bindgen)

--- a/support/x509-limbo-tests/Cargo.lock
+++ b/support/x509-limbo-tests/Cargo.lock
@@ -141,13 +141,13 @@ dependencies = [
  "bitvec",
  "cfg-if",
  "ciborium",
- "cidr 0.3.2",
+ "cidr",
  "cms",
  "const-oid",
  "der",
  "ecdsa",
  "flagset",
- "getrandom 0.3.4",
+ "getrandom 0.4.3",
  "hex-literal",
  "log",
  "p256",
@@ -235,12 +235,6 @@ dependencies = [
  "ciborium-io",
  "half",
 ]
-
-[[package]]
-name = "cidr"
-version = "0.2.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdf600c45bd958cf2945c445264471cca8b6c8e67bc87b71affd6d7e5682621"
 
 [[package]]
 name = "cidr"
@@ -691,18 +685,6 @@ dependencies = [
 
 [[package]]
 name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "libc",
- "r-efi 5.3.0",
- "wasip2",
-]
-
-[[package]]
-name = "getrandom"
 version = "0.4.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "300e883d756b2e4ec94e02791f39b04b522276138852cfc41d9fb7e904106099"
@@ -710,7 +692,7 @@ dependencies = [
  "cfg-if",
  "js-sys",
  "libc",
- "r-efi 6.0.0",
+ "r-efi",
  "rand_core",
  "wasm-bindgen",
 ]
@@ -1419,12 +1401,6 @@ dependencies = [
 
 [[package]]
 name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "r-efi"
 version = "6.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f8dcc9c7d52a811697d2151c701e0d08956f92b0e24136cf4cf27b57a6a0d9bf"
@@ -1600,7 +1576,6 @@ version = "0.1.1"
 dependencies = [
  "certval",
  "chrono",
- "cidr 0.2.3",
  "ed25519-dalek",
  "limbo-harness-support",
  "pem",
@@ -2333,15 +2308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.4+wasi-0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b67efb37e106e55ce722a510d6b5f9c17f083e5fc79afc2badeb12cc313d9487"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.126"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2594,12 +2560,6 @@ name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "wnaf"

--- a/support/x509-limbo-tests/Cargo.toml
+++ b/support/x509-limbo-tests/Cargo.toml
@@ -13,7 +13,6 @@ serde_json = "1.0.150"
 certval = { path = "../../certval", features = ["rsa"] }
 x509-cert = { version = "0.3.0", features = ["hazmat"] }
 rayon = "1.12.0"
-cidr = "0.2.3"
 
 ed25519-dalek = { version = "3.0.0", default-features = false, features = ["fast", "zeroize", "pkcs8"] }
 


### PR DESCRIPTION
- Bump getrandom 0.3->0.4 and zip 7.2->8.6; drop unused cidr dep
- Previously, revocation checking required a CertificateInner for the issuer, obtained via get_certificate_from_trust_anchor. This returns None for a trust anchor expressed as a name plus public key, like those from the webpki crate.
- This PR adds the SubjectNameAndKey trait (spki / subject_name / key_usage / is_implicitly_trusted), with Send + Sync supertraits. A &dyn SubjectNameAndKey is used in the CRL and OCSP implementation in place of &CertificateInner. check_revocation now derives the issuer per certificate (the trust anchor for the first, the preceding cert otherwise) instead of cloning a CertificateInner. A trust anchor is implicitly trusted to sign CRLs even without a key usage extension asserting cRLSign; an ordinary certificate lacking one stays fail-closed.
- This PR contains a breaking change. The issuer parameter of the public send_ocsp_request and process_ocsp_response changes from &CertificateInner<Raw> to &dyn SubjectNameAndKey (existing callers can pass &cert as &dyn SubjectNameAndKey).
