### PR TITLE
Refinements to CRL performance improvements

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -53,7 +53,8 @@ use crate::PathValidationStatus::RevocationStatusNotDetermined;
 use crate::{
     environment::pki_environment_traits::*, path_settings::*, util::crypto::*, util::error::*,
     util::pdv_utilities::oid_lookup, validate_path_rfc5280, CertificationPath,
-    CertificationPathResults, PDVCertificate, PDVTrustAnchorChoice, TimeOfInterest,
+    CertificationPathResults, PDVCertificate, PDVTrustAnchorChoice, SubjectNameAndKey,
+    TimeOfInterest,
 };
 
 #[cfg(feature = "pqc")]
@@ -623,10 +624,16 @@ impl PkiEnvironment {
 
     /// Offers a CRL that the caller has already verified to every [`CrlSource`] so any configured to
     /// retain entries in memory may do so. A no-op for sources that do not support retention. Invoked
-    /// from the post-verification CRL processing path (see `keep_verified_crl` on [`CrlSource`]).
-    pub fn keep_verified_crl(&self, crl_buf: &[u8], crl: &CertificateList<Raw>) {
+    /// from the post-verification CRL processing path (see `keep_verified_crl` on [`CrlSource`]);
+    /// `verifier` is the issuer whose key verified the CRL and bounds who the kept entries may answer.
+    pub fn keep_verified_crl(
+        &self,
+        crl_buf: &[u8],
+        crl: &CertificateList<Raw>,
+        verifier: &dyn SubjectNameAndKey,
+    ) {
         for f in &self.crl_sources {
-            let _ = f.keep_verified_crl(crl_buf, crl);
+            let _ = f.keep_verified_crl(crl_buf, crl, verifier);
         }
     }
 
@@ -674,14 +681,17 @@ impl PkiEnvironment {
         }
     }
 
-    /// Retrieves cached revocation status determination for given certificate from store
+    /// Retrieves cached revocation status determination for given certificate from store. `issuer`
+    /// is the subject that would verify revocation data for the certificate on the current path;
+    /// caches bind their answers to its key (see [`RevocationStatusCache`]).
     pub fn get_status(
         &self,
         cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
         time_of_interest: TimeOfInterest,
     ) -> PathValidationStatus {
         for f in &self.revocation_cache {
-            let status = f.get_status(cert, time_of_interest);
+            let status = f.get_status(cert, issuer, time_of_interest);
             if RevocationStatusNotDetermined != status {
                 return status;
             }
@@ -689,15 +699,17 @@ impl PkiEnvironment {
         RevocationStatusNotDetermined
     }
 
-    /// Adds a cached revocation status determination to the store
+    /// Adds a cached revocation status determination to the store, keyed to the issuer whose key
+    /// verified the revocation data behind it.
     pub fn add_status(
         &self,
         cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
         next_update: u64,
         status: PathValidationStatus,
     ) {
         for f in &self.revocation_cache {
-            f.add_status(cert, next_update, status);
+            f.add_status(cert, issuer, next_update, status);
         }
     }
 

--- a/certval/src/environment/pki_environment_traits.rs
+++ b/certval/src/environment/pki_environment_traits.rs
@@ -11,7 +11,7 @@ use x509_cert::{certificate::Raw, crl::CertificateList, name::Name};
 use crate::util::error::*;
 use crate::{
     CertFile, CertificationPath, CertificationPathResults, CertificationPathSettings,
-    PDVCertificate, PDVTrustAnchorChoice, PkiEnvironment, TimeOfInterest,
+    PDVCertificate, PDVTrustAnchorChoice, PkiEnvironment, SubjectNameAndKey, TimeOfInterest,
 };
 
 /// `ValidatePath` provides a function signature for implementations that perform certification path
@@ -178,9 +178,17 @@ pub trait CrlSource {
     /// Offered a CRL that the caller has already verified so a store may retain its revoked serial
     /// numbers in memory for fast subsequent revocation status determinations. The default
     /// implementation is a no-op; only stores that support in-memory retention override it. The
-    /// caller MUST have verified the CRL signature (the store cannot, and when loaded cold has no
-    /// issuer to verify against), so this is invoked only from the post-verification path.
-    fn keep_verified_crl(&self, _crl_buf: &[u8], _crl: &CertificateList<Raw>) -> Result<()> {
+    /// caller MUST have verified the CRL signature against `verifier`'s key (the store cannot, and
+    /// when loaded cold has no issuer to verify against), so this is invoked only from the
+    /// post-verification path. Retained entries must be bound to `verifier`'s SPKI so that issuers
+    /// sharing a subject name (e.g. across a key rollover) can never answer for one another's
+    /// certificates.
+    fn keep_verified_crl(
+        &self,
+        _crl_buf: &[u8],
+        _crl: &CertificateList<Raw>,
+        _verifier: &dyn SubjectNameAndKey,
+    ) -> Result<()> {
         Ok(())
     }
 }
@@ -203,16 +211,29 @@ pub trait CheckRemoteResource {
 /// The [`RevocationStatusCache`] trait defines the interface for storing and retrieving cached revocation status determinations
 /// in support of certification path validation.
 pub trait RevocationStatusCache {
-    /// Returns Ok(Valid) is status is known to be good at time of interest, Ok(Revoked) if
-    /// certificate is known to be revoked and Err(RevocationStatusDetermined) otherwise.
+    /// Returns Valid if status is known to be good at time of interest, CertificateRevoked if
+    /// certificate is known to be revoked and RevocationStatusNotDetermined otherwise. `issuer` is
+    /// the subject that would verify revocation data for `cert` (its issuing CA or trust anchor);
+    /// implementations must bind answers to the issuer's key, not just its name, so that issuers
+    /// sharing a subject name (e.g. across a key rollover) can never answer for one another's
+    /// certificates.
     fn get_status(
         &self,
         cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
         time_of_interest: TimeOfInterest,
     ) -> PathValidationStatus;
 
-    /// Sets status for certificate to one of Valid or Revoked and a next update value.
-    fn add_status(&self, cert: &PDVCertificate, next_update: u64, status: PathValidationStatus);
+    /// Sets status for certificate to one of Valid or Revoked and a next update value. `issuer` is
+    /// the subject whose key verified the revocation data behind the determination and must key the
+    /// cached entry alongside the certificate identity (see `get_status`).
+    fn add_status(
+        &self,
+        cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
+        next_update: u64,
+        status: PathValidationStatus,
+    );
 }
 // TODO add allowlist and blocklist as RevocationStatusCache implementations
 

--- a/certval/src/lib.rs
+++ b/certval/src/lib.rs
@@ -10,7 +10,8 @@ pub mod source;
 pub mod util;
 pub mod validator;
 
-#[cfg(feature = "revocation")]
+// The module itself is always present because the environment traits reference the
+// SubjectNameAndKey abstraction it hosts; the CRL/OCSP machinery within is feature-gated.
 pub mod revocation;
 
 #[cfg(feature = "std")]
@@ -27,7 +28,6 @@ pub use crate::builder::*;
 
 pub use crate::environment::*;
 
-#[cfg(feature = "revocation")]
 pub use crate::revocation::*;
 
 #[cfg(feature = "pqc")]

--- a/certval/src/revocation.rs
+++ b/certval/src/revocation.rs
@@ -61,6 +61,7 @@
 //! - [`PS_CRL_TIMEOUT`](../certval/path_settings/static.PS_CRL_TIMEOUT.html)
 //! - [`PS_OCSP_AIA_NONCE_SETTING`](../validator/path_settings/static.PS_OCSP_AIA_NONCE_SETTING.html)
 //!
+#[cfg(feature = "revocation")]
 pub mod check_revocation;
 pub mod subject_name_and_key;
 
@@ -69,6 +70,7 @@ pub mod crl;
 #[cfg(feature = "revocation")]
 pub mod ocsp_client;
 
+#[cfg(feature = "revocation")]
 pub use crate::check_revocation::*;
 pub use crate::revocation::subject_name_and_key::*;
 

--- a/certval/src/revocation/check_revocation.rs
+++ b/certval/src/revocation/check_revocation.rs
@@ -110,7 +110,7 @@ pub async fn check_revocation(
         };
 
         // check revocation status cache
-        let mut cur_status = pe.get_status(cur_cert, toi);
+        let mut cur_status = pe.get_status(cur_cert, issuer, toi);
         if CertificateRevoked == cur_status {
             info!("Determined revocation status (revoked) using cached status for certificate issued to {cur_cert_subject}");
             cpr.set_validation_status(revoked_error);
@@ -304,7 +304,7 @@ pub fn check_revocation(
         };
 
         // check revocation status cache
-        let mut cur_status = pe.get_status(cur_cert, toi);
+        let mut cur_status = pe.get_status(cur_cert, issuer, toi);
 
         if CertificateRevoked == cur_status {
             info!("Determined revocation status (revoked) using cached status for certificate issued to {}", cur_cert_subject);

--- a/certval/src/revocation/crl.rs
+++ b/certval/src/revocation/crl.rs
@@ -1172,11 +1172,22 @@ pub(crate) fn process_crl(
         }
     }
 
+    // Reject a stale or future-dated CRL before offering it for in-memory retention so kept entries
+    // are never sourced from a CRL the inline path would have refused. Unlike crl_covers_cert below,
+    // this check is target-independent, so its verdict applies to every certificate the kept entries
+    // might later answer.
+    let toi = cps.get_time_of_interest();
+    if let Err(e) = check_crl_validity(toi, cps.get_revocation_max_age(), &crl) {
+        cpr.add_failed_crl(crl_info.clone(), result_index);
+        return Err(e);
+    }
+
     // Offer the just-verified CRL to any store configured to keep its entries in memory so that
     // subsequent certificates under the same scope are answered from get_status without re-entering
     // process_crl. This is the only path that populates the in-memory kept serials, which is why a
-    // cold-loaded store cannot serve them until a CRL has been verified here at least once.
-    pe.keep_verified_crl(crl_buf, &crl);
+    // cold-loaded store cannot serve them until a CRL has been verified here at least once. The
+    // kept entries are bound to the issuer whose key verified the CRL just above.
+    pe.keep_verified_crl(crl_buf, &crl, issuer);
 
     //4-a) confirm that the CRL type and cert type are compatible
     //4-b) validate the CRL issuer name (validate_crl_issuer_name is called by validate_distribution_point)
@@ -1188,12 +1199,6 @@ pub(crate) fn process_crl(
             name_to_string(&crl.tbs_cert_list.issuer),
             name_to_string(target_cert.decoded().tbs_certificate().subject())
         );
-        cpr.add_failed_crl(crl_info.clone(), result_index);
-        return Err(e);
-    }
-
-    let toi = cps.get_time_of_interest();
-    if let Err(e) = check_crl_validity(toi, cps.get_revocation_max_age(), &crl) {
         cpr.add_failed_crl(crl_info.clone(), result_index);
         return Err(e);
     }
@@ -1249,6 +1254,7 @@ pub(crate) fn process_crl(
                 if let Some(nu) = crl.tbs_cert_list.next_update {
                     pe.add_status(
                         target_cert,
+                        issuer,
                         nu.to_unix_duration().as_secs(),
                         PathValidationStatus::CertificateRevoked,
                     );
@@ -1263,6 +1269,7 @@ pub(crate) fn process_crl(
     if let Some(nu) = crl.tbs_cert_list.next_update {
         pe.add_status(
             target_cert,
+            issuer,
             nu.to_unix_duration().as_secs(),
             PathValidationStatus::Valid,
         );

--- a/certval/src/revocation/ocsp_client.rs
+++ b/certval/src/revocation/ocsp_client.rs
@@ -826,6 +826,7 @@ fn process_ocsp_response_internal(
                     if let Some(nu) = sr.next_update {
                         pe.add_status(
                             target_cert,
+                            issuer,
                             nu.0.to_unix_duration().as_secs(),
                             PathValidationStatus::Valid,
                         );
@@ -837,6 +838,7 @@ fn process_ocsp_response_internal(
                 if let Some(nu) = sr.next_update {
                     pe.add_status(
                         target_cert,
+                        issuer,
                         nu.0.to_unix_duration().as_secs(),
                         PathValidationStatus::CertificateRevoked,
                     );

--- a/certval/src/source/crl_source.rs
+++ b/certval/src/source/crl_source.rs
@@ -25,7 +25,7 @@ use crate::PathValidationStatus::RevocationStatusNotDetermined;
 use crate::{buffer_to_hex, CheckRemoteResource, PathValidationStatus, RevocationStatusCache};
 use crate::{
     get_file_as_byte_vec_pem, name_to_string, CrlSource, Error, PDVCertificate, PDVExtension,
-    Result, TimeOfInterest,
+    Result, SubjectNameAndKey, TimeOfInterest,
 };
 
 #[cfg(feature = "revocation")]
@@ -57,9 +57,12 @@ struct CrlSourceFoldersInner {
 /// [`CrlSourceFolders::with_options`]) it also implements [`RevocationStatusCache`]: after a CRL is
 /// verified and processed once (via `keep_verified_crl` from the CRL processing path), the revoked
 /// serial numbers of full/direct CRLs are retained in memory so subsequent certificates under the
-/// same scope are answered without re-parsing or re-verifying the CRL. As a RevocationStatusCache it
-/// answers only from those kept CRLs and abstains otherwise; register a [`RevocationCache`] alongside
-/// it to memoize OCSP determinations and anything not covered by a kept CRL.
+/// same scope are answered without re-parsing or re-verifying the CRL. Kept entries are bound to
+/// the key that verified the CRL and answer only on behalf of that same issuing key, so issuers
+/// sharing a subject name (e.g. across a key rollover) can never answer for one another. As a
+/// RevocationStatusCache it answers only from those kept CRLs and abstains otherwise; register a
+/// [`RevocationCache`] alongside it to cache OCSP determinations and anything not covered by a
+/// kept CRL.
 #[readonly::make]
 pub struct CrlSourceFolders {
     /// Folder where CRLs are stored
@@ -94,31 +97,43 @@ pub struct RemoteStatus {
 type IssuerMap = BTreeMap<String, Vec<usize>>;
 type SkidMap = BTreeMap<Vec<u8>, Vec<usize>>;
 type DpMap = BTreeMap<Vec<u8>, Vec<usize>>;
-type CacheMap = BTreeMap<(String, String), StatusAndTime>;
+// Keyed by (issuer name, hex SHA-256 of issuer SPKI, serial). The SPKI hash binds a cached
+// determination to the issuing key so issuers sharing a subject name cannot answer for one another.
+type CacheMap = BTreeMap<(String, String, String), StatusAndTime>;
 type LastModifiedMap = BTreeMap<String, String>;
 type Blocklist = Vec<String>;
 
 /// Scope key for kept CRL entries. Issuer-qualified so two issuers that share an idp name cannot
 /// collide; the optional idp distinguishes distribution-point partitions within a single issuer.
-/// Both population and lookup derive the key from a [`CrlInfo`], so the two are symmetric.
+/// The verifier SPKI binds the entries to the key that verified the CRL's signature: population
+/// keys on the SPKI that did verify, lookup keys on the SPKI that would verify for the current
+/// path, so issuers sharing a subject name (e.g. across a key rollover) occupy separate slots and
+/// can never answer for one another's certificates.
 #[derive(Clone, PartialEq, Eq, PartialOrd, Ord)]
 struct CrlKey {
     issuer: String,
     idp: Option<String>,
+    verifier_spki: Vec<u8>,
 }
 
-/// A kept CRL: the sorted revoked serial numbers plus the next-update bound through which they are
-/// valid. Serial numbers are INTEGER value octets (canonical for a DER-decoded serial number).
+/// A kept CRL: the sorted revoked serial numbers plus the validity window through which they may be
+/// used (mirroring check_crl_validity, the time of interest must fall within thisUpdate/nextUpdate).
+/// Serial numbers are INTEGER value octets (canonical for a DER-decoded serial number). The
+/// per-validation revocation max age was applied by the processing path that verified the CRL and is
+/// not re-applied here; a validation configured with a stricter max age that shares this store gets
+/// answers vetted under the policy in force at keep time.
 struct KeptCrl {
+    this_update: u64,
     next_update: u64,
     serials: Vec<Vec<u8>>,
 }
 
 #[cfg(feature = "revocation")]
-fn crl_key(info: &CrlInfo) -> CrlKey {
+fn crl_key(info: &CrlInfo, verifier_spki: &[u8]) -> CrlKey {
     CrlKey {
         issuer: info.issuer_name.clone(),
         idp: info.idp_name.clone(),
+        verifier_spki: verifier_spki.to_vec(),
     }
 }
 
@@ -413,7 +428,12 @@ impl CrlSource for CrlSourceFolders {
     }
 
     #[cfg_attr(not(feature = "revocation"), allow(unused_variables))]
-    fn keep_verified_crl(&self, _crl_buf: &[u8], crl: &CertificateList<Raw>) -> Result<()> {
+    fn keep_verified_crl(
+        &self,
+        _crl_buf: &[u8],
+        crl: &CertificateList<Raw>,
+        verifier: &dyn SubjectNameAndKey,
+    ) -> Result<()> {
         #[cfg(feature = "revocation")]
         {
             if !self.keep_entries_in_memory {
@@ -429,13 +449,21 @@ impl CrlSource for CrlSourceFolders {
                 Some(nu) => nu,
                 None => return Ok(()),
             };
+            // The kept entries are bound to the key that verified the CRL; with no encodable SPKI
+            // there is nothing sound to bind to, so decline to keep.
+            let verifier_spki = match verifier.spki().to_der() {
+                Ok(spki) => spki,
+                Err(_e) => return Ok(()),
+            };
             let serials = match build_kept_serials(crl, &info) {
                 Some(serials) => serials,
                 None => return Ok(()),
             };
-            let key = crl_key(&info);
+            let key = crl_key(&info, &verifier_spki);
             let mut inner = self.inner.write().map_err(|_| Error::Unrecognized)?;
             // Latest-verified wins so a reissued CRL replaces stale serials for the same scope.
+            // Replacement only ever compares CRLs verified by the same key, since the key is part
+            // of the slot identity.
             let fresher = inner
                 .kept
                 .get(&key)
@@ -444,6 +472,7 @@ impl CrlSource for CrlSourceFolders {
                 inner.kept.insert(
                     key,
                     KeptCrl {
+                        this_update: info.this_update,
                         next_update,
                         serials,
                     },
@@ -662,13 +691,25 @@ fn index_crls_internal(
     Ok(crl_info.len() - initial_count)
 }
 
+/// Hex SHA-256 of the issuer's DER-encoded SPKI, used to key cached determinations to the issuing
+/// key. None when the SPKI cannot be encoded, in which case there is nothing sound to key on.
+fn issuer_spki_hash_hex(issuer: &dyn SubjectNameAndKey) -> Option<String> {
+    let spki = issuer.spki().to_der().ok()?;
+    Some(buffer_to_hex(Sha256::digest(&spki).to_vec().as_slice()))
+}
+
 impl RevocationStatusCache for RevocationCache {
     fn get_status(
         &self,
         cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
         time_of_interest: TimeOfInterest,
     ) -> PathValidationStatus {
         let name = name_to_string(cert.decoded().tbs_certificate().issuer());
+        let issuer_key = match issuer_spki_hash_hex(issuer) {
+            Some(hash) => hash,
+            None => return RevocationStatusNotDetermined,
+        };
         let serial = buffer_to_hex(cert.decoded().tbs_certificate().serial_number().as_bytes());
 
         let cache_map = if let Ok(c) = self.cache_map.read() {
@@ -676,18 +717,24 @@ impl RevocationStatusCache for RevocationCache {
         } else {
             return RevocationStatusNotDetermined;
         };
-        let key = (name, serial);
+        let key = (name, issuer_key, serial);
         if cache_map.contains_key(&key) {
             let status_and_time = &cache_map[&key];
             if status_and_time.time > time_of_interest.as_unix_secs() {
-                info!("Serviced revocation status check for certificate with serial number {} issued by {} from cache", key.1, key.0);
+                info!("Serviced revocation status check for certificate with serial number {} issued by {} from cache", key.2, key.0);
                 return status_and_time.status;
             }
         }
 
         RevocationStatusNotDetermined
     }
-    fn add_status(&self, cert: &PDVCertificate, next_update: u64, status: PathValidationStatus) {
+    fn add_status(
+        &self,
+        cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
+        next_update: u64,
+        status: PathValidationStatus,
+    ) {
         if status != PathValidationStatus::Valid
             && status != PathValidationStatus::CertificateRevoked
         {
@@ -695,8 +742,12 @@ impl RevocationStatusCache for RevocationCache {
         }
 
         let name = name_to_string(cert.decoded().tbs_certificate().issuer());
+        let issuer_key = match issuer_spki_hash_hex(issuer) {
+            Some(hash) => hash,
+            None => return,
+        };
         let serial = buffer_to_hex(cert.decoded().tbs_certificate().serial_number().as_bytes());
-        let key = (name, serial);
+        let key = (name, issuer_key, serial);
 
         let mut cache_map = if let Ok(g) = self.cache_map.write() {
             g
@@ -710,11 +761,11 @@ impl RevocationStatusCache for RevocationCache {
         if cache_map.contains_key(&key) {
             let old_status_and_time = &cache_map[&key];
             if old_status_and_time.time < next_update {
-                debug!("Updating entry in revocation status check for certificate with serial number {} issued by {} in cache", key.1, key.0);
+                debug!("Updating entry in revocation status check for certificate with serial number {} issued by {} in cache", key.2, key.0);
                 cache_map.insert(key, status_and_time);
             }
         } else {
-            debug!("Adding entry to revocation status check for certificate with serial number {} issued by {} to cache", key.1, key.0);
+            debug!("Adding entry to revocation status check for certificate with serial number {} issued by {} to cache", key.2, key.0);
             cache_map.insert(key, status_and_time);
         }
     }
@@ -730,10 +781,20 @@ impl RevocationStatusCache for CrlSourceFolders {
     fn get_status(
         &self,
         cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
         time_of_interest: TimeOfInterest,
     ) -> PathValidationStatus {
         #[cfg(feature = "revocation")]
         {
+            // The kept slot is keyed by the SPKI that verified the CRL; look it up with the SPKI
+            // that would verify a CRL for this certificate (its issuer on the current path). A CRL
+            // verified by a different key than the one that issued the certificate can therefore
+            // never answer for it, no matter how its names line up — the miss falls through to full
+            // processing, which settles matters with a signature check.
+            let verifier_spki = match issuer.spki().to_der() {
+                Ok(spki) => spki,
+                Err(_e) => return RevocationStatusNotDetermined,
+            };
             if let Ok(inner) = self.inner.read() {
                 let serial = cert
                     .decoded()
@@ -746,12 +807,14 @@ impl RevocationStatusCache for CrlSourceFolders {
                         Some(info) => info,
                         None => continue,
                     };
-                    let kept = match inner.kept.get(&crl_key(info)) {
+                    let kept = match inner.kept.get(&crl_key(info, &verifier_spki)) {
                         Some(kept) => kept,
                         None => continue,
                     };
-                    // Freshness against the kept entry's own nextUpdate (fresh iff nextUpdate > toi).
-                    if kept.next_update <= time_of_interest.as_unix_secs() {
+                    // Freshness mirrors check_crl_validity in both directions: the time of interest
+                    // must fall within the kept CRL's thisUpdate/nextUpdate window.
+                    let toi_secs = time_of_interest.as_unix_secs();
+                    if kept.this_update > toi_secs || kept.next_update <= toi_secs {
                         continue;
                     }
                     if crl_covers_cert(cert, info).is_err() {
@@ -768,9 +831,15 @@ impl RevocationStatusCache for CrlSourceFolders {
         RevocationStatusNotDetermined
     }
 
-    // Nothing to record: this store answers only from kept CRLs. Determinations are memoized by a
+    // Nothing to record: this store answers only from kept CRLs. Determinations are cached by a
     // separately-registered RevocationStatusCache (e.g. RevocationCache).
-    fn add_status(&self, _cert: &PDVCertificate, _next_update: u64, _status: PathValidationStatus) {
+    fn add_status(
+        &self,
+        _cert: &PDVCertificate,
+        _issuer: &dyn SubjectNameAndKey,
+        _next_update: u64,
+        _status: PathValidationStatus,
+    ) {
     }
 }
 
@@ -789,8 +858,13 @@ impl CrlSource for Arc<CrlSourceFolders> {
     fn add_crl(&self, crl_buf: &[u8], crl: &CertificateList<Raw>, uri: &str) -> Result<()> {
         (**self).add_crl(crl_buf, crl, uri)
     }
-    fn keep_verified_crl(&self, crl_buf: &[u8], crl: &CertificateList<Raw>) -> Result<()> {
-        (**self).keep_verified_crl(crl_buf, crl)
+    fn keep_verified_crl(
+        &self,
+        crl_buf: &[u8],
+        crl: &CertificateList<Raw>,
+        verifier: &dyn SubjectNameAndKey,
+    ) -> Result<()> {
+        (**self).keep_verified_crl(crl_buf, crl, verifier)
     }
 }
 
@@ -798,12 +872,19 @@ impl RevocationStatusCache for Arc<CrlSourceFolders> {
     fn get_status(
         &self,
         cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
         time_of_interest: TimeOfInterest,
     ) -> PathValidationStatus {
-        (**self).get_status(cert, time_of_interest)
+        (**self).get_status(cert, issuer, time_of_interest)
     }
-    fn add_status(&self, cert: &PDVCertificate, next_update: u64, status: PathValidationStatus) {
-        (**self).add_status(cert, next_update, status)
+    fn add_status(
+        &self,
+        cert: &PDVCertificate,
+        issuer: &dyn SubjectNameAndKey,
+        next_update: u64,
+        status: PathValidationStatus,
+    ) {
+        (**self).add_status(cert, issuer, next_update, status)
     }
 }
 

--- a/certval/tests/path_validator.rs
+++ b/certval/tests/path_validator.rs
@@ -182,7 +182,12 @@ fn get_trust_anchors_merges_all_sources() {
 
 #[test]
 fn denies_self_signed_ee() {
+    // This test deliberately drives the forbid_self_signed_ee guard, which the library correctly
+    // reports at ERROR. Suppress log output for the duration so the induced error does not clutter
+    // otherwise-quiet test output; no assertion depends on logging.
     let _ = pretty_env_logger::try_init();
+    let prev_log_level = log::max_level();
+    log::set_max_level(log::LevelFilter::Off);
 
     let time_of_interest: TimeOfInterest = TimeOfInterest::from_unix_secs(1707264000).unwrap();
     let mut pe = PkiEnvironment::default();
@@ -212,6 +217,7 @@ fn denies_self_signed_ee() {
     // not failed for some incidental reason that would mask a regression in the guard.
     let mut cpr = CertificationPathResults::new();
     let r = validate_path_rfc5280(&pe, &cps, &mut cert_path, &mut cpr);
+    log::set_max_level(prev_log_level);
     assert!(
         matches!(
             r,

--- a/certval/tests/revocation.rs
+++ b/certval/tests/revocation.rs
@@ -251,6 +251,8 @@ async fn cached_crl_async() {
 // retained in memory so get_status answers subsequent certificates straight from the sorted
 // serials, sustaining the RevocationStatusCache without a per-certificate memo entry. The memo
 // (cache_map) is never populated here, so a Valid result can only come from the kept serials.
+// Kept entries are bound to the SPKI that verified the CRL: a lookup on behalf of an issuer with
+// a different key (e.g. a same-name CA across a key rollover) must miss and abstain.
 #[cfg(all(feature = "revocation", feature = "std", feature = "rsa"))]
 #[test]
 fn keep_entries_in_memory_sustains_revocation_cache() {
@@ -263,6 +265,17 @@ fn keep_entries_in_memory_sustains_revocation_cache() {
     let mut ee = PDVCertificate::try_from(der_encoded_ee.as_slice()).unwrap();
     ee.parse_extensions(EXTS_OF_INTEREST);
 
+    // The CA that issued the EE and signed the CRLs: the issuer process_crl would have verified
+    // the CRL against before offering it for retention.
+    let der_encoded_ca = include_bytes!("examples/makaan.com/1.der");
+    let ca = PDVCertificate::try_from(der_encoded_ca.as_slice()).unwrap();
+    let issuer: &dyn SubjectNameAndKey = ca.decoded();
+
+    // A different subject with a different key, standing in for a wrong-key issuer.
+    let der_encoded_ta = include_bytes!("examples/makaan.com/0-ta.der");
+    let ta = PDVCertificate::try_from(der_encoded_ta.as_slice()).unwrap();
+    let wrong_issuer: &dyn SubjectNameAndKey = ta.decoded();
+
     let mut d = PathBuf::from(env!("CARGO_MANIFEST_DIR"));
     d.push("tests/examples/makaan.com/crls");
     let folder = d.as_path().to_str().unwrap();
@@ -272,7 +285,7 @@ fn keep_entries_in_memory_sustains_revocation_cache() {
     let plain = CrlSourceFolders::with_options(folder, false);
     plain.index_crls(toi).unwrap();
     assert_eq!(
-        plain.get_status(&ee, toi),
+        plain.get_status(&ee, issuer, toi),
         PathValidationStatus::RevocationStatusNotDetermined
     );
 
@@ -280,7 +293,7 @@ fn keep_entries_in_memory_sustains_revocation_cache() {
     let store = CrlSourceFolders::with_options(folder, true);
     store.index_crls(toi).unwrap();
     assert_eq!(
-        store.get_status(&ee, toi),
+        store.get_status(&ee, issuer, toi),
         PathValidationStatus::RevocationStatusNotDetermined,
         "must not answer before a CRL is verified and kept"
     );
@@ -289,12 +302,20 @@ fn keep_entries_in_memory_sustains_revocation_cache() {
     assert_eq!(1, crls.len());
     let crl = CertificateList::<Raw>::from_der(&crls[0]).unwrap();
     // Stand in for the post-verify call process_crl makes.
-    store.keep_verified_crl(&crls[0], &crl).unwrap();
+    store.keep_verified_crl(&crls[0], &crl, issuer).unwrap();
 
     assert_eq!(
-        store.get_status(&ee, toi),
+        store.get_status(&ee, issuer, toi),
         PathValidationStatus::Valid,
         "EE (not revoked) must be answered from the kept serials"
+    );
+
+    // Same certificate, same kept CRL, but on behalf of an issuer with a different key: the kept
+    // entries must not answer (name-only matching would wrongly return Valid here).
+    assert_eq!(
+        store.get_status(&ee, wrong_issuer, toi),
+        PathValidationStatus::RevocationStatusNotDetermined,
+        "kept serials must be bound to the key that verified the CRL"
     );
 }
 


### PR DESCRIPTION
- Store thisUpdate/nextUpdate to support time of interest in the past queries
- Store CRL issuer's key (in addition to issuer name and IDP) to distinguish between key rollover keys. Changed the RevocationStatusCache trait and CrlSource::keep_verified_crl interfaces to align with this change (revocation status should only be checked for a valid certification path, so issuer is expected to be available). Kept entries are populated under the key that verified the CRL and consulted under the key that would verify for the current path (a mismatch goes through full CRL processing).
- Key the RevocationCache map by issuer SPKI hash as well, for the same reason
- Check CRL validity before offering a CRL for in-memory retention so stale or future-dated CRLs are never retained
- Make the revocation module present without the revocation feature (SubjectNameAndKey is referenced by always-compiled traits); the CRL/OCSP machinery within remains gated