### PR TITLE
Improve network performance for revocation and SIA/AIA

### DIFF
--- a/certval/src/builder/graph_builder.rs
+++ b/certval/src/builder/graph_builder.rs
@@ -100,6 +100,7 @@ pub async fn build_graph(pe: &PkiEnvironment, cps: &CertificationPathSettings) -
                 &mut lmm,
                 &mut blocklist,
                 toi,
+                cps.get_max_aia_fetch_bytes(),
             )
             .await;
             if let Err(e) = r {

--- a/certval/src/builder/uri_utils.rs
+++ b/certval/src/builder/uri_utils.rs
@@ -28,8 +28,75 @@ cfg_if! {
         use std::io::Write;
         use std::path::{PathBuf, Path};
         use std::str::FromStr;
+        use std::sync::OnceLock;
         use std::time::Duration;
     }
+}
+
+/// Returns a process-wide [`reqwest::Client`] shared across every artifact download (CRL, OCSP, and
+/// AIA/SIA fetches). Building a fresh client per request throws away reqwest's connection pool,
+/// forcing a new TCP+TLS handshake for every fetch on the enrollment hot path; a single pooled
+/// client amortizes connection setup across requests. The shared client carries no default timeout
+/// -- callers apply a per-request bound via [`reqwest::RequestBuilder::timeout`], since the CRL path
+/// takes a caller-supplied timeout while OCSP/AIA use a fixed one.
+///
+/// Returns `None` (logged once) if the client could not be built -- e.g. the TLS backend failed to
+/// initialize -- which callers translate into a network error.
+#[cfg(feature = "remote")]
+pub(crate) fn shared_http_client() -> Option<&'static reqwest::Client> {
+    static CLIENT: OnceLock<Option<reqwest::Client>> = OnceLock::new();
+    CLIENT
+        .get_or_init(|| match reqwest::Client::builder().build() {
+            Ok(client) => Some(client),
+            Err(e) => {
+                error!("Failed to build the shared HTTP client: {e}");
+                None
+            }
+        })
+        .as_ref()
+}
+
+/// Reads a fetched HTTP response body into memory while enforcing `max_bytes` as it streams, so a
+/// hostile or misconfigured responder cannot exhaust memory with an unbounded body. Reading the whole
+/// body up front (reqwest's `bytes()`) allocates it in full before any size or parse check runs, so
+/// the cap must be applied at ingest -- here, over the streamed chunks.
+///
+/// The `Content-Length` header is attacker-controlled and absent on chunked responses, so it serves
+/// only as a fast-fail hint (a claimed length over the cap is rejected before any body is read); the
+/// running byte count over the streamed chunks is the authoritative guard. `label` names the source
+/// in log messages. Returns [`Error::LengthError`] if the body exceeds `max_bytes` and
+/// [`Error::NetworkError`] on a transport error mid-stream.
+#[cfg(feature = "remote")]
+pub(crate) async fn read_capped_body(
+    mut response: reqwest::Response,
+    max_bytes: u64,
+    label: &str,
+) -> Result<Vec<u8>> {
+    if let Some(len) = response.content_length() {
+        if len > max_bytes {
+            debug!("{label} reported a {len}-byte body exceeding the {max_bytes}-byte cap");
+            return Err(Error::LengthError);
+        }
+    }
+
+    let mut buf: Vec<u8> = Vec::new();
+    loop {
+        match response.chunk().await {
+            Ok(Some(chunk)) => {
+                if buf.len() as u64 + chunk.len() as u64 > max_bytes {
+                    debug!("{label} streamed a body exceeding the {max_bytes}-byte cap");
+                    return Err(Error::LengthError);
+                }
+                buf.extend_from_slice(&chunk);
+            }
+            Ok(None) => break,
+            Err(e) => {
+                debug!("Failed to read body from {label} with {e}");
+                return Err(Error::NetworkError);
+            }
+        }
+    }
+    Ok(buf)
 }
 
 /// `save_certs_from_p7` takes a buffer that notionally contains a degenerate certs-only SignedData
