### PR TITLE
CRL processing performance improvements

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -621,6 +621,15 @@ impl PkiEnvironment {
         Err(Error::NotFound)
     }
 
+    /// Offers a CRL that the caller has already verified to every [`CrlSource`] so any configured to
+    /// retain entries in memory may do so. A no-op for sources that do not support retention. Invoked
+    /// from the post-verification CRL processing path (see `keep_verified_crl` on [`CrlSource`]).
+    pub fn keep_verified_crl(&self, crl_buf: &[u8], crl: &CertificateList<Raw>) {
+        for f in &self.crl_sources {
+            let _ = f.keep_verified_crl(crl_buf, crl);
+        }
+    }
+
     /// add_revocation_cache adds a [`RevocationStatusCache`] object to the list.
     pub fn add_revocation_cache(&mut self, c: Box<dyn RevocationStatusCache + Send + Sync>) {
         self.revocation_cache.push(c);

--- a/certval/src/environment/pki_environment_traits.rs
+++ b/certval/src/environment/pki_environment_traits.rs
@@ -174,6 +174,15 @@ pub trait CrlSource {
     fn get_crls(&self, cert: &PDVCertificate) -> Result<Vec<Vec<u8>>>;
     /// Adds a CRL to the store
     fn add_crl(&self, crl_buf: &[u8], crl: &CertificateList<Raw>, uri: &str) -> Result<()>;
+
+    /// Offered a CRL that the caller has already verified so a store may retain its revoked serial
+    /// numbers in memory for fast subsequent revocation status determinations. The default
+    /// implementation is a no-op; only stores that support in-memory retention override it. The
+    /// caller MUST have verified the CRL signature (the store cannot, and when loaded cold has no
+    /// issuer to verify against), so this is invoked only from the post-verification path.
+    fn keep_verified_crl(&self, _crl_buf: &[u8], _crl: &CertificateList<Raw>) -> Result<()> {
+        Ok(())
+    }
 }
 
 /// The [`CheckRemoteResource`] trait defines an interface for checking last modified and blocklist values when downloading remote item

--- a/certval/src/revocation/check_revocation.rs
+++ b/certval/src/revocation/check_revocation.rs
@@ -156,11 +156,9 @@ pub async fn check_revocation(
                 match process_crl(pe, cps, cpr, cur_cert, issuer, pos, crl, None) {
                     Ok(_ok) => {
                         info!("Determined revocation status (valid) using stapled CRL for certificate issued to {cur_cert_subject}");
-                        cpr.add_crl(crl, pos);
                         cur_status = Valid
                     }
                     Err(e) => {
-                        cpr.add_crl(crl, pos);
                         if Error::PathValidation(CertificateRevoked) == e {
                             info!("Determined revocation status (revoked) using stapled CRL for certificate issued to {cur_cert_subject}");
                             cpr.set_validation_status(revoked_error);
@@ -179,20 +177,17 @@ pub async fn check_revocation(
                 for crl in crls {
                     match process_crl(pe, cps, cpr, cur_cert, issuer, pos, crl.as_slice(), None) {
                         Ok(_ok) => {
-                            cpr.add_crl(crl.as_slice(), pos);
                             info!("Determined revocation status (valid) using cached CRL for certificate issued to {cur_cert_subject}");
                             cur_status = Valid;
                             break;
                         }
                         Err(Error::PathValidation(CertificateRevoked)) => {
-                            cpr.add_crl(crl.as_slice(), pos);
                             info!("Determined revocation status (revoked) using cached CRL for certificate issued to {cur_cert_subject}");
                             cpr.set_validation_status(revoked_error);
                             cpr.set_failure_index(pos as u32 + 1);
                             return Err(Error::PathValidation(revoked_error));
                         }
                         Err(e) => {
-                            cpr.add_failed_crl(crl.as_slice(), pos);
                             info!("Failed to determine revocation status using cached CRL for certificate issued to {cur_cert_subject} with {e}");
                         }
                     };
@@ -357,11 +352,9 @@ pub fn check_revocation(
                 match process_crl(pe, cps, cpr, cur_cert, issuer, pos, crl, None) {
                     Ok(_ok) => {
                         info!("Determined revocation status (valid) using stapled CRL for certificate issued to {}", cur_cert_subject);
-                        cpr.add_crl(crl, pos);
                         cur_status = Valid
                     }
                     Err(e) => {
-                        cpr.add_crl(crl, pos);
                         if Error::PathValidation(CertificateRevoked) == e {
                             info!("Determined revocation status (revoked) using stapled CRL for certificate issued to {}", cur_cert_subject);
                             cpr.set_validation_status(revoked_error);
@@ -380,20 +373,17 @@ pub fn check_revocation(
                 for crl in crls {
                     match process_crl(pe, cps, cpr, cur_cert, issuer, pos, crl.as_slice(), None) {
                         Ok(_ok) => {
-                            cpr.add_crl(crl.as_slice(), pos);
                             info!("Determined revocation status (valid) using cached CRL for certificate issued to {}", cur_cert_subject);
                             cur_status = Valid;
                             break;
                         }
                         Err(e) => {
                             if Error::PathValidation(CertificateRevoked) == e {
-                                cpr.add_crl(crl.as_slice(), pos);
                                 info!("Determined revocation status (revoked) using cached CRL for certificate issued to {}", cur_cert_subject);
                                 cpr.set_validation_status(revoked_error);
                                 cpr.set_failure_index(pos as u32 + 1);
                                 return Err(Error::PathValidation(revoked_error));
                             } else {
-                                cpr.add_failed_crl(crl.as_slice(), pos);
                                 info!("Failed to determine revocation status using cached CRL for certificate issued to {} with {}", cur_cert_subject, e);
                             }
                         }

--- a/certval/src/revocation/crl.rs
+++ b/certval/src/revocation/crl.rs
@@ -323,6 +323,10 @@ pub struct CrlInfo {
     pub skid: Option<Vec<u8>>,
     /// Optional filename in DER-encoded form
     pub filename: Option<String>,
+    /// Optional source URI the CRL was fetched from (its CRL distribution point) -- a clue for where
+    /// the full CRL can be re-obtained. Set when the CRL was fetched/stored via a URI; None for CRLs
+    /// parsed without a known source (e.g. stapled) or loaded from disk.
+    pub uri: Option<String>,
 }
 
 //CRL Processing Steps
@@ -658,6 +662,7 @@ pub fn get_crl_info(crl: &CertificateList<Raw>) -> Result<CrlInfo> {
         idp_name,
         idp_blob,
         filename: None,
+        uri: None,
     })
 }
 
@@ -873,6 +878,91 @@ fn validate_crl_authority(target_cert: &PDVCertificate, crl_info: &CrlInfo) -> R
     }
 }
 
+/// Determines whether `crl_info` is in scope for `target_cert`, i.e., whether this CRL is one that
+/// may be used to determine the revocation status of the certificate. This is the per-target
+/// coverage affirmation performed by [`process_crl`] (certificate/CRL type compatibility,
+/// distribution point validation and CRL authority validation), factored out so an in-memory
+/// kept-CRL answer path can apply the identical checks. It does NOT check freshness (callers bound
+/// that separately) nor consult the revoked list. Returns `Ok(())` when in scope.
+pub(crate) fn crl_covers_cert(target_cert: &PDVCertificate, crl_info: &CrlInfo) -> Result<()> {
+    let cert_type = classify_certificate(target_cert);
+    let dps_from_crl_dp = match target_cert.get_extension(&ID_CE_CRL_DISTRIBUTION_POINTS) {
+        Ok(Some(PDVExtension::CrlDistributionPoints(crldp))) => Some(crldp),
+        _ => None,
+    };
+
+    let scope_ok = COMPATIBLE_SCOPE
+        .get(cert_type as usize)
+        .and_then(|row| row.get(crl_info.type_info.scope as usize))
+        .copied()
+        .unwrap_or(false);
+    let coverage_ok = COMPATIBLE_COVERAGE
+        .get(cert_type as usize)
+        .and_then(|row| row.get(crl_info.type_info.coverage as usize))
+        .copied()
+        .unwrap_or(false);
+    if !scope_ok || !coverage_ok {
+        return Err(Error::CrlIncompatible);
+    }
+
+    let mut collected_reasons = ReasonFlags::new(0).map_err(|_| Error::Unrecognized)?;
+    validate_distribution_point(
+        dps_from_crl_dp,
+        crl_info,
+        cert_type,
+        target_cert,
+        &mut collected_reasons,
+    )
+    .map_err(|_| Error::CrlIncompatible)?;
+
+    // matches process_crl: only an error discards the CRL (the returned bool is not consulted)
+    validate_crl_authority(target_cert, crl_info).map_err(|_| Error::CrlIncompatible)?;
+
+    Ok(())
+}
+
+/// True if a CRL of this type must not be answered from a kept in-memory serial list because a
+/// single CRL cannot yield a complete determination: delta CRLs, indirect CRLs, and reason-
+/// partitioned CRLs. Such CRLs fall through to full [`process_crl`] handling.
+#[cfg(feature = "std")]
+fn info_precludes_keeping(info: &CrlInfo) -> bool {
+    matches!(info.type_info.scope, CrlScope::Delta | CrlScope::DeltaDp)
+        || CrlAuthority::Indirect == info.type_info.authority
+        || CrlReasons::SomeReasons == info.type_info.reasons
+}
+
+/// Builds the sorted list of revoked serial numbers for a verified CRL to keep in memory, or `None`
+/// to decline keeping (so callers fall through to [`process_crl`]) for any CRL that cannot be
+/// answered from a bare serial list: delta/indirect/reason-partitioned scope, an unrecognized
+/// critical CRL extension, an indirect (certificate-issuer) entry extension, or an unrecognized
+/// critical entry extension. Serial keys are the INTEGER value octets, which are canonical for a
+/// DER-decoded serial number, so the same integer yields identical bytes on both build and lookup.
+#[cfg(feature = "std")]
+pub(crate) fn build_kept_serials(
+    crl: &CertificateList<Raw>,
+    info: &CrlInfo,
+) -> Option<Vec<Vec<u8>>> {
+    if info_precludes_keeping(info) {
+        return None;
+    }
+    if let Some(exts) = &crl.tbs_cert_list.crl_extensions {
+        if check_crl_extensions(exts).is_err() {
+            return None;
+        }
+    }
+    let mut serials = Vec::new();
+    if let Some(revoked) = &crl.tbs_cert_list.revoked_certificates {
+        for rc in revoked {
+            if certificate_issuer_extension_present(rc) || check_entry_extensions(rc).is_err() {
+                return None;
+            }
+            serials.push(rc.serial_number.as_bytes().to_vec());
+        }
+    }
+    serials.sort();
+    Some(serials)
+}
+
 fn verify_crl(
     pe: &PkiEnvironment,
     crl_buf: &[u8],
@@ -1030,9 +1120,16 @@ pub(crate) fn process_crl(
     crl_buf: &[u8],
     uri: Option<&str>,
 ) -> Result<()> {
-    // Verify then parse and classify the CRL
-    verify_crl(pe, crl_buf, issuer, cpr)?;
-    check_crl_sign(issuer)?;
+    // Verify then parse and classify the CRL. A CRL that fails verification or the CRL-signing
+    // authority check is deliberately not retained in the results (it may be bogus and would only be
+    // re-saved on every pass); log the source URI when it is known so the CRL can still be re-obtained
+    // for diagnosis. verify_crl/check_crl_sign already log the specific failure and issuer.
+    if let Err(e) = verify_crl(pe, crl_buf, issuer, cpr).and_then(|_| check_crl_sign(issuer)) {
+        if let Some(uri) = uri {
+            error!("Discarding unverifiable CRL from {uri} with {e}");
+        }
+        return Err(e);
+    }
 
     let crl = match CertificateList::<Raw>::from_der(crl_buf) {
         Ok(crl) => crl,
@@ -1042,10 +1139,16 @@ pub(crate) fn process_crl(
             } else {
                 error!("Failed to parse CRL from with {e}");
             }
-            cpr.add_failed_crl(crl_buf, result_index);
+            // No CrlInfo can be built from an unparseable CRL, so there is nothing to record here.
             return Err(Error::Asn1Error(e));
         }
     };
+
+    // Build the compact metadata record once, right after the CRL parses. This is what gets recorded
+    // in the results (as a failed or contributing CRL) in place of the full CRL body, and it carries
+    // the URI clue for where the full CRL was obtained when one is available.
+    let mut crl_info = get_crl_info(&crl)?;
+    crl_info.uri = uri.map(|u| u.to_string());
 
     // RFC 5280 5.1.1.2/5.1.2: the signatureAlgorithm in the CRL must match the signature field
     // of the tbsCertList it protects, else the algorithm is subject to substitution (the cert
@@ -1057,13 +1160,11 @@ pub(crate) fn process_crl(
             crl.signature_algorithm,
             crl.tbs_cert_list.signature
         );
-        cpr.add_failed_crl(crl_buf, result_index);
+        cpr.add_failed_crl(crl_info.clone(), result_index);
         return Err(Error::PathValidation(
             PathValidationStatus::SignatureVerificationFailure,
         ));
     }
-
-    let crl_info = get_crl_info(&crl)?;
 
     if let Some(uri) = uri {
         if let Err(e) = pe.add_crl(crl_buf, &crl, uri) {
@@ -1071,64 +1172,31 @@ pub(crate) fn process_crl(
         }
     }
 
-    //Classify the certificate as DP/not DP and CA/EE and harvest DPs, if any
-    let cert_type = classify_certificate(target_cert);
-    let dps_from_crl_dp = match target_cert.get_extension(&ID_CE_CRL_DISTRIBUTION_POINTS) {
-        Ok(Some(PDVExtension::CrlDistributionPoints(crldp))) => Some(crldp),
-        _ => None,
-    };
+    // Offer the just-verified CRL to any store configured to keep its entries in memory so that
+    // subsequent certificates under the same scope are answered from get_status without re-entering
+    // process_crl. This is the only path that populates the in-memory kept serials, which is why a
+    // cold-loaded store cannot serve them until a CRL has been verified here at least once.
+    pe.keep_verified_crl(crl_buf, &crl);
 
     //4-a) confirm that the CRL type and cert type are compatible
-    let scope_ok = COMPATIBLE_SCOPE
-        .get(cert_type as usize)
-        .and_then(|row| row.get(crl_info.type_info.scope as usize))
-        .copied()
-        .unwrap_or(false);
-    let coverage_ok = COMPATIBLE_COVERAGE
-        .get(cert_type as usize)
-        .and_then(|row| row.get(crl_info.type_info.coverage as usize))
-        .copied()
-        .unwrap_or(false);
-    if !scope_ok || !coverage_ok {
-        info!("Discarding CRL from {} as having incompatible scope or coverage for certificate issued to {}", name_to_string(&crl.tbs_cert_list.issuer), name_to_string(target_cert.decoded().tbs_certificate().subject()));
-        return Err(Error::CrlIncompatible);
-    }
-
     //4-b) validate the CRL issuer name (validate_crl_issuer_name is called by validate_distribution_point)
     //4-c) Validate DP (sets activeCRLDP as necessary)
-    let mut collected_reasons = match ReasonFlags::new(0) {
-        Ok(rf) => rf,
-        Err(_e) => {
-            info!(
-                "Discarding CRL from {} due to failure to prepare ReasonFlags",
-                name_to_string(&crl.tbs_cert_list.issuer)
-            );
-            return Err(Error::Unrecognized);
-        }
-    };
-    if let Err(_e) = validate_distribution_point(
-        dps_from_crl_dp,
-        &crl_info,
-        cert_type,
-        target_cert,
-        &mut collected_reasons,
-    ) {
-        info!("Discarding CRL from {} as having incompatible distribution point for certificate issued to {}", name_to_string(&crl.tbs_cert_list.issuer), name_to_string(target_cert.decoded().tbs_certificate().subject()));
-        return Err(Error::CrlIncompatible);
-    }
-
     //4-d) Validate CRL authority
-    if let Err(_e) = validate_crl_authority(target_cert, &crl_info) {
+    if let Err(e) = crl_covers_cert(target_cert, &crl_info) {
         info!(
-            "Discarding CRL from {} as having incompatible authority for certificate issued to {}",
+            "Discarding CRL from {} as not covering certificate issued to {}",
             name_to_string(&crl.tbs_cert_list.issuer),
             name_to_string(target_cert.decoded().tbs_certificate().subject())
         );
-        return Err(Error::CrlIncompatible);
+        cpr.add_failed_crl(crl_info.clone(), result_index);
+        return Err(e);
     }
 
     let toi = cps.get_time_of_interest();
-    check_crl_validity(toi, cps.get_revocation_max_age(), &crl)?;
+    if let Err(e) = check_crl_validity(toi, cps.get_revocation_max_age(), &crl) {
+        cpr.add_failed_crl(crl_info.clone(), result_index);
+        return Err(e);
+    }
 
     if let Some(exts) = &crl.tbs_cert_list.crl_extensions {
         if let Err(_e) = check_crl_extensions(exts) {
@@ -1136,6 +1204,7 @@ pub(crate) fn process_crl(
                 "Discarding CRL from {} due to unrecognized critical extension",
                 name_to_string(&crl.tbs_cert_list.issuer)
             );
+            cpr.add_failed_crl(crl_info.clone(), result_index);
             return Err(Error::UnsupportedCrlExtension);
         }
     }
@@ -1147,6 +1216,7 @@ pub(crate) fn process_crl(
             // that IDP check is good enough.
             if certificate_issuer_extension_present(&rc) {
                 info!("Discarding CRL from {} due to presence of certificate issuer CRL entry extension", name_to_string(&crl.tbs_cert_list.issuer));
+                cpr.add_failed_crl(crl_info.clone(), result_index);
                 return Err(Error::UnsupportedIndirectCrl);
             }
 
@@ -1163,6 +1233,7 @@ pub(crate) fn process_crl(
                         "Discarding CRL from {} due to unrecognized critical CRL entry extension",
                         name_to_string(&crl.tbs_cert_list.issuer)
                     );
+                    cpr.add_failed_crl(crl_info.clone(), result_index);
                     return Err(Error::UnsupportedCrlEntryExtension);
                 }
 
@@ -1182,6 +1253,7 @@ pub(crate) fn process_crl(
                         PathValidationStatus::CertificateRevoked,
                     );
                 }
+                cpr.add_crl(crl_info.clone(), result_index);
                 return Err(Error::PathValidation(
                     PathValidationStatus::CertificateRevoked,
                 ));
@@ -1195,6 +1267,7 @@ pub(crate) fn process_crl(
             PathValidationStatus::Valid,
         );
     }
+    cpr.add_crl(crl_info.clone(), result_index);
     Ok(())
 }
 
@@ -1238,20 +1311,16 @@ pub(crate) async fn check_revocation_crl_remote(
                 Some(crl_dp.as_str()),
             ) {
                 Ok(_ok) => {
-                    target_status = {
-                        cpr.add_crl(crl.as_slice(), pos);
-                        info!("Determined revocation status (valid) using CRL for certificate issued to {cur_cert_subject}");
-                        PathValidationStatus::Valid
-                    }
+                    // process_crl records the contributing CRL (as compact CrlInfo) in the results.
+                    info!("Determined revocation status (valid) using CRL for certificate issued to {cur_cert_subject}");
+                    target_status = PathValidationStatus::Valid;
                 }
                 Err(e) => {
                     if Error::PathValidation(PathValidationStatus::CertificateRevoked) == e {
-                        cpr.add_crl(crl.as_slice(), pos);
                         info!("Determined revocation status (revoked) using CRL for certificate issued to {cur_cert_subject}");
                         return PathValidationStatus::CertificateRevoked;
                     } else {
                         info!("Failed to determine revocation status using CRL for certificate issued to {cur_cert_subject} with {e}");
-                        cpr.add_failed_crl(crl.as_slice(), pos);
                     }
                 }
             };

--- a/certval/src/source/crl_source.rs
+++ b/certval/src/source/crl_source.rs
@@ -6,7 +6,7 @@ use core::ops::{Deref, DerefMut};
 use std::ffi::OsStr;
 use std::fs;
 use std::path::Path;
-use std::sync::{RwLock, RwLockWriteGuard};
+use std::sync::{Arc, RwLock, RwLockWriteGuard};
 
 use log::{debug, error, info};
 
@@ -29,7 +29,9 @@ use crate::{
 };
 
 #[cfg(feature = "revocation")]
-use crate::revocation::crl::{check_crl_validity, get_crl_info, CrlInfo, CrlScope};
+use crate::revocation::crl::{
+    build_kept_serials, check_crl_validity, crl_covers_cert, get_crl_info, CrlInfo, CrlScope,
+};
 
 struct StatusAndTime {
     status: PathValidationStatus, // Valid or Revoked
@@ -44,21 +46,30 @@ struct CrlSourceFoldersInner {
     issuer_map: IssuerMap,
     skid_map: SkidMap,
     dp_map: DpMap,
+    /// Revoked serials of verified full/direct CRLs, keyed by CRL scope (not by crl_info index, so
+    /// it is independent of the append-only crl_info vector). Populated only via keep_verified_crl,
+    /// which the post-verification CRL processing path invokes; never populated by a cold index.
+    kept: BTreeMap<CrlKey, KeptCrl>,
 }
 
-//TODO hygiene
 /// CrlSourceFolders provides a simple CRL store that supports storing CRL retrieved from remote
-/// resources for subsequent use.
+/// resources for subsequent use. When constructed with `keep_entries_in_memory` set (see
+/// [`CrlSourceFolders::with_options`]) it also implements [`RevocationStatusCache`]: after a CRL is
+/// verified and processed once (via `keep_verified_crl` from the CRL processing path), the revoked
+/// serial numbers of full/direct CRLs are retained in memory so subsequent certificates under the
+/// same scope are answered without re-parsing or re-verifying the CRL. As a RevocationStatusCache it
+/// answers only from those kept CRLs and abstains otherwise; register a [`RevocationCache`] alongside
+/// it to memoize OCSP determinations and anything not covered by a kept CRL.
 #[readonly::make]
 pub struct CrlSourceFolders {
     /// Folder where CRLs are stored
     #[readonly]
     pub crls_folder: String,
 
+    /// When true, retain verified full/direct CRLs' revoked serials in memory (see the type doc).
+    keep_entries_in_memory: bool,
+
     inner: RwLock<CrlSourceFoldersInner>,
-    // cache_map: Arc<Mutex<RefCell<CacheMap>>>,
-    // blocklist: Arc<Mutex<RefCell<Blocklist>>>,
-    // last_modified_map: Arc<Mutex<RefCell<LastModifiedMap>>>,
 }
 
 /// Provided in-memory revocation status cache
@@ -87,17 +98,52 @@ type CacheMap = BTreeMap<(String, String), StatusAndTime>;
 type LastModifiedMap = BTreeMap<String, String>;
 type Blocklist = Vec<String>;
 
+/// Scope key for kept CRL entries. Issuer-qualified so two issuers that share an idp name cannot
+/// collide; the optional idp distinguishes distribution-point partitions within a single issuer.
+/// Both population and lookup derive the key from a [`CrlInfo`], so the two are symmetric.
+#[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
+struct CrlKey {
+    issuer: String,
+    idp: Option<String>,
+}
+
+/// A kept CRL: the sorted revoked serial numbers plus the next-update bound through which they are
+/// valid. Serial numbers are INTEGER value octets (canonical for a DER-decoded serial number).
+struct KeptCrl {
+    next_update: u64,
+    serials: Vec<Vec<u8>>,
+}
+
+#[cfg(feature = "revocation")]
+fn crl_key(info: &CrlInfo) -> CrlKey {
+    CrlKey {
+        issuer: info.issuer_name.clone(),
+        idp: info.idp_name.clone(),
+    }
+}
+
 impl CrlSourceFolders {
     /// Instantiates a new CrlSourceFolders instance that uses the indicated folder for storage and
     /// retrieval of CRLs.
     pub fn new(crls_folder: &str) -> Self {
+        Self::with_options(crls_folder, false)
+    }
+
+    /// Instantiates a CrlSourceFolders instance that, when `keep_entries_in_memory` is true, retains
+    /// the revoked serial numbers of each verified full/direct CRL in memory so subsequent
+    /// certificates under the same scope are answered via the [`RevocationStatusCache`]
+    /// implementation without re-parsing or re-verifying the CRL. Memory is traded for speed; a
+    /// value of false yields the original file-backed behavior.
+    pub fn with_options(crls_folder: &str, keep_entries_in_memory: bool) -> Self {
         CrlSourceFolders {
             crls_folder: crls_folder.to_string(),
+            keep_entries_in_memory,
             inner: RwLock::new(CrlSourceFoldersInner {
                 crl_info: vec![],
                 issuer_map: BTreeMap::new(),
                 dp_map: BTreeMap::new(),
                 skid_map: BTreeMap::new(),
+                kept: BTreeMap::new(),
             }),
         }
     }
@@ -301,6 +347,7 @@ impl CrlSource for CrlSourceFolders {
                 return Err(Error::Unrecognized);
             }
             cur_crl_info.filename = path.to_str().map(|s| s.to_string());
+            cur_crl_info.uri = Some(uri.to_string());
 
             let mut inner = self.inner.write().map_err(|_| Error::Unrecognized)?;
             let inner = inner.deref_mut();
@@ -363,6 +410,76 @@ impl CrlSource for CrlSourceFolders {
             return Ok(retval);
         }
         Err(Error::NotFound)
+    }
+
+    #[cfg_attr(not(feature = "revocation"), allow(unused_variables))]
+    fn keep_verified_crl(&self, _crl_buf: &[u8], crl: &CertificateList<Raw>) -> Result<()> {
+        #[cfg(feature = "revocation")]
+        {
+            if !self.keep_entries_in_memory {
+                return Ok(());
+            }
+            let info = match get_crl_info(crl) {
+                Ok(info) => info,
+                Err(_e) => return Ok(()),
+            };
+            // A CRL with no nextUpdate cannot be freshness-bounded, mirroring add_status which only
+            // caches determinations that carry a nextUpdate.
+            let next_update = match info.next_update {
+                Some(nu) => nu,
+                None => return Ok(()),
+            };
+            let serials = match build_kept_serials(crl, &info) {
+                Some(serials) => serials,
+                None => return Ok(()),
+            };
+            let key = crl_key(&info);
+            let mut inner = self.inner.write().map_err(|_| Error::Unrecognized)?;
+            // Latest-verified wins so a reissued CRL replaces stale serials for the same scope.
+            let fresher = inner
+                .kept
+                .get(&key)
+                .is_none_or(|k| next_update >= k.next_update);
+            if fresher {
+                inner.kept.insert(
+                    key,
+                    KeptCrl {
+                        next_update,
+                        serials,
+                    },
+                );
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(feature = "revocation")]
+impl CrlSourceFoldersInner {
+    /// Candidate crl_info indices for a certificate, mirroring the distribution-point / SKID /
+    /// issuer-name lookup precedence used by get_crls. Used by the RevocationStatusCache path.
+    fn matching_indices(&self, cert: &PDVCertificate) -> Vec<usize> {
+        if let Some(dps) = get_dps_from_cert(cert) {
+            for dp in dps {
+                if let Some(indices) = self.dp_map.get(&dp) {
+                    return indices.clone();
+                }
+            }
+        }
+        if let Ok(Some(PDVExtension::AuthorityKeyIdentifier(akid))) =
+            cert.get_extension(&ID_CE_AUTHORITY_KEY_IDENTIFIER)
+        {
+            if let Some(kid) = &akid.key_identifier {
+                if let Some(indices) = self.skid_map.get(kid.as_bytes()) {
+                    return indices.clone();
+                }
+            }
+        }
+        let issuer_name = name_to_string(cert.decoded().tbs_certificate().issuer());
+        self.issuer_map
+            .get(&issuer_name)
+            .cloned()
+            .unwrap_or_default()
     }
 }
 
@@ -600,6 +717,93 @@ impl RevocationStatusCache for RevocationCache {
             debug!("Adding entry to revocation status check for certificate with serial number {} issued by {} to cache", key.1, key.0);
             cache_map.insert(key, status_and_time);
         }
+    }
+}
+
+impl RevocationStatusCache for CrlSourceFolders {
+    /// Answers only from the in-memory kept CRLs (populated via keep_verified_crl); abstains with
+    /// RevocationStatusNotDetermined otherwise. A per-certificate memo registered alongside (e.g. a
+    /// [`RevocationCache`]) handles OCSP determinations and anything not covered by a kept CRL --
+    /// PkiEnvironment::get_status consults each registered cache in turn and returns the first
+    /// determination.
+    #[cfg_attr(not(feature = "revocation"), allow(unused_variables))]
+    fn get_status(
+        &self,
+        cert: &PDVCertificate,
+        time_of_interest: TimeOfInterest,
+    ) -> PathValidationStatus {
+        #[cfg(feature = "revocation")]
+        {
+            if let Ok(inner) = self.inner.read() {
+                let serial = cert
+                    .decoded()
+                    .tbs_certificate()
+                    .serial_number()
+                    .as_bytes()
+                    .to_vec();
+                for idx in inner.matching_indices(cert) {
+                    let info = match inner.crl_info.get(idx) {
+                        Some(info) => info,
+                        None => continue,
+                    };
+                    let kept = match inner.kept.get(&crl_key(info)) {
+                        Some(kept) => kept,
+                        None => continue,
+                    };
+                    // Freshness against the kept entry's own nextUpdate (fresh iff nextUpdate > toi).
+                    if kept.next_update <= time_of_interest.as_unix_secs() {
+                        continue;
+                    }
+                    if crl_covers_cert(cert, info).is_err() {
+                        continue;
+                    }
+                    return if kept.serials.binary_search(&serial).is_ok() {
+                        PathValidationStatus::CertificateRevoked
+                    } else {
+                        PathValidationStatus::Valid
+                    };
+                }
+            }
+        }
+        RevocationStatusNotDetermined
+    }
+
+    // Nothing to record: this store answers only from kept CRLs. Determinations are memoized by a
+    // separately-registered RevocationStatusCache (e.g. RevocationCache).
+    fn add_status(&self, _cert: &PDVCertificate, _next_update: u64, _status: PathValidationStatus) {
+    }
+}
+
+// A single CrlSourceFolders often needs to be registered in two roles at once: as a CrlSource
+// (which populates the in-memory kept CRLs via keep_verified_crl) and as a RevocationStatusCache
+// (which answers from them). Because the kept state is mutated at runtime, both roles must observe
+// the same instance, so consumers share one via Arc and register a clone in each role. These
+// delegating implementations let `Arc<CrlSourceFolders>` satisfy both traits.
+impl CrlSource for Arc<CrlSourceFolders> {
+    fn get_all_crls(&self) -> Result<Vec<Vec<u8>>> {
+        (**self).get_all_crls()
+    }
+    fn get_crls(&self, cert: &PDVCertificate) -> Result<Vec<Vec<u8>>> {
+        (**self).get_crls(cert)
+    }
+    fn add_crl(&self, crl_buf: &[u8], crl: &CertificateList<Raw>, uri: &str) -> Result<()> {
+        (**self).add_crl(crl_buf, crl, uri)
+    }
+    fn keep_verified_crl(&self, crl_buf: &[u8], crl: &CertificateList<Raw>) -> Result<()> {
+        (**self).keep_verified_crl(crl_buf, crl)
+    }
+}
+
+impl RevocationStatusCache for Arc<CrlSourceFolders> {
+    fn get_status(
+        &self,
+        cert: &PDVCertificate,
+        time_of_interest: TimeOfInterest,
+    ) -> PathValidationStatus {
+        (**self).get_status(cert, time_of_interest)
+    }
+    fn add_status(&self, cert: &PDVCertificate, next_update: u64, status: PathValidationStatus) {
+        (**self).add_status(cert, next_update, status)
     }
 }
 

--- a/certval/src/validator/path_results.rs
+++ b/certval/src/validator/path_results.rs
@@ -35,6 +35,10 @@ pub enum CertificationPathResultsTypes {
     U32(u32),
     /// Represents a terminal name-constraints working set (permitted or excluded subtrees)
     NameConstraintsSet(NameConstraintsSet),
+    /// Represents per-position CRL metadata records ([`Crls`]) -- notes which CRLs were consulted
+    /// without retaining the CRL bodies
+    #[cfg(feature = "revocation")]
+    Crls(Crls),
 }
 
 /// `CertificationPathResults` is a typedef for a `BTreeMap` that maps arbitrary string values to a
@@ -171,34 +175,41 @@ impl CertificationPathResults {
     }
 }
 
-cpr_gets_and_sets!(PR_FAILED_CRLS, ListOfBuffers);
+#[cfg(feature = "revocation")]
+cpr_gets_and_sets!(PR_FAILED_CRLS, Crls);
+#[cfg(feature = "revocation")]
 impl CertificationPathResults {
-    /// Add a failed OCSP response to list maintained by CertificationPathResults
-    pub fn add_failed_crl(&mut self, crl: &[u8], pos: usize) {
-        let mut v: ListOfBuffers = if let Some(v) = self.get_failed_crls() {
+    /// Notes a CRL that was consulted but did not yield a status determination (i.e., was discarded
+    /// as incompatible, stale, or otherwise unusable). Only the compact [`CrlInfo`] metadata is
+    /// retained, not the (potentially very large) CRL body.
+    pub fn add_failed_crl(&mut self, crl: crate::revocation::crl::CrlInfo, pos: usize) {
+        let mut v: Crls = if let Some(v) = self.get_failed_crls() {
             v
         } else {
             return;
         };
         if v.len() > pos {
-            v[pos].push(crl.to_vec());
+            v[pos].push(crl);
         }
         self.set_failed_crls(v);
     }
 }
 
-//TODO use Vec<CrlInfo> instead?
-cpr_gets_and_sets!(PR_CRL, ListOfBuffers);
+#[cfg(feature = "revocation")]
+cpr_gets_and_sets!(PR_CRL, Crls);
+#[cfg(feature = "revocation")]
 impl CertificationPathResults {
-    /// Add a failed OCSP request to list maintained by CertificationPathResults
-    pub fn add_crl(&mut self, crl: &[u8], pos: usize) {
-        let mut v: ListOfBuffers = if let Some(v) = self.get_crl() {
+    /// Notes a CRL that contributed to a revocation status determination (valid or revoked). Only
+    /// the compact [`CrlInfo`] metadata is retained, not the CRL body; the metadata carries a
+    /// [`CrlInfo::uri`](crate::revocation::crl::CrlInfo::uri) clue for where the full CRL was obtained.
+    pub fn add_crl(&mut self, crl: crate::revocation::crl::CrlInfo, pos: usize) {
+        let mut v: Crls = if let Some(v) = self.get_crl() {
             v
         } else {
             return;
         };
         if v.len() > pos {
-            v[pos].push(crl.to_vec());
+            v[pos].push(crl);
         }
         self.set_crl(v);
     }
@@ -326,8 +337,10 @@ impl CertificationPathResults {
         self.set_ocsp_responses(vec![vec![]; num_certs]);
         self.set_failed_ocsp_requests(vec![vec![]; num_certs]);
         self.set_failed_ocsp_responses(vec![vec![]; num_certs]);
+        #[cfg(feature = "revocation")]
         self.set_failed_crls(vec![vec![]; num_certs]);
         self.set_ocsp_entry(vec![vec![]; num_certs]);
+        #[cfg(feature = "revocation")]
         self.set_crl(vec![vec![]; num_certs]);
         self.set_crl_entry(vec![vec![]; num_certs]);
         Ok(())
@@ -355,8 +368,10 @@ fn check_prepared_results() {
     assert_eq!(4, cpr.get_ocsp_responses().unwrap().len());
     assert_eq!(4, cpr.get_failed_ocsp_requests().unwrap().len());
     assert_eq!(4, cpr.get_failed_ocsp_responses().unwrap().len());
+    #[cfg(feature = "revocation")]
     assert_eq!(4, cpr.get_failed_crls().unwrap().len());
     assert_eq!(4, cpr.get_ocsp_entry().unwrap().len());
+    #[cfg(feature = "revocation")]
     assert_eq!(4, cpr.get_crl().unwrap().len());
     assert_eq!(4, cpr.get_crl_entry().unwrap().len());
 
@@ -369,8 +384,10 @@ fn check_prepared_results() {
     assert_eq!(0, cpr.get_ocsp_responses().unwrap().len());
     assert_eq!(0, cpr.get_failed_ocsp_requests().unwrap().len());
     assert_eq!(0, cpr.get_failed_ocsp_responses().unwrap().len());
+    #[cfg(feature = "revocation")]
     assert_eq!(0, cpr.get_failed_crls().unwrap().len());
     assert_eq!(0, cpr.get_ocsp_entry().unwrap().len());
+    #[cfg(feature = "revocation")]
     assert_eq!(0, cpr.get_crl().unwrap().len());
     assert_eq!(0, cpr.get_crl_entry().unwrap().len());
 }

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -53,6 +53,11 @@ pub type Buffers = Vec<Vec<u8>>;
 /// `ListOfBuffers` is a typedef for a vector of vectors of `Vec<u8>` values.
 pub type ListOfBuffers = Vec<Vec<Vec<u8>>>;
 
+/// `Crls` holds per-position lists of [`CrlInfo`](crate::revocation::crl::CrlInfo) metadata records
+/// used to note which CRLs were consulted, without retaining the (potentially very large) CRL bodies.
+#[cfg(feature = "revocation")]
+pub type Crls = Vec<Vec<crate::revocation::crl::CrlInfo>>;
+
 /// `Bools` is a typedef for a vector bool values.
 pub type Bools = Vec<bool>;
 

--- a/certval/tests/revocation.rs
+++ b/certval/tests/revocation.rs
@@ -247,6 +247,57 @@ async fn cached_crl_async() {
     }
 }
 
+// keep_entries_in_memory: a CRL verified once (as process_crl would, via keep_verified_crl) is
+// retained in memory so get_status answers subsequent certificates straight from the sorted
+// serials, sustaining the RevocationStatusCache without a per-certificate memo entry. The memo
+// (cache_map) is never populated here, so a Valid result can only come from the kept serials.
+#[cfg(all(feature = "revocation", feature = "std", feature = "rsa"))]
+#[test]
+fn keep_entries_in_memory_sustains_revocation_cache() {
+    use certval::*;
+    use der::Decode;
+    use std::path::PathBuf;
+    use x509_cert::{certificate::Raw, crl::CertificateList};
+
+    let der_encoded_ee = include_bytes!("examples/makaan.com/2-target.der");
+    let mut ee = PDVCertificate::try_from(der_encoded_ee.as_slice()).unwrap();
+    ee.parse_extensions(EXTS_OF_INTEREST);
+
+    let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
+    d.push("tests/examples/makaan.com/crls");
+    let folder = d.as_path().to_str().unwrap();
+    let toi = TimeOfInterest::from_unix_secs(1647011592).unwrap();
+
+    // Flag off: the store abstains as a RevocationStatusCache (original behavior preserved).
+    let plain = CrlSourceFolders::with_options(folder, false);
+    plain.index_crls(toi).unwrap();
+    assert_eq!(
+        plain.get_status(&ee, toi),
+        PathValidationStatus::RevocationStatusNotDetermined
+    );
+
+    // Flag on: no answer until a CRL has been verified and kept, then Valid straight from memory.
+    let store = CrlSourceFolders::with_options(folder, true);
+    store.index_crls(toi).unwrap();
+    assert_eq!(
+        store.get_status(&ee, toi),
+        PathValidationStatus::RevocationStatusNotDetermined,
+        "must not answer before a CRL is verified and kept"
+    );
+
+    let crls = store.get_crls(&ee).unwrap();
+    assert_eq!(1, crls.len());
+    let crl = CertificateList::<Raw>::from_der(&crls[0]).unwrap();
+    // Stand in for the post-verify call process_crl makes.
+    store.keep_verified_crl(&crls[0], &crl).unwrap();
+
+    assert_eq!(
+        store.get_status(&ee, toi),
+        PathValidationStatus::Valid,
+        "EE (not revoked) must be answered from the kept serials"
+    );
+}
+
 #[cfg(all(feature = "revocation", feature = "std", feature = "rsa"))]
 #[tokio::test]
 async fn cached_crl_revoked_async() {

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -339,6 +339,7 @@ pub(crate) fn App() -> Element {
             results_folder: string_or_none(s_results_folder),
             settings: string_or_none(s_settings),
             crl_folder: string_or_none(s_crl_folder),
+            keep_crl_entries_in_memory: false,
             cleanup: s_cleanup(),
             ta_cleanup: s_ta_cleanup(),
             report_only: s_report_only(),

--- a/pittv3-lib/src/args.rs
+++ b/pittv3-lib/src/args.rs
@@ -115,6 +115,12 @@ pub struct Pittv3Args {
     #[cfg(feature = "std")]
     pub crl_folder: Option<String>,
 
+    /// When set together with crl_folder, retain the revoked serial numbers of each verified
+    /// full/direct CRL in memory so subsequent certificates under the same scope are answered
+    /// without re-parsing or re-verifying the CRL.
+    #[cfg(feature = "std")]
+    pub keep_crl_entries_in_memory: bool,
+
     /// Paired with ca_folder to remove expired, unparseable certificates, self-signed
     /// certificates and non-CA certificates from consideration. When paired with error_folder,
     /// the errant files are moved instead of deleted. After cleanup completes, the application

--- a/pittv3-lib/src/no_std_utils.rs
+++ b/pittv3-lib/src/no_std_utils.rs
@@ -34,10 +34,6 @@ pub(crate) fn validate_cert(
     let mut paths: Vec<CertificationPath> = vec![];
     let r = pe.get_paths_for_target(&target_cert, &mut paths, 0, time_of_interest);
     if let Err(e) = r {
-        println!(
-            "Failed to find certification paths for target with error {:?}",
-            e
-        );
         error!(
             "Failed to find certification paths for target with error {:?}",
             e

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -274,7 +274,8 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
         let cbor_file: &String = if let Some(cbor) = &args.cbor {
             cbor
         } else {
-            panic!("cbor argument must be provided when using a diagnostic command")
+            eprintln!("error: --cbor is required when using a diagnostic command");
+            std::process::exit(1)
         };
 
         let download_folder = if let Some(download_folder) = &args.download_folder {
@@ -297,7 +298,8 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
         let mut cert_source = match CertSource::new_from_cbor(cbor.as_slice()) {
             Ok(cbor_data) => cbor_data,
             Err(e) => {
-                panic!("Failed to parse CBOR file at {cbor_file} with: {e}")
+                eprintln!("error: failed to parse CBOR file at {cbor_file}: {e}");
+                std::process::exit(1)
             }
         };
         let r = cert_source.initialize(&cps);
@@ -486,7 +488,8 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
         let ca_folder = if let Some(ca_folder) = &args.ca_folder {
             ca_folder.clone()
         } else {
-            panic!("The ca-folder option is required when parsing a Mozilla CSV file (to receive the certificate files)");
+            eprintln!("error: --ca-folder is required when parsing a Mozilla CSV file (to receive the certificate files)");
+            std::process::exit(1)
         };
 
         use csv::ReaderBuilder;
@@ -620,15 +623,17 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
 
     #[cfg(feature = "remote")]
     if args.dynamic_build && download_folder.is_empty() {
-        panic!(
-            "Either ca_folder or download_folder must be specified when dynamic_build is specified"
-        )
+        eprintln!(
+            "error: --ca-folder or --download-folder is required when --dynamic-build (-y) is used"
+        );
+        std::process::exit(1);
     }
 
     let mut cps = match read_settings(&args.settings) {
         Ok(cps) => cps,
         Err(e) => {
-            panic!("Failed to parse settings file: {e:?}")
+            eprintln!("error: failed to parse settings file: {e:?}");
+            std::process::exit(1)
         }
     };
 
@@ -731,9 +736,10 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
     #[cfg(all(feature = "std", feature = "revocation"))]
     let crl_source = match &args.crl_folder {
         Some(crl_folder) => {
-            let crl_source = CrlSourceFolders::new(crl_folder);
+            let crl_source =
+                CrlSourceFolders::with_options(crl_folder, args.keep_crl_entries_in_memory);
             match crl_source.index_crls(cps.get_time_of_interest()) {
-                Ok(_) => Some(crl_source),
+                Ok(_) => Some(std::sync::Arc::new(crl_source)),
                 Err(e) => {
                     error!("Failed to index CRL source with {e}");
                     None
@@ -750,15 +756,22 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         .map(|crl_folder| RemoteStatus::new(crl_folder));
 
     #[cfg(all(feature = "std", feature = "revocation"))]
-    if let Some(crl_source) = crl_source {
-        pe.add_crl_source(Box::new(crl_source));
-    }
-    #[cfg(all(feature = "std", feature = "revocation"))]
     if let Some(remote_status) = remote_status {
         pe.add_check_remote(Box::new(remote_status));
     }
+    // The CrlSourceFolders serves CRLs (as a CrlSource) and, when keep_crl_entries_in_memory is set,
+    // answers revocation status from its retained CRL serials (as a RevocationStatusCache). Register
+    // it in both roles via a shared Arc, with its revocation cache FIRST so the kept fast path is
+    // consulted before the per-certificate memo. A RevocationCache is always registered as that memo
+    // for OCSP determinations and anything not covered by a kept CRL.
     #[cfg(all(feature = "std", feature = "revocation"))]
-    pe.add_revocation_cache(Box::new(RevocationCache::new()));
+    {
+        if let Some(crl_source) = crl_source {
+            pe.add_crl_source(Box::new(crl_source.clone()));
+            pe.add_revocation_cache(Box::new(crl_source));
+        }
+        pe.add_revocation_cache(Box::new(RevocationCache::new()));
+    }
     loop {
         // Create a new CertSource and (re-)deserialize on every iteration due references to
         // buffers in the certs member. On the first pass, cbor will contain data read from file,

--- a/pittv3-lib/src/pitt_log.rs
+++ b/pittv3-lib/src/pitt_log.rs
@@ -561,28 +561,59 @@ pub fn log_cpr(_pe: &PkiEnvironment, f: &mut File, np: &Path, cpr: &Certificatio
     if let Some(crls) = cpr.get_crl() {
         for (i, or) in crls.iter().enumerate() {
             let suffix = or.len() > 1;
-            for (j, ir) in or.iter().enumerate() {
-                let p = if suffix {
-                    np.join(format!("{}-crl-{}.crl", i + 1, j).as_str())
+            for (j, info) in or.iter().enumerate() {
+                let stem = if suffix {
+                    format!("{}-crl-{}", i + 1, j)
                 } else {
-                    np.join(format!("{}-crl.crl", i + 1).as_str())
+                    format!("{}-crl", i + 1)
                 };
-                fs::write(p, ir).expect("Unable to write CRL");
+                write_crl_artifact(np, &stem, info);
             }
         }
     }
     if let Some(crls) = cpr.get_failed_crls() {
         for (i, or) in crls.iter().enumerate() {
             let suffix = or.len() > 1;
-            for (j, ir) in or.iter().enumerate() {
-                let p = if suffix {
-                    np.join(format!("{}-crl-{}.failed.crl", i + 1, j).as_str())
+            for (j, info) in or.iter().enumerate() {
+                let stem = if suffix {
+                    format!("{}-crl-{}.failed", i + 1, j)
                 } else {
-                    np.join(format!("{}-crl.failed.crl", i + 1).as_str())
+                    format!("{}-crl.failed", i + 1)
                 };
-                fs::write(p, ir).expect("Unable to write CRL");
+                write_crl_artifact(np, &stem, info);
             }
         }
+    }
+}
+
+/// Writes a CRL artifact into the manifest folder from the compact [`CrlInfo`] now retained in the
+/// results (the results no longer carry the full CRL body). When the CRL was loaded from a folder
+/// its cached bytes are copied out as a `.crl`; when it is only known by URI (e.g., fetched remotely
+/// and not retained) a `.crl.txt` note is written recording where the full CRL can be re-obtained
+/// along with its validity window.
+fn write_crl_artifact(np: &Path, stem: &str, info: &CrlInfo) {
+    if let Some(filename) = &info.filename {
+        let p = np.join(format!("{stem}.crl"));
+        if let Err(e) = fs::copy(filename, &p) {
+            error!("Unable to copy cached CRL {filename} into manifest: {e}");
+        }
+        return;
+    }
+
+    let p = np.join(format!("{stem}.crl.txt"));
+    let mut note = format!("issuer: {}\n", info.issuer_name);
+    if let Some(uri) = &info.uri {
+        note.push_str(&format!("uri: {uri}\n"));
+    }
+    if let Some(idp) = &info.idp_name {
+        note.push_str(&format!("idp: {idp}\n"));
+    }
+    note.push_str(&format!("this_update: {}\n", info.this_update));
+    if let Some(nu) = info.next_update {
+        note.push_str(&format!("next_update: {nu}\n"));
+    }
+    if let Err(e) = fs::write(&p, note.as_bytes()) {
+        error!("Unable to write CRL note {}: {e}", p.display());
     }
 }
 

--- a/pittv3-lib/src/report.rs
+++ b/pittv3-lib/src/report.rs
@@ -376,12 +376,17 @@ pub fn revocation_outcomes_from_cpr(
     let blocklist = cpr.get_blocklist_usage();
     let allowlist = cpr.get_allowlist_usage();
     let ocsp_responses = cpr.get_ocsp_responses();
+    #[cfg(feature = "revocation")]
     let crls = cpr.get_crl();
+    #[cfg(feature = "revocation")]
+    let crls_none = crls.is_none();
+    #[cfg(not(feature = "revocation"))]
+    let crls_none = true;
     if nocheck.is_none()
         && blocklist.is_none()
         && allowlist.is_none()
         && ocsp_responses.is_none()
-        && crls.is_none()
+        && crls_none
     {
         return vec![];
     }
@@ -404,6 +409,16 @@ pub fn revocation_outcomes_from_cpr(
             .map(|v| v.get(pos).map(|b| !b.is_empty()).unwrap_or(false))
             .unwrap_or(false)
     };
+    // CRL results are held as compact CrlInfo records (revocation-gated), so they need their own
+    // presence check; without the revocation feature there are never any CRL artifacts.
+    #[cfg(feature = "revocation")]
+    let crl_artifact_at = |pos: usize| -> bool {
+        crls.as_ref()
+            .map(|v| v.get(pos).map(|b| !b.is_empty()).unwrap_or(false))
+            .unwrap_or(false)
+    };
+    #[cfg(not(feature = "revocation"))]
+    let crl_artifact_at = |_pos: usize| -> bool { false };
 
     let mut outcomes = Vec::with_capacity(num_certs);
     for pos in 0..num_certs {
@@ -422,7 +437,7 @@ pub fn revocation_outcomes_from_cpr(
             } else {
                 (RevocationMethod::Ocsp, RevocationStatus::NotRevoked)
             }
-        } else if artifacts_at(&crls, pos) {
+        } else if crl_artifact_at(pos) {
             if revoked_here {
                 (RevocationMethod::Crl, RevocationStatus::Revoked)
             } else {
@@ -523,6 +538,31 @@ pub fn name_constraints_from_cpr(cpr: &CertificationPathResults) -> Option<NameC
 mod tests {
     use super::*;
 
+    /// Builds a minimal CrlInfo used to mark that a CRL contributed at a given path position. The
+    /// content is irrelevant to these tests; only presence at the position matters.
+    #[cfg(feature = "revocation")]
+    fn crl_marker() -> certval::CrlInfo {
+        certval::CrlInfo {
+            type_info: certval::CrlType {
+                scope: certval::CrlScope::Complete,
+                coverage: certval::CrlCoverage::All,
+                authority: certval::CrlAuthority::Direct,
+                reasons: certval::CrlReasons::AllReasons,
+            },
+            this_update: 0,
+            next_update: None,
+            issuer_name: String::new(),
+            issuer_name_blob: Vec::new(),
+            sig_alg_blob: Vec::new(),
+            exts_blob: None,
+            idp_name: None,
+            idp_blob: None,
+            skid: None,
+            filename: None,
+            uri: None,
+        }
+    }
+
     #[test]
     fn report_json_round_trip() {
         let report = ValidationReport {
@@ -618,13 +658,14 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "revocation")]
     fn revocation_outcomes_methods_and_statuses() {
         let mut cpr = CertificationPathResults::new();
         cpr.prepare_revocation_results(4).unwrap();
 
         // position 0: OCSP no-check; position 1: CRL; position 2: OCSP; position 3: nothing
         cpr.set_nocheck_for_item(0);
-        cpr.add_crl(&[0x30, 0x00], 1);
+        cpr.add_crl(crl_marker(), 1);
         cpr.add_ocsp_response(vec![0x30, 0x00], 2);
 
         let outcomes = revocation_outcomes_from_cpr(&cpr, 4);
@@ -646,11 +687,12 @@ mod tests {
     }
 
     #[test]
+    #[cfg(feature = "revocation")]
     fn revocation_outcomes_revoked_at_failure_index() {
         let mut cpr = CertificationPathResults::new();
         cpr.prepare_revocation_results(2).unwrap();
-        cpr.add_crl(&[0x30, 0x00], 0);
-        cpr.add_crl(&[0x30, 0x00], 1);
+        cpr.add_crl(crl_marker(), 0);
+        cpr.add_crl(crl_marker(), 1);
         cpr.set_validation_status(PathValidationStatus::CertificateRevokedEndEntity);
         cpr.set_failure_index(2);
 

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -183,7 +183,6 @@ pub async fn validate_cert_bytes(
     let mut paths: Vec<CertificationPath> = vec![];
     let r = pe.get_paths_for_target(&target_cert, &mut paths, threshold, time_of_interest);
     if let Err(e) = r {
-        println!("Failed to find certification paths for target with error {e:?}");
         error!("Failed to find certification paths for target with error {e:?}");
         return Err(Error::Unrecognized);
     }

--- a/pittv3/src/cliargs.rs
+++ b/pittv3/src/cliargs.rs
@@ -135,6 +135,13 @@ pub struct Pittv3CliArgs {
     #[clap(long, help_heading = "VALIDATION")]
     pub crl_folder: Option<String>,
 
+    /// When set together with --crl-folder, retain the revoked serial numbers of each verified
+    /// full/direct CRL in memory so subsequent certificates under the same scope are answered
+    /// without re-parsing or re-verifying the CRL.
+    #[cfg(feature = "std")]
+    #[clap(long, help_heading = "VALIDATION")]
+    pub keep_crl_entries_in_memory: bool,
+
     /// Paired with ca_folder to remove expired, unparseable certificates, self-signed
     /// certificates and non-CA certificates from consideration. When paired with error_folder,
     /// the errant files are moved instead of deleted. After cleanup completes, the application
@@ -256,6 +263,8 @@ impl From<Pittv3CliArgs> for Pittv3Args {
             settings: v.settings,
             #[cfg(feature = "std")]
             crl_folder: v.crl_folder,
+            #[cfg(feature = "std")]
+            keep_crl_entries_in_memory: v.keep_crl_entries_in_memory,
             #[cfg(feature = "std")]
             cleanup: v.cleanup,
             #[cfg(feature = "std")]


### PR DESCRIPTION
- Added a new "kept" field to CrlSourceFoldersInner to retain a sorted list of serial numbers in a map keyed by Issuer Name (+ optional Issuing Distribution Point).
- Added a new keep_verified_crl function to the CrlSource trait to allow the CRL processor to indicate that a CRL has been successfully verified.
- The serial numbers collection is assembled when keep_verified_crl is invoked. Thus, every CRL is fully processed once through process_crl. After that, if a CrlSourceFolders instance is created with the new keep_entries_in_memory member set to true, all entries from the CRL are saved in memory to avoid future parsing/verification costs. These serial numbers then support the RevocationStatusCache implementation.
- Refactored process_crl to move CRL coverage determination into a new shared function, crl_covers_cert. The RevocationStatusCache implementation also calls it to affirm that a kept CRL's scope covers the target certificate, so the coverage logic lives in one place.
- Refrain from saving the full CRL into CertificationPathResults and instead save CrlInfo, which was extended to save the URI from which the CRL was retrieved. In this change, the CRL result fields on CertificationPathResults were moved to be gated on the revocation feature. One side effect: CRLs that fail before parsing (verification failure, parse failure, etc.) are no longer listed in failed_crls; such failures are logged (including the source URI when known) so the CRL can still be re-obtained for diagnosis.
- Added a new --keep-crl-entries-in-memory flag to pittv3 to enable testing the changes
- Fixed some error handling on bad input in the pittv3 CLI