### PR TITLE
Clean up trailing references to legacy policy processing

### DIFF
--- a/certval/src/validator/path_results.rs
+++ b/certval/src/validator/path_results.rs
@@ -55,10 +55,6 @@ impl CertificationPathResults {
 /// to check for unprocessed critical extensions.
 pub static PR_PROCESSED_EXTENSIONS: &str = "cprProcessedExtensions";
 
-/// `PR_FINAL_VALID_POLICY_TREE` is used to retrieve a FinalValidPolicyTree value from a [`CertificationPathResults`]
-/// object.
-pub static PR_FINAL_VALID_POLICY_TREE: &str = "cprValidPolicyTree";
-
 /// `PR_FINAL_VALID_POLICY_GRAPH` is used to retrieve a FinalValidPolicyGraph value from a [`CertificationPathResults`]
 /// object.
 pub static PR_FINAL_VALID_POLICY_GRAPH: &str = "cprValidPolicyTree";
@@ -136,7 +132,6 @@ pub static PR_FINAL_EXCLUDED_SUBTREES: &str = "cprFinalExcludedSubtrees";
 cpr_gets_and_sets_with_default!(PR_PROCESSED_EXTENSIONS, ObjectIdentifierSet, {
     BTreeSet::new()
 });
-cpr_gets_and_sets!(PR_FINAL_VALID_POLICY_TREE, FinalValidPolicyTree);
 cpr_gets_and_sets!(PR_FINAL_VALID_POLICY_GRAPH, FinalValidPolicyTree);
 cpr_gets_and_sets!(PR_VALIDATION_STATUS, PathValidationStatus);
 cpr_gets_and_sets!(PR_FAILURE_INDEX, u32);

--- a/certval/tests/pkits.rs
+++ b/certval/tests/pkits.rs
@@ -47,6 +47,46 @@ use crate::pkits_data::*;
 mod pkits_utils;
 use crate::pkits_utils::*;
 
+/// Assert that the valid-policy graph certval recorded matches NIST PKITS §4.8. The graph leaf is the
+/// RFC 5280 §6.1.5(g) *user-constrained-policy-set* — the path's authorities-constrained-policy-set
+/// (fixed per test, taken from the PKITS document) intersected with the caller's initial-policy-set
+/// during path-processing wrap-up. No-op for cases with no encoded expected set (non-§4.8).
+fn check_policy_graph(
+    case_name: &str,
+    cps: &CertificationPathSettings,
+    cpr: &CertificationPathResults,
+) {
+    // Strip the sub-case suffix: "4.8.10.2" -> "4.8.10", "4.8.4" -> "4.8.4".
+    let test = case_name.split('.').take(3).collect::<Vec<_>>().join(".");
+    let Some(authorities) = authorities_constrained_policy_set(&test) else {
+        return;
+    };
+    let authorities: ObjectIdentifierSet = authorities.into_iter().collect();
+    let initial = cps.get_initial_policy_set_as_oid_set();
+
+    // Wrap-up intersection; anyPolicy on either side imposes no restriction from that side.
+    let expected: ObjectIdentifierSet = if initial.is_empty() || initial.contains(&ANY_POLICY_OID) {
+        authorities
+    } else if authorities.contains(&ANY_POLICY_OID) {
+        initial
+    } else {
+        authorities.intersection(&initial).copied().collect()
+    };
+
+    let actual: ObjectIdentifierSet = cpr
+        .get_final_valid_policy_graph()
+        .and_then(|g| {
+            g.last()
+                .map(|leaf| leaf.iter().map(|n| n.valid_policy).collect())
+        })
+        .unwrap_or_default();
+
+    assert_eq!(
+        actual, expected,
+        "policy-graph leaf mismatch for {case_name}: expected {expected:?}, got {actual:?}"
+    );
+}
+
 #[derive(Clone)]
 pub struct CertPool {
     pub certs: BTreeMap<String, Vec<u8>>,
@@ -769,6 +809,10 @@ pub fn pkits_guts_sync(
                     }
                 }
 
+                if r.is_ok() {
+                    check_policy_graph(&case_name, &tmp_settings, &cpr);
+                }
+
                 if !verified_ta_as_target {
                     let ta_as_cert =
                         parse_cert(&ta.encoded_ta.to_vec(), "TrustAnchorRootCertificate.crt")
@@ -1063,6 +1107,10 @@ pub async fn pkits_guts(
                     || (r.is_ok() && case.expected_error.is_some())
                 {
                     panic!("Unexpected result for {case_name}");
+                }
+
+                if r.is_ok() {
+                    check_policy_graph(&case_name, &tmp_settings, &cpr);
                 }
 
                 if !verified_ta_as_target {

--- a/certval/tests/pkits_data.rs
+++ b/certval/tests/pkits_data.rs
@@ -39,6 +39,30 @@ pub const PKITS_TEST_POLICY_5: ObjectIdentifier =
 pub const PKITS_TEST_POLICY_6: ObjectIdentifier =
     ObjectIdentifier::new_unwrap("2.16.840.1.101.3.2.1.48.6");
 
+pub const ANY_POLICY_OID: ObjectIdentifier = ObjectIdentifier::new_unwrap("2.5.29.32.0");
+
+/// The `authorities-constrained-policy-set` NIST PKITS v1.0.1 §4.8 specifies for each certificate-
+/// policies test (fixed by the certification path, independent of the caller's initial-policy-set).
+/// `test` is the test number without the sub-case suffix, e.g. "4.8.10" for case "4.8.10.2". Returns
+/// `None` for cases outside §4.8 (no expected set encoded). The graph leaf certval records is the
+/// *user*-constrained set — this intersected with the initial-policy-set — which the caller derives.
+pub fn authorities_constrained_policy_set(test: &str) -> Option<Vec<ObjectIdentifier>> {
+    Some(match test {
+        "4.8.1" | "4.8.6" | "4.8.14" | "4.8.15" | "4.8.16" | "4.8.17" | "4.8.19" | "4.8.20" => {
+            vec![PKITS_TEST_POLICY_1]
+        }
+        "4.8.10" | "4.8.18" => vec![PKITS_TEST_POLICY_1, PKITS_TEST_POLICY_2],
+        "4.8.13" => vec![
+            PKITS_TEST_POLICY_1,
+            PKITS_TEST_POLICY_2,
+            PKITS_TEST_POLICY_3,
+        ],
+        "4.8.11" => vec![ANY_POLICY_OID],
+        "4.8.2" | "4.8.3" | "4.8.4" | "4.8.5" | "4.8.7" | "4.8.8" | "4.8.9" | "4.8.12" => vec![],
+        _ => return None,
+    })
+}
+
 #[cfg(feature = "std")]
 #[test]
 fn serialize_pkits_settings() {

--- a/pittv3-lib/src/pitt_log.rs
+++ b/pittv3-lib/src/pitt_log.rs
@@ -488,7 +488,7 @@ pub fn log_cpr(_pe: &PkiEnvironment, f: &mut File, np: &Path, cpr: &Certificatio
             .expect("Unable to write manifest file");
     }
 
-    let vpt = cpr.get_final_valid_policy_tree();
+    let vpt = cpr.get_final_valid_policy_graph();
     if let Some(vpt) = vpt {
         f.write_all("Valid certificate policies\n".as_bytes())
             .expect("Unable to write manifest file");


### PR DESCRIPTION
add richer policy processing results checks to test cases

The tree-based policy implementation is gone; the graph is the only one.  Drop the vestigial PR_FINAL_VALID_POLICY_TREE result key (it aliased the graph's map entry) and point the one remaining reader at get_final_valid_policy_graph().