@@ -175,16 +242,14 @@ pub async fn fetch_to_buffer(
     last_mod_map: &mut BTreeMap<String, String>,
     blocklist: &mut Vec<String>,
     time_of_interest: TimeOfInterest,
+    max_bytes: u64,
 ) -> Result<()> {
     // Downloaded artifacts are saved for future use, create a path object for that folder
     let path = Path::new(folder);
 
-    let client = match reqwest::Client::builder()
-        .timeout(Duration::from_secs(10))
-        .build()
-    {
-        Ok(client) => client,
-        Err(_e) => return Err(Error::Unrecognized),
+    let client = match shared_http_client() {
+        Some(client) => client,
+        None => return Err(Error::Unrecognized),
     };
 
     // URIs may be piled up by the caller wiht the start_index used to ignore URIs that were
@@ -206,11 +271,16 @@ pub async fn fetch_to_buffer(
         };
 
         let response = if h.is_empty() {
-            client.get(target).send().await
+            client
+                .get(target)
+                .timeout(Duration::from_secs(10))
+                .send()
+                .await
         } else {
             client
                 .get(target)
                 .header("If-Modified-Since", h)
+                .timeout(Duration::from_secs(10))
                 .send()
                 .await
         };
@@ -254,7 +324,7 @@ pub async fn fetch_to_buffer(
 
                 let fname = path.join(fname_from_response);
 
-                match &response.bytes().await {
+                match read_capped_body(response, max_bytes, target).await {
                     Ok(bytes) => {
                         debug!("Downloaded buffer {target}");
 

--- a/certval/src/revocation/crl.rs
+++ b/certval/src/revocation/crl.rs
@@ -390,7 +390,12 @@ fn get_crl_dps(target_cert: &PDVCertificate) -> Vec<&Ia5String> {
 
 /// fetch_crl takes a string that notionally contains a URI that may be used to retrieve a CRL.
 #[cfg(feature = "remote")]
-async fn fetch_crl(pe: &PkiEnvironment, uri: &str, timeout: Duration) -> Result<Vec<u8>> {
+async fn fetch_crl(
+    pe: &PkiEnvironment,
+    uri: &str,
+    timeout: Duration,
+    max_bytes: u64,
+) -> Result<Vec<u8>> {
     if !uri.starts_with("http") {
         debug!("Ignored non-HTTP URI presented for CRL retrieval",);
         return Err(Error::InvalidUriScheme);
@@ -401,10 +406,10 @@ async fn fetch_crl(pe: &PkiEnvironment, uri: &str, timeout: Duration) -> Result<
         return Err(Error::UriOnBlocklist);
     }
 
-    let client = match reqwest::Client::builder().timeout(timeout).build() {
-        Ok(c) => c,
-        Err(e) => {
-            debug!("Failed to prepare HTTP client to retrieve CRL: {e}");
+    let client = match crate::builder::uri_utils::shared_http_client() {
+        Some(c) => c,
+        None => {
+            debug!("Failed to prepare HTTP client to retrieve CRL");
             return Err(Error::ResourceUnchanged);
         }
     };
@@ -413,9 +418,14 @@ async fn fetch_crl(pe: &PkiEnvironment, uri: &str, timeout: Duration) -> Result<
     let h = pe.get_last_modified(uri);
 
     let response = if let Some(h) = h {
-        client.get(uri).header("If-Modified-Since", h).send().await
+        client
+            .get(uri)
+            .header("If-Modified-Since", h)
+            .timeout(timeout)
+            .send()
+            .await
     } else {
-        client.get(uri).send().await
+        client.get(uri).timeout(timeout).send().await
     };
     match response {
         Ok(response) => {
@@ -431,14 +441,7 @@ async fn fetch_crl(pe: &PkiEnvironment, uri: &str, timeout: Duration) -> Result<
                 }
             }
 
-            let b = response.bytes().await;
-            match &b {
-                Ok(bytes) => Ok(bytes.clone().to_vec()),
-                Err(e) => {
-                    debug!("Failed to retrieve CRL bytes from {uri} with {e}");
-                    Err(Error::NetworkError)
-                }
-            }
+            crate::builder::uri_utils::read_capped_body(response, max_bytes, uri).await
         }
         Err(e) => {
             debug!("Failed to fetch CRL from {uri}: {e:?}");
@@ -1214,10 +1217,11 @@ pub(crate) async fn check_revocation_crl_remote(
         );
     } else {
         let timeout = cps.get_crl_timeout();
+        let max_bytes = cps.get_max_crl_fetch_bytes();
         for crl_dp in crl_dps {
             debug!("Fetching CRL from {}", crl_dp.as_str());
 
-            let crl = match fetch_crl(pe, crl_dp.as_str(), timeout).await {
+            let crl = match fetch_crl(pe, crl_dp.as_str(), timeout, max_bytes).await {
                 Ok(crl) => crl,
                 Err(_e) => continue,
             };
@@ -1270,6 +1274,7 @@ mod tests {
 
         use crate::{
             crl::fetch_crl, CrlSourceFolders, RemoteStatus, RevocationCache, TimeOfInterest,
+            PS_MAX_CRL_FETCH_BYTES_DEFAULT,
         };
         use std::{path::PathBuf, time::Duration};
         let mut pe = PkiEnvironment::default();
@@ -1289,11 +1294,23 @@ mod tests {
         pe.add_revocation_cache(Box::new(RevocationCache::new()));
         pe.add_check_remote(Box::new(RemoteStatus::new(f.as_path().to_str().unwrap())));
 
-        let r = fetch_crl(&pe, "ldap://ldap.scheme/", Duration::from_secs(60)).await;
+        let r = fetch_crl(
+            &pe,
+            "ldap://ldap.scheme/",
+            Duration::from_secs(60),
+            PS_MAX_CRL_FETCH_BYTES_DEFAULT,
+        )
+        .await;
         assert!(r.is_err());
         assert_eq!(Some(Error::InvalidUriScheme), r.err());
         pe.add_to_blocklist("http://blocklist.test");
-        let r = fetch_crl(&pe, "http://blocklist.test", Duration::from_secs(60)).await;
+        let r = fetch_crl(
+            &pe,
+            "http://blocklist.test",
+            Duration::from_secs(60),
+            PS_MAX_CRL_FETCH_BYTES_DEFAULT,
+        )
+        .await;
         assert!(r.is_err());
         assert_eq!(Some(Error::UriOnBlocklist), r.err());
 
@@ -1306,6 +1323,7 @@ mod tests {
             &pe,
             "http://crl.sectigo.com/SectigoRSAOrganizationValidationSecureServerCA.crl",
             Duration::from_secs(60),
+            PS_MAX_CRL_FETCH_BYTES_DEFAULT,
         )
         .await;
         assert!(r.is_ok());
@@ -1313,12 +1331,38 @@ mod tests {
             &pe,
             "http://crl.sectigo.com/SectigoRSAOrganizationValidationSecureServerCA.crl",
             Duration::from_secs(60),
+            PS_MAX_CRL_FETCH_BYTES_DEFAULT,
         )
         .await;
         assert!(r.is_err());
         assert_eq!(Some(Error::ResourceUnchanged), r.err());
 
         let _ = tokio::fs::remove_file(f.to_str().unwrap()).await;
+    }
+
+    // The ingest cap must reject an oversized CRL body while streaming it, before the whole body is
+    // buffered. A 1-byte cap against a real (multi-KB) CRL trips the guard and yields LengthError.
+    #[cfg(feature = "remote")]
+    #[tokio::test]
+    async fn fetch_crl_respects_size_cap() {
+        use crate::util::Error;
+        use crate::PkiEnvironment;
+        use crate::{crl::fetch_crl, RemoteStatus};
+        use std::time::Duration;
+
+        let mut pe = PkiEnvironment::default();
+        pe.clear_all_callbacks();
+        pe.populate_5280_pki_environment();
+        // Point last-modified tracking at a private temp dir and clear any persisted map up front, so
+        // no cached If-Modified-Since (from a prior run) short-circuits the fetch with a 304.
+        let lmm_dir = std::env::temp_dir().join("certval_fetch_cap_test");
+        let _ = std::fs::create_dir_all(&lmm_dir);
+        let _ = std::fs::remove_file(lmm_dir.join("last_modified_map.json"));
+        pe.add_check_remote(Box::new(RemoteStatus::new(lmm_dir.to_str().unwrap_or("."))));
+
+        let uri = "http://crl.sectigo.com/SectigoRSAOrganizationValidationSecureServerCA.crl";
+        let r = fetch_crl(&pe, uri, Duration::from_secs(60), 1).await;
+        assert_eq!(Some(Error::LengthError), r.err());
     }
 
     // A CRL that omits nextUpdate has no upper time bound. check_crl_validity caps its age

--- a/certval/src/revocation/ocsp_client.rs
+++ b/certval/src/revocation/ocsp_client.rs
@@ -212,22 +212,20 @@ fn generate_nonce() -> Result<Vec<u8>> {
 }
 
 #[cfg(feature = "remote")]
-async fn post_ocsp(uri_to_check: &str, enc_ocsp_req: &[u8]) -> Result<Vec<u8>> {
-    let client = if let Ok(client) = reqwest::Client::builder()
-        .pool_max_idle_per_host(0)
-        .timeout(Duration::from_secs(10))
-        .build()
-    {
-        client
-    } else {
-        error!("Failed to prepare OCSP client: {uri_to_check}");
-        return Err(Error::NetworkError);
+async fn post_ocsp(uri_to_check: &str, enc_ocsp_req: &[u8], max_bytes: u64) -> Result<Vec<u8>> {
+    let client = match crate::builder::uri_utils::shared_http_client() {
+        Some(client) => client,
+        None => {
+            error!("Failed to prepare OCSP client: {uri_to_check}");
+            return Err(Error::NetworkError);
+        }
     };
 
     let body = match client
         .post(uri_to_check)
         .body(enc_ocsp_req.to_vec())
         .header(CONTENT_TYPE, "application/ocsp-request")
+        .timeout(Duration::from_secs(10))
         .send()
         .await
     {
@@ -238,15 +236,7 @@ async fn post_ocsp(uri_to_check: &str, enc_ocsp_req: &[u8]) -> Result<Vec<u8>> {
         }
     };
 
-    let body_bytes = match body.bytes().await {
-        Ok(bb) => bb,
-        Err(e) => {
-            error!("Failed to read OCSP response with {e}: {uri_to_check}");
-            return Err(Error::NetworkError);
-        }
-    };
-
-    Ok(body_bytes.to_vec())
+    crate::builder::uri_utils::read_capped_body(body, max_bytes, uri_to_check).await
 }
 
 #[cfg(feature = "remote")]
@@ -472,7 +462,13 @@ pub async fn send_ocsp_request(
         nonce.as_deref(),
     )?;
 
-    let enc_ocsp_resp = match post_ocsp(uri_to_check, enc_ocsp_req.as_slice()).await {
+    let enc_ocsp_resp = match post_ocsp(
+        uri_to_check,
+        enc_ocsp_req.as_slice(),
+        cps.get_max_ocsp_fetch_bytes(),
+    )
+    .await
+    {
         Ok(eor) => eor,
         Err(e) => {
             error!("Failed sending OCSP request to {uri_to_check} with {e:?}");

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -358,6 +358,40 @@ pub static PS_MAX_AIA_SIA_CERTS: &str = "psMaxAiaSiaCerts";
 /// bounding an AIA/SIA fetch loop that never converges.
 pub static PS_MAX_AIA_SIA_CERTS_DEFAULT: u64 = 2000;
 
+/// `PS_MAX_CRL_FETCH_BYTES` bounds, in bytes, the size of a CRL body accepted from a remote CRL
+/// distribution point. The fetch path enforces it while streaming the response, so a hostile or
+/// misconfigured responder cannot exhaust memory by streaming an unbounded body regardless of the
+/// (attacker-controlled) `Content-Length`. This is an OOM ceiling, not artifact-size validation:
+/// pick it comfortably above the largest legitimate CRL and far below "exhausts RAM". The default is
+/// [`PS_MAX_CRL_FETCH_BYTES_DEFAULT`].
+pub static PS_MAX_CRL_FETCH_BYTES: &str = "psMaxCrlFetchBytes";
+
+/// Default value for [`PS_MAX_CRL_FETCH_BYTES`]: 100 MiB. Enterprise CRLs are large -- the biggest
+/// current DoD CRL is ~25 MB -- so the ceiling leaves several-fold headroom for growth while still
+/// bounding an unbounded-ingest DoS.
+pub static PS_MAX_CRL_FETCH_BYTES_DEFAULT: u64 = 100 * 1024 * 1024;
+
+/// `PS_MAX_OCSP_FETCH_BYTES` bounds, in bytes, the size of an OCSP response body accepted from a
+/// remote responder, enforced while streaming the response (see [`PS_MAX_CRL_FETCH_BYTES`] for the
+/// rationale). Legitimate OCSP responses are tens of KB even with a delegated-responder certificate,
+/// so the default ceiling is generous. The default is [`PS_MAX_OCSP_FETCH_BYTES_DEFAULT`].
+pub static PS_MAX_OCSP_FETCH_BYTES: &str = "psMaxOcspFetchBytes";
+
+/// Default value for [`PS_MAX_OCSP_FETCH_BYTES`]: 1 MiB, far above any realistic OCSP response.
+pub static PS_MAX_OCSP_FETCH_BYTES_DEFAULT: u64 = 1024 * 1024;
+
+/// `PS_MAX_AIA_FETCH_BYTES` bounds, in bytes, the size of a single artifact (certificate or
+/// certs-only PKCS#7) fetched from an AIA/SIA URI, enforced while streaming the response (see
+/// [`PS_MAX_CRL_FETCH_BYTES`] for the rationale). Fetched artifacts are CA certificates (moderate
+/// signature-key certs); the default leaves headroom for a large PQC certificate (a Classic McEliece
+/// public key can approach ~1.5 MB) should one be served via caIssuers. The default is
+/// [`PS_MAX_AIA_FETCH_BYTES_DEFAULT`].
+pub static PS_MAX_AIA_FETCH_BYTES: &str = "psMaxAiaFetchBytes";
+
+/// Default value for [`PS_MAX_AIA_FETCH_BYTES`]: 4 MiB, above the largest legitimate certificate
+/// (including a Classic McEliece cert) while bounding an unbounded-ingest DoS.
+pub static PS_MAX_AIA_FETCH_BYTES_DEFAULT: u64 = 4 * 1024 * 1024;
+
 /// `PS_CERTIFICATES` is used to retrieve a set of potentially useful certificates from a [`CertificationPathSettings`]
 /// object.
 pub static PS_CERTIFICATES: &str = "psCertificates";
@@ -730,6 +764,13 @@ cps_gets_and_sets_with_default!(
     PS_REVOCATION_MAX_AGE_DEFAULT
 );
 cps_gets_and_sets_with_default!(PS_MAX_AIA_SIA_CERTS, u64, PS_MAX_AIA_SIA_CERTS_DEFAULT);
+cps_gets_and_sets_with_default!(PS_MAX_CRL_FETCH_BYTES, u64, PS_MAX_CRL_FETCH_BYTES_DEFAULT);
+cps_gets_and_sets_with_default!(
+    PS_MAX_OCSP_FETCH_BYTES,
+    u64,
+    PS_MAX_OCSP_FETCH_BYTES_DEFAULT
+);
+cps_gets_and_sets_with_default!(PS_MAX_AIA_FETCH_BYTES, u64, PS_MAX_AIA_FETCH_BYTES_DEFAULT);
 // PS_MAXIMUM_PATH_DEPTH (ditch this and use PS_INITIAL_PATH_LENGTH_CONSTRAINT)
 // PS_CERTIFICATES (will need lifetime aware macro)
 cps_gets_and_sets_with_default!(PS_REQUIRE_COUNTRY_CODE_INDICATOR, bool, false);

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -404,6 +404,7 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
                         &mut lmm,
                         &mut blocklist,
                         TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
+                        cps.get_max_aia_fetch_bytes(),
                     )
                     .await;
                     if let Err(e) = r {
@@ -841,6 +842,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
                     &mut lmm,
                     &mut blocklist,
                     TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
+                    cps.get_max_aia_fetch_bytes(),
                 )
                 .await;
 


### PR DESCRIPTION
- Reuse reqwest clients to take advantage of reqwest's connection pool support. This replaces creation of a new client per request.
- Add configurable maximum size values for remote artifacts, with generous defaults defined.