### PR TITLE
Improve diagnostic feedback when no certification paths are found and two other changes

### DIFF
--- a/certval/src/builder/file_utils.rs
+++ b/certval/src/builder/file_utils.rs
@@ -134,18 +134,21 @@ fn cert_or_ta_folder_to_vec(
                         // make sure it parses before saving buffer; a rejected object skips only
                         // itself, not the rest of a bundle.
                         if collect_tas {
-                            let r = TrustAnchorChoice::<Raw>::from_der(buffer.as_slice());
-                            if let Ok(TrustAnchorChoice::Certificate(cert)) = r {
-                                let r =
-                                    valid_at_time(cert.tbs_certificate(), time_of_interest, true);
-                                if let Err(_e) = r {
-                                    error!(
-                                        "Ignored an object in {} as not valid at indicated time of interest",
-                                        path.to_str().unwrap_or("")
-                                    );
-                                    continue;
-                                }
-                            } else {
+                            // Every TrustAnchorChoice alternative is a trust anchor here, not only
+                            // the Certificate one: an RFC 5914 TrustAnchorInfo is how trust anchor
+                            // constraints are expressed, which is most of the reason to hold anchors
+                            // in this form at all, and .ta is an accepted extension for exactly that
+                            // material. An anchor asserting no validity period (Ok(None)) is kept --
+                            // there is nothing to check, which is not the same as failing a check.
+                            let ta = match TrustAnchorChoice::<Raw>::from_der(buffer.as_slice()) {
+                                Ok(ta) => ta,
+                                Err(_e) => continue,
+                            };
+                            if ta_valid_at_time(&ta, time_of_interest, true).is_err() {
+                                error!(
+                                    "Ignored an object in {} as not valid at indicated time of interest",
+                                    path.to_str().unwrap_or("")
+                                );
                                 continue;
                             }
                         } else {
@@ -299,6 +302,39 @@ pub fn get_file_as_der_certs_pem(filename: &Path) -> Result<Vec<Vec<u8>>> {
     decode_pem_to_ders(&b).inspect_err(|e| {
         error!("Failed to PEM decode data from {filename:?}: {e:?}");
     })
+}
+
+// An RFC 5914 TrustAnchorInfo is a trust anchor, and is the form that carries trust anchor
+// constraints, so a folder of .ta files must load as anchors. It previously loaded as nothing: only
+// the Certificate alternative was accepted, and everything else was skipped without a word.
+#[test]
+fn loads_rfc5914_trust_anchors() {
+    let pe = PkiEnvironment::default();
+    let mut tasvec = TaSource::new();
+    let toi = TimeOfInterest::from_unix_secs(1647264981).unwrap();
+    let n = cert_or_ta_folder_to_vec(
+        &pe,
+        "tests/examples/PKITS_data_2048/5914_tas",
+        &mut tasvec,
+        toi,
+        true,
+    )
+    .unwrap();
+    assert!(n > 0);
+    assert!(tasvec.initialize().is_ok());
+
+    // the same folder read as certificates yields nothing, i.e., these are TaInfo objects rather
+    // than certificates that happen to parse either way
+    let mut certsvec = CertSource::default();
+    let n = cert_or_ta_folder_to_vec(
+        &pe,
+        "tests/examples/PKITS_data_2048/5914_tas",
+        &mut certsvec,
+        toi,
+        false,
+    )
+    .unwrap();
+    assert_eq!(0, n);
 }
 
 #[test]

--- a/certval/src/util/pdv_utilities.rs
+++ b/certval/src/util/pdv_utilities.rs
@@ -813,26 +813,38 @@ pub fn get_leaf_rdn(name: &Name) -> String {
     rdn.map(|r| r.to_string()).unwrap_or_default()
 }
 
-/// ta_valid_at_time checks the validity of the given trust anchor relative to the given time of interest.
+/// ta_valid_at_time checks the validity of the given trust anchor relative to the given time of
+/// interest.
+///
+/// Trust anchors need not assert a validity period: an RFC 5914 [`TrustAnchorInfo`] carrying no
+/// certificate (a name and public key, as a webpki-roots anchor is expressed) has none to check.
+/// That is not the same as failing the check, so the three outcomes are distinct:
+///
+/// - `Ok(Some(ttl))` — a validity period is present and covers `toi`, with the seconds remaining
+/// - `Ok(None)` — the anchor asserts no validity period, so there is nothing to enforce
+/// - `Err(Error::PathValidation(_))` — a validity period is present and `toi` falls outside it
+///
+/// [`TrustAnchorInfo`]: x509_cert::anchor::TrustAnchorInfo
 pub fn ta_valid_at_time(
     ta: &TrustAnchorChoice<Raw>,
     toi: TimeOfInterest,
     stifle_log: bool,
-) -> Result<u64> {
+) -> Result<Option<u64>> {
     match ta {
         TrustAnchorChoice::Certificate(c) => {
-            return valid_at_time(c.tbs_certificate(), toi, stifle_log);
+            valid_at_time(c.tbs_certificate(), toi, stifle_log).map(Some)
         }
-        TrustAnchorChoice::TaInfo(tai) => {
-            if let Some(cp) = &tai.cert_path {
-                if let Some(c) = &cp.certificate {
-                    return valid_at_time(c.tbs_certificate(), toi, stifle_log);
-                }
-            }
-        }
-        _ => {}
+        // The tbsCert alternative carries a validity like any certificate does
+        TrustAnchorChoice::TbsCertificate(tbs) => valid_at_time(tbs, toi, stifle_log).map(Some),
+        TrustAnchorChoice::TaInfo(tai) => match tai
+            .cert_path
+            .as_ref()
+            .and_then(|cp| cp.certificate.as_ref())
+        {
+            Some(c) => valid_at_time(c.tbs_certificate(), toi, stifle_log).map(Some),
+            None => Ok(None),
+        },
     }
-    Err(Error::Unrecognized)
 }
 
 pub(crate) fn general_subtree_to_string(gs: &GeneralSubtree) -> String {
@@ -1341,4 +1353,50 @@ fn descended_from_dn_ignores_insignificant_whitespace() {
     // a genuine difference is still outside the subtree
     let other = Name::from_str("O=Acme Corps").unwrap();
     assert!(!descended_from_dn(&subtree, &other, 0, None));
+}
+
+// A trust anchor that asserts no validity period is not an invalid trust anchor. The distinction is
+// load-bearing in three places: path validation must not fail such a path, the folder loader must
+// not skip such a file, and pittv3's --ta-cleanup deletes or moves what it rejects, so conflating
+// the two would destroy exactly the anchors that carry only a name and a public key.
+#[cfg(feature = "std")]
+#[test]
+fn ta_validity_distinguishes_absent_from_failed() {
+    use der::{Decode, Encode};
+    use x509_cert::anchor::TrustAnchorInfo;
+    use x509_cert::certificate::CertificateInner;
+
+    let der =
+        include_bytes!("../../tests/examples/PKITS_data_2048/certs/TrustAnchorRootCertificate.crt");
+    let ta = TrustAnchorChoice::<Raw>::from_der(der).unwrap();
+    assert!(matches!(ta, TrustAnchorChoice::Certificate(_)));
+
+    // a certificate anchor inside its validity reports the time it has left
+    let toi = TimeOfInterest::from_unix_secs(1647264981).unwrap();
+    assert!(matches!(ta_valid_at_time(&ta, toi, true), Ok(Some(_))));
+
+    // and outside it, a validity failure -- not merely "no answer"
+    let expired = TimeOfInterest::from_unix_secs(1930000000).unwrap();
+    assert!(matches!(
+        ta_valid_at_time(&ta, expired, true),
+        Err(Error::PathValidation(
+            PathValidationStatus::InvalidNotAfterDate
+        ))
+    ));
+
+    // an RFC 5914 anchor carrying a key but no certificate has nothing to check, at any time
+    let cert = CertificateInner::<Raw>::from_der(der).unwrap();
+    let tai: TrustAnchorInfo<Raw> = TrustAnchorInfo {
+        version: Default::default(),
+        pub_key: cert.tbs_certificate().subject_public_key_info().clone(),
+        key_id: der::asn1::OctetString::new(&[0x01, 0x02, 0x03][..]).unwrap(),
+        ta_title: None,
+        cert_path: None,
+        extensions: None,
+        ta_title_lang_tag: None,
+    };
+    let bytes = TrustAnchorChoice::TaInfo(tai).to_der().unwrap();
+    let no_validity = TrustAnchorChoice::<Raw>::from_der(&bytes).unwrap();
+    assert_eq!(Ok(None), ta_valid_at_time(&no_validity, toi, true));
+    assert_eq!(Ok(None), ta_valid_at_time(&no_validity, expired, true));
 }

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -274,14 +274,14 @@ pub fn check_validity(
     }
 
     if cps.get_enforce_trust_anchor_validity() {
-        // Check TA validity if feature is on (it's on by default) but if the TA does not feature a
-        // validity, i.e., if it's a TrustAnchorInfo without an embedded certificate (e.g. a
-        // webpki-roots trust anchor, which carries only name + SPKI), there is no validity period
-        // to enforce — carry on rather than failing the path. `ta_valid_at_time` signals this with
-        // `Error::Unrecognized`; only a real `PathValidation` status is a validity failure.
+        // Check TA validity if the feature is on (it's on by default). A trust anchor that asserts
+        // no validity period, i.e., a TrustAnchorInfo without an embedded certificate (e.g. a
+        // webpki-roots trust anchor, which carries only name + SPKI), has nothing to enforce and
+        // yields Ok(None) — a distinct outcome from failing the check, and not a path failure.
         match ta_valid_at_time(&cp.trust_anchor.decoded_ta, toi, false) {
-            Err(Error::Unrecognized) => {}
-            ta_ttl => is_valid(ta_ttl, 0)?,
+            Ok(None) => {}
+            Ok(Some(ttl)) => is_valid(Ok(ttl), 0)?,
+            Err(e) => is_valid(Err(e), 0)?,
         }
     }
 

--- a/pittv3-gui-lib/assets/pittv3.css
+++ b/pittv3-gui-lib/assets/pittv3.css
@@ -193,6 +193,15 @@ button[type="submit"] {
   margin: 0.2rem 0 0.4rem 0;
 }
 
+/* Why a target found no paths. Muted rather than red: this describes the run's inputs, not a
+   defect in the certificate, and long distinguished names appear inline. */
+.no-paths-hints {
+  color: var(--muted);
+  margin: 0.2rem 0 0.4rem 0;
+  padding-left: 1.2rem;
+  overflow-wrap: anywhere;
+}
+
 .cert-table th {
   text-align: left;
   border-bottom: 1px solid var(--border);

--- a/pittv3-gui-lib/src/gui_help.rs
+++ b/pittv3-gui-lib/src/gui_help.rs
@@ -31,7 +31,8 @@ pub fn HelpView() -> Element {
                 li {
                     "Select the certificate to validate (End Entity File) or a folder of "
                     "certificates (End Entity Folder), then run. Results appear in the Results "
-                    "view with one card per target."
+                    "view, one expandable entry per certificate validated, showing its status and "
+                    "the paths considered for it."
                 }
             }
 
@@ -58,8 +59,10 @@ pub fn HelpView() -> Element {
                 }
                 li {
                     strong { "No paths found" }
-                    " — the builder could not connect the target to any trust anchor; check the "
-                    "trust anchor selection and intermediate store."
+                    " — the builder could not connect the target to any trust anchor. The result "
+                    "lists what was missing: whether any trust anchor was loaded, whether any "
+                    "loaded certificate has the target's issuer name, and whether the target is "
+                    "within its validity period at the time of interest."
                 }
             }
 
@@ -102,10 +105,13 @@ pub fn HelpView() -> Element {
             h2 { "FAQ" }
             p { strong { "Why did my run report no paths found?" } }
             p {
-                "The most common causes: the trust anchor folder does not contain the root that "
-                "issued the chain, the CBOR store lacks the needed intermediates (regenerate it "
-                "or enable Dynamic Build), or the certificates are not valid at the selected "
-                "time of interest."
+                "Expand that certificate's entry in the Results view: the reasons are listed "
+                "there, beneath its status. The most common causes: the "
+                "trust anchor folder does not contain the root that issued the chain, the CBOR "
+                "store lacks the needed intermediates (regenerate it or enable Dynamic Build), or "
+                "the certificates are not valid at the selected time of interest. Note that a CA "
+                "folder on its own is a generate-time input: it populates a CBOR store, and path "
+                "building reads the store."
             }
             p { strong { "What does the time of interest do?" } }
             p {

--- a/pittv3-gui-lib/src/gui_results.rs
+++ b/pittv3-gui-lib/src/gui_results.rs
@@ -264,6 +264,15 @@ pub fn TargetCard(target: TargetReport, #[props(default)] open: bool) -> Element
                     "No certification paths were processed for this target."
                 }
             }
+            // A zero-path outcome describes the run's inputs rather than the certificate, so the
+            // reasons belong on the card itself: there is no path row for them to hang off.
+            if !target.no_paths_hints.is_empty() {
+                ul { class: "no-paths-hints",
+                    for hint in target.no_paths_hints.iter() {
+                        li { "{hint}" }
+                    }
+                }
+            }
             for (i , path) in target.paths.iter().enumerate() {
                 PathDetail { path: path.clone(), path_index: i }
             }

--- a/pittv3-lib/src/no_std_utils.rs
+++ b/pittv3-lib/src/no_std_utils.rs
@@ -2,7 +2,7 @@
 
 #![cfg(any(not(feature = "std"), doc))]
 
-use crate::{stats::PathValidationStats, Pittv3Args};
+use crate::{report::NoPathsContext, stats::PathValidationStats, Pittv3Args};
 use certval::*;
 use log::{error, info};
 
@@ -31,6 +31,12 @@ pub(crate) fn validate_cert(
 
     stats.files_processed += 1;
 
+    // Same diagnosis as the std build, from the same feature-free helper. The trust material here is
+    // compiled in rather than read from folders, so the causes are narrower -- but "which piece is
+    // missing" is exactly as opaque from a zero, and there is no filesystem to go rummage through.
+    // Chasing is None: a no-std build has no fetching to suggest.
+    let diagnose = || NoPathsContext::collect(pe, &target_cert, time_of_interest, None).hints();
+
     let mut paths: Vec<CertificationPath> = vec![];
     let r = pe.get_paths_for_target(&target_cert, &mut paths, 0, time_of_interest);
     if let Err(e) = r {
@@ -38,13 +44,18 @@ pub(crate) fn validate_cert(
             "Failed to find certification paths for target with error {:?}",
             e
         );
+        stats.no_paths_hints = diagnose();
         return Err(Error::Unrecognized);
     }
 
     if paths.is_empty() {
         info!("Failed to find any certification paths for target",);
+        stats.no_paths_hints = diagnose();
         return Err(Error::Unrecognized);
     }
+
+    // a path was found, so an earlier diagnosis for this target is stale
+    stats.no_paths_hints.clear();
 
     // the index is only consumed by the std_app log_path call below
     #[allow(clippy::unused_enumerate_index)]

--- a/pittv3-lib/src/options_no_std.rs
+++ b/pittv3-lib/src/options_no_std.rs
@@ -155,6 +155,13 @@ pub fn options_no_std(args: &Pittv3Args) {
         totals.valid_paths_per_target += s.valid_paths_per_target;
         totals.invalid_paths_per_target += s.invalid_paths_per_target;
 
+        // say why the count is zero, where the count is reported
+        if 0 == s.paths_per_target {
+            for hint in &s.no_paths_hints {
+                info!("\t * {}", hint);
+            }
+        }
+
         if 0 < s.paths_per_target {
             info!("\t * Status codes");
             let ec = &error_counts[k];

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -189,6 +189,26 @@ use crate::std_utils::*;
 #[cfg(feature = "sha1_sig")]
 use crate::sha1_sig::verify_signature_message_rust_crypto_sha1;
 
+/// Added to the no-paths diagnosis when the run was given a CA folder and nothing to do with it.
+/// Named here because it is reported twice: once in the run log beside the zero count, and once in
+/// the structured report for a frontend to display.
+/// Added to the no-paths diagnosis, and logged where the folder is read, when a trust anchor folder
+/// was supplied and yielded nothing. The filtering happens quietly in `ta_folder_to_vec`, which
+/// returns `Ok(0)` for a folder it emptied — indistinguishable from no folder at all by the time the
+/// environment is queried. Note the validity filter there is not governed by
+/// `PS_ENFORCE_TRUST_ANCHOR_VALIDITY`: that setting applies during path validation, where it also
+/// (correctly) passes an anchor that asserts no validity to enforce.
+const TA_FOLDER_EMPTY: &str =
+    "A trust anchor folder was supplied but no anchor was read from it: objects that do not parse \
+     as a trust anchor, or that are expired at the time of interest, are dropped when the folder \
+     is read.";
+
+const CA_FOLDER_INCOMPLETE: &str =
+    "A CA folder was supplied but no CBOR store: the CA folder is a generate-time input and \
+     contributes nothing to path building on its own. Generate a store from it first \
+     (--generate --cbor <file>), then validate against that store, or turn on dynamic building \
+     (--dynamic-build) to fetch issuers as needed.";
+
 /// Normalizes a PEM block so its base64 body is wrapped at the 64 columns that RFC 7468 (and the
 /// strict `pem-rfc7468` decoder) requires. Some CCADB CSV exports wrap the certificate PEM at a
 /// non-standard width (e.g. 65 columns), which the strict decoder rejects; re-wrapping lets those
@@ -794,6 +814,12 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
             println!("Failed to load trust anchors from {ta_folder} with error {e:?}");
             return ValidationReport::default();
         }
+        // A folder whose objects were all filtered returns Ok(0), which is otherwise indistinguishable
+        // from having supplied no folder at all — and is the loudest thing that can be said at the
+        // point where the anchors went missing.
+        if let Ok(0) = r {
+            error!("No trust anchors were loaded from {ta_folder}. {TA_FOLDER_EMPTY}");
+        }
         if let Err(e) = ta_store.initialize() {
             println!("Failed to initialize trust anchor source from {ta_folder} with error {e:?}");
             return ValidationReport::default();
@@ -1137,6 +1163,19 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         error_indices.insert(key, index_map);
     }
 
+    // The one cause a zero-path run cannot read off its own environment: a CA folder is a
+    // generate-time input, so supplying one without a store to write (or to read) leaves the graph
+    // empty while the user has every reason to believe they provided the intermediates.
+    #[cfg(feature = "remote")]
+    let dynamic_build = args.dynamic_build;
+    #[cfg(not(feature = "remote"))]
+    let dynamic_build = false;
+    let ca_folder_incomplete =
+        args.ca_folder.is_some() && args.cbor.is_none() && !args.generate && !dynamic_build;
+    // Distinguishes "no folder was given" from "the folder was given and nothing survived reading
+    // it", which the shared diagnosis cannot tell apart because both leave the environment empty
+    let ta_folder_empty = args.ta_folder.is_some() && pe.get_trust_anchors().is_empty();
+
     let mut totals = PathValidationStats::default();
     for k in stats.keys() {
         let s = &stats[k];
@@ -1144,6 +1183,19 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         info!("\t * Paths found: {}", s.paths_per_target);
         info!("\t * Valid paths found: {}", s.valid_paths_per_target);
         info!("\t * Invalid paths found: {}", s.invalid_paths_per_target);
+
+        // Say why the count is zero where the count is reported, not only in the structured report
+        if 0 == s.paths_per_target {
+            for hint in &s.no_paths_hints {
+                info!("\t * {hint}");
+            }
+            if !s.no_paths_hints.is_empty() && ta_folder_empty {
+                info!("\t * {TA_FOLDER_EMPTY}");
+            }
+            if !s.no_paths_hints.is_empty() && ca_folder_incomplete {
+                info!("\t * {CA_FOLDER_INCOMPLETE}");
+            }
+        }
         totals.paths_per_target += s.paths_per_target;
         totals.valid_paths_per_target += s.valid_paths_per_target;
         totals.invalid_paths_per_target += s.invalid_paths_per_target;
@@ -1187,7 +1239,18 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         let paths_found = s.paths_per_target > 0;
         let path_reports = core::mem::take(&mut s.path_reports);
         let status = TargetReport::compute_status(&path_reports, paths_found);
-        let target_summary = path_reports.iter().find_map(|p| p.certs.last().cloned());
+        let target_summary = s
+            .target_summary
+            .clone()
+            .or_else(|| path_reports.iter().find_map(|p| p.certs.last().cloned()));
+
+        let mut no_paths_hints = core::mem::take(&mut s.no_paths_hints);
+        if !no_paths_hints.is_empty() && ta_folder_empty {
+            no_paths_hints.push(TA_FOLDER_EMPTY.to_string());
+        }
+        if !no_paths_hints.is_empty() && ca_folder_incomplete {
+            no_paths_hints.push(CA_FOLDER_INCOMPLETE.to_string());
+        }
 
         report.totals.targets += 1;
         report.totals.paths_found += s.paths_per_target;
@@ -1199,6 +1262,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
             target: target_summary,
             status,
             paths: path_reports,
+            no_paths_hints,
         });
     }
     report

--- a/pittv3-lib/src/report.rs
+++ b/pittv3-lib/src/report.rs
@@ -16,9 +16,9 @@ use serde::{Deserialize, Serialize};
 
 use certval::{
     get_certificate_from_trust_anchor, name_constraints_set_to_name_constraints_settings,
-    name_to_string, source::ta_source::buffer_to_hex, CertificationPath, CertificationPathResults,
-    Error, NameConstraintsSet, NameConstraintsSettings, PDVCertificate, PDVTrustAnchorChoice,
-    PathValidationStatus,
+    name_to_string, source::ta_source::buffer_to_hex, valid_at_time, CertificationPath,
+    CertificationPathResults, Error, NameConstraintsSet, NameConstraintsSettings, PDVCertificate,
+    PDVTrustAnchorChoice, PathValidationStatus, PkiEnvironment, TimeOfInterest,
 };
 
 /// Summary details for one certificate (or trust anchor) in a certification path.
@@ -258,6 +258,157 @@ pub struct TargetReport {
     pub status: TargetStatus,
     /// Results for each certification path processed for the target
     pub paths: Vec<PathReport>,
+    /// Why no certification path was found, when the status is
+    /// [`NoPathsFound`](TargetStatus::NoPathsFound). Empty otherwise, and empty when the outcome
+    /// could not be attributed (a diagnosis is best-effort, never a substitute for the status).
+    /// See [`NoPathsContext`].
+    #[serde(default, skip_serializing_if = "Vec::is_empty")]
+    pub no_paths_hints: Vec<String>,
+}
+
+/// What the path builder had to work with, used to explain a zero-path outcome.
+///
+/// "No paths found" is the one outcome that says nothing about the certificate: it reports the
+/// absence of a result, and the cause is almost always in the run's inputs rather than in the
+/// target. This type collects the few facts that separate the causes — whether any trust anchor is
+/// loaded, whether any loaded certificate could even have issued the target, whether the target is
+/// within its validity period at the time of interest — so that [`hints`](NoPathsContext::hints)
+/// can say which one applies.
+///
+/// The facts come from the [`PkiEnvironment`] the run used, so the diagnosis reflects the material
+/// actually in play rather than what the caller believes it configured. That distinction is the
+/// point: the common cause is trust material a frontend accepted but never routed into path
+/// building.
+///
+/// The hints are deliberately free of any frontend's vocabulary — no flags, no field names — so
+/// the CLI, desktop and browser can all render them. A frontend that wants to name its own input
+/// appends its own line to [`TargetReport::no_paths_hints`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+pub struct NoPathsContext {
+    /// Number of trust anchors available to the run
+    pub trust_anchors: usize,
+    /// Number of intermediate CA certificates available to the run
+    pub intermediates: usize,
+    /// The target's issuer name, rendered for display
+    pub issuer_name: String,
+    /// Whether a trust anchor matches the target's issuer name
+    pub issuer_is_trust_anchor: bool,
+    /// Number of available certificates whose subject matches the target's issuer name, i.e., the
+    /// candidate issuers the builder had to work with
+    pub issuer_certs: usize,
+    /// Why the target is outside its validity period at the time of interest, when it is. Path
+    /// building excludes such certificates, so this alone explains a zero-path outcome.
+    pub target_invalid_at_toi: Option<String>,
+    /// Whether the frontend can chase AIA and SIA URIs to fetch missing issuers: `None` when it
+    /// cannot (so suggesting it would be noise), `Some(false)` when it can but the run did not, and
+    /// `Some(true)` when the run already did.
+    pub dynamic_build: Option<bool>,
+}
+
+impl NoPathsContext {
+    /// Collects the diagnosis inputs from the environment a run used. `toi` is the time of interest
+    /// the run validated against, expressed as it is in the settings.
+    pub fn collect(
+        pe: &PkiEnvironment,
+        target: &PDVCertificate,
+        toi: TimeOfInterest,
+        dynamic_build: Option<bool>,
+    ) -> NoPathsContext {
+        let issuer = target.decoded().tbs_certificate().issuer();
+        NoPathsContext {
+            trust_anchors: pe.get_trust_anchors().len(),
+            intermediates: pe.get_intermediates().map(|i| i.len()).unwrap_or_default(),
+            issuer_name: name_to_string(issuer),
+            issuer_is_trust_anchor: pe.get_trust_anchor_by_name(issuer).is_ok(),
+            issuer_certs: pe.get_cert_by_name(issuer).len(),
+            // stifle_log: the caller has already logged the failure to find a path, and this is a
+            // question about the target rather than a fresh error
+            target_invalid_at_toi: valid_at_time(target.decoded().tbs_certificate(), toi, true)
+                .err()
+                .map(|e| format!("{e:?}")),
+            dynamic_build,
+        }
+    }
+
+    /// Explains the zero-path outcome as one or more display-ready sentences, most specific first.
+    ///
+    /// Returns an empty vector when the facts do not distinguish a cause, which is why the caller
+    /// treats this as an addition to the status rather than a replacement for it.
+    pub fn hints(&self) -> Vec<String> {
+        let mut hints = vec![];
+
+        // Ordered as the builder fails: nothing to terminate at, then a target that cannot enter
+        // path building at all, then the gap between the target and the material on hand.
+        if 0 == self.trust_anchors {
+            // Deliberately says only what is true of every frontend. Why a supplied anchor did not
+            // survive loading depends on the source it came from, so the frontend that owns that
+            // source appends the explanation; this layer cannot know it.
+            hints.push(
+                "No trust anchors are loaded, so no certification path can terminate.".to_string(),
+            );
+        }
+
+        if let Some(reason) = &self.target_invalid_at_toi {
+            hints.push(format!(
+                "The target certificate is not valid at the time of interest ({reason}); \
+                 certificates outside their validity period are excluded from path building."
+            ));
+        }
+
+        // A missing issuer and a present-but-unusable issuer are different problems with different
+        // remedies, and reporting a bare zero conflates them.
+        let material_missing = if 0 == self.trust_anchors {
+            false
+        } else if self.issuer_is_trust_anchor {
+            hints.push(format!(
+                "A trust anchor matches the target's issuer name ({}), so the missing link is not \
+                 the issuer certificate: the anchor's key identifier or signature does not match \
+                 the target, or the anchor is not valid at the time of interest.",
+                self.issuer_name
+            ));
+            false
+        } else if 0 == self.intermediates {
+            hints.push(format!(
+                "No intermediate CA certificates are loaded and no trust anchor has subject {}, \
+                 the target's issuer.",
+                self.issuer_name
+            ));
+            true
+        } else if 0 == self.issuer_certs {
+            hints.push(format!(
+                "None of the {} loaded intermediate CA certificates has subject {}, the target's \
+                 issuer.",
+                self.intermediates, self.issuer_name
+            ));
+            true
+        } else {
+            hints.push(format!(
+                "{} loaded certificate(s) have subject {}, the target's issuer, but no chain from \
+                 any of them reaches a loaded trust anchor.",
+                self.issuer_certs, self.issuer_name
+            ));
+            true
+        };
+
+        // Only worth raising when the gap is material the builder could have fetched.
+        if material_missing {
+            match self.dynamic_build {
+                Some(false) => hints.push(
+                    "Chasing AIA and SIA URIs is off; enabling it lets the builder fetch the \
+                     missing certificates."
+                        .to_string(),
+                ),
+                Some(true) => hints.push(
+                    "Chasing AIA and SIA URIs was enabled and still produced no issuer, so the \
+                     missing certificates are not reachable from the URIs on hand."
+                        .to_string(),
+                ),
+                None => {}
+            }
+        }
+
+        hints
+    }
 }
 
 impl TargetReport {
@@ -631,6 +782,7 @@ mod tests {
                     }),
                     duration_ms: 12,
                 }],
+                no_paths_hints: vec![],
             }],
             totals: ReportTotals {
                 targets: 1,
@@ -667,6 +819,98 @@ mod tests {
         // Some(vec![]) survives the round trip, preserving "nothing permitted" vs. unconstrained
         assert_eq!(nc.excluded.directory_name, Some(vec![]));
         assert_eq!(round_tripped.totals, report.totals);
+    }
+
+    /// A context with material on hand, i.e., the shape where the diagnosis has to discriminate
+    fn ctx() -> NoPathsContext {
+        NoPathsContext {
+            trust_anchors: 3,
+            intermediates: 40,
+            issuer_name: "CN=Some CA".to_string(),
+            issuer_is_trust_anchor: false,
+            issuer_certs: 0,
+            target_invalid_at_toi: None,
+            dynamic_build: Some(false),
+        }
+    }
+
+    #[test]
+    fn no_paths_hints_name_the_missing_piece() {
+        // no anchors: nothing for a path to terminate at, and the issuer analysis is beside the
+        // point until that is fixed
+        let hints = NoPathsContext {
+            trust_anchors: 0,
+            intermediates: 0,
+            ..ctx()
+        }
+        .hints();
+        assert_eq!(hints.len(), 1);
+        assert!(hints[0].contains("No trust anchors are loaded"));
+
+        // anchors but an empty graph: the case a CA folder that was never compiled produces
+        let hints = NoPathsContext {
+            intermediates: 0,
+            ..ctx()
+        }
+        .hints();
+        assert!(hints[0].contains("No intermediate CA certificates are loaded"));
+        assert!(hints[0].contains("CN=Some CA"));
+        assert!(hints[1].contains("Chasing AIA and SIA URIs is off"));
+
+        // a populated graph that does not happen to contain the issuer
+        let hints = ctx().hints();
+        assert!(hints[0].contains("None of the 40 loaded intermediate CA certificates"));
+
+        // the issuer is present but nothing above it reaches an anchor, which is a different
+        // problem from the issuer being absent
+        let hints = NoPathsContext {
+            issuer_certs: 2,
+            ..ctx()
+        }
+        .hints();
+        assert!(hints[0].contains("2 loaded certificate(s) have subject"));
+        assert!(hints[0].contains("no chain from any of them reaches"));
+    }
+
+    #[test]
+    fn no_paths_hints_distinguish_target_and_anchor_problems() {
+        // an anchor issued the target, so no amount of extra material will help
+        let hints = NoPathsContext {
+            issuer_is_trust_anchor: true,
+            ..ctx()
+        }
+        .hints();
+        assert!(hints[0].contains("A trust anchor matches the target's issuer name"));
+        // fetching is not proposed: the material is present, it just does not fit
+        assert_eq!(hints.len(), 1);
+
+        // a target outside its validity period never enters path building at all
+        let hints = NoPathsContext {
+            target_invalid_at_toi: Some("PathValidation(InvalidNotAfterDate)".to_string()),
+            ..ctx()
+        }
+        .hints();
+        assert!(hints[0].contains("not valid at the time of interest"));
+        assert!(hints[0].contains("InvalidNotAfterDate"));
+    }
+
+    #[test]
+    fn no_paths_hints_respect_what_the_frontend_can_do() {
+        // None: a frontend that cannot fetch is not told to fetch
+        let hints = NoPathsContext {
+            dynamic_build: None,
+            ..ctx()
+        }
+        .hints();
+        assert_eq!(hints.len(), 1);
+
+        // already chasing: the remedy has been tried, so say that instead of suggesting it
+        let hints = NoPathsContext {
+            dynamic_build: Some(true),
+            ..ctx()
+        }
+        .hints();
+        assert!(hints[1].contains("was enabled and still produced no issuer"));
     }
 
     #[test]

--- a/pittv3-lib/src/stats.rs
+++ b/pittv3-lib/src/stats.rs
@@ -3,7 +3,7 @@
 use alloc::collections::BTreeMap;
 use certval::CertificationPathResults;
 
-use crate::report::PathReport;
+use crate::report::{CertSummary, PathReport};
 
 /// `PathValidationStats` enables collection of some basic statistics related to path validation.
 pub struct PathValidationStats {
@@ -22,6 +22,15 @@ pub struct PathValidationStats {
     pub results: Vec<CertificationPathResults>,
     /// Structured report for each certification path processed for the target
     pub path_reports: Vec<PathReport>,
+    /// Summary details for the target certificate. Recorded when the target is parsed so that a
+    /// target for which no path was found can still be named in the report; the path reports are
+    /// the only other source and they are empty in exactly that case.
+    pub target_summary: Option<CertSummary>,
+    /// Why no certification path was found for the target, when none was. Recorded where the
+    /// builder returns nothing, since the environment is fully populated there and is torn down
+    /// before the report is assembled. Cleared as soon as a path is found, so a diagnosis from an
+    /// early pass of the dynamic-building loop does not survive a later pass that succeeds.
+    pub no_paths_hints: Vec<String>,
 }
 
 impl Default for PathValidationStats {
@@ -42,6 +51,8 @@ impl PathValidationStats {
             target_is_revoked: false,
             results: vec![],
             path_reports: vec![],
+            target_summary: None,
+            no_paths_hints: vec![],
         }
     }
 }

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -20,7 +20,8 @@ use crate::pitt_log::*;
 use crate::{
     args::Pittv3Args,
     report::{
-        CertSummary, PathReport, ProgressEvent, ReportTotals, TargetReport, ValidationReport,
+        CertSummary, NoPathsContext, PathReport, ProgressEvent, ReportTotals, TargetReport,
+        ValidationReport,
     },
     stats::{PVStats, PathValidationStats, PathValidationStatsGroup},
 };
@@ -62,6 +63,20 @@ impl ValidateOpts {
             crls: vec![],
         }
     }
+}
+
+/// Whether chasing AIA and SIA URIs is a remedy worth suggesting when path building comes up empty,
+/// in the form [`NoPathsContext`] takes: `None` when the build cannot fetch at all, so proposing it
+/// would send the user after an option that does not exist.
+#[cfg(feature = "remote")]
+fn dynamic_build_state(opts: &ValidateOpts) -> Option<bool> {
+    Some(opts.dynamic_build)
+}
+
+/// Without the `remote` feature there is no fetching to enable, whatever the option says.
+#[cfg(not(feature = "remote"))]
+fn dynamic_build_state(_opts: &ValidateOpts) -> Option<bool> {
+    None
 }
 
 /// `staple_crls` staples caller-provided DER-encoded CRLs into a candidate certification path by
@@ -179,19 +194,42 @@ pub async fn validate_cert_bytes(
 
     let start2 = Instant::now();
     stats.files_processed += 1;
+    if stats.target_summary.is_none() {
+        stats.target_summary = Some(CertSummary::from_cert(&target_cert));
+    }
+
+    // Diagnose a zero-path outcome here rather than where the report is assembled: this is where
+    // the environment still holds the trust material, and where the target is parsed. Chasing is
+    // reported as available-but-off from `opts` because this entry point performs no fetching
+    // itself; the CLI's dynamic-building loop calls back in after each fetch, so the last pass
+    // leaves the diagnosis that reflects everything that was retrieved.
+    let diagnose = |pe: &PkiEnvironment| {
+        NoPathsContext::collect(
+            pe,
+            &target_cert,
+            time_of_interest,
+            dynamic_build_state(opts),
+        )
+        .hints()
+    };
 
     let mut paths: Vec<CertificationPath> = vec![];
     let r = pe.get_paths_for_target(&target_cert, &mut paths, threshold, time_of_interest);
     if let Err(e) = r {
         error!("Failed to find certification paths for target with error {e:?}");
+        stats.no_paths_hints = diagnose(pe);
         return Err(Error::Unrecognized);
     }
 
     if paths.is_empty() {
         collect_uris_from_aia_and_sia(&target_cert, fresh_uris);
         info!("Failed to find any certification paths for target",);
+        stats.no_paths_hints = diagnose(pe);
         return Err(Error::Unrecognized);
     }
+
+    // A path was found, so any diagnosis from an earlier pass of the dynamic-building loop is stale
+    stats.no_paths_hints.clear();
 
     for (i, path) in paths.iter_mut().enumerate() {
         info!(
@@ -382,6 +420,7 @@ pub async fn validate_targets(
             Ok(target_cert) => Some(CertSummary::from_cert(&target_cert)),
             Err(_e) => None,
         };
+        let no_paths_hints = core::mem::take(&mut stats_for_target.no_paths_hints);
 
         totals.targets += 1;
         totals.paths_found += paths_found;
@@ -393,6 +432,7 @@ pub async fn validate_targets(
             target: target_summary,
             status,
             paths: path_reports,
+            no_paths_hints,
         });
     }
 
@@ -666,6 +706,10 @@ pub fn cleanup_tas(
                     let mut delete_file = false;
                     match TrustAnchorChoice::from_der(target.as_slice()) {
                         Ok(ta) => {
+                            // Only a failed validity check condemns the file. An anchor that asserts
+                            // no validity period returns Ok(None) and must be kept: cleanup deletes
+                            // or moves what it rejects, so treating "nothing to check" as "expired"
+                            // would destroy every RFC 5914 anchor carrying only a name and key.
                             let r = ta_valid_at_time(&ta, t, true);
                             if r.is_err() {
                                 delete_file = true;

--- a/pittv3-lib/tests/validate_targets.rs
+++ b/pittv3-lib/tests/validate_targets.rs
@@ -151,6 +151,70 @@ fn validate_targets_report_shapes() {
     assert_eq!(round_tripped.targets[1].paths[0].failure_index, Some(2));
 }
 
+/// A zero-path outcome carries the reason, drawn from the environment the run actually used. The
+/// unit tests cover the phrasing of each branch; this covers the collection step, i.e., that the
+/// counts and the issuer lookup come back from a real `PkiEnvironment` as the diagnosis assumes.
+#[test]
+fn validate_targets_no_paths_are_explained() {
+    let flavor = "PKITS_data_p256/certs";
+    let mut cps = base_settings();
+    cps.set_check_revocation_status(false);
+
+    // the trust anchor is loaded but the intermediate that issued the target is not, so the
+    // builder has an anchor to aim at and no way to reach it
+    let mut pe = PkiEnvironment::default();
+    pe.populate_5280_pki_environment();
+    let mut ta_store = TaSource::new();
+    ta_store.push(CertFile {
+        filename: "TrustAnchorRootCertificate.crt".to_string(),
+        bytes: read_example(flavor, "TrustAnchorRootCertificate.crt"),
+    });
+    ta_store.initialize().unwrap();
+    pe.add_trust_anchor_source(Box::new(ta_store));
+
+    let targets = vec![(
+        "orphan".to_string(),
+        read_example(flavor, "ValidCertificatePathTest1EE.crt"),
+    )];
+
+    let report = tokio_test::block_on(validate_targets(
+        &pe,
+        &cps,
+        &targets,
+        &ValidateOpts::default(),
+        None,
+    ));
+
+    let target = &report.targets[0];
+    assert_eq!(target.status, TargetStatus::NoPathsFound);
+    // the target is still named, which is the other half of not reporting a bare zero
+    assert!(target.target.is_some());
+    assert!(!target.no_paths_hints.is_empty());
+    let hints = target.no_paths_hints.join(" ");
+    assert!(hints.contains("No intermediate CA certificates are loaded"));
+    // the diagnosis names the issuer it could not find rather than describing the gap in general
+    assert!(hints.contains("Good CA"));
+    // and it survives to a frontend by way of the serialized report
+    let json = serde_json::to_string(&report).unwrap();
+    let round_tripped: ValidationReport = serde_json::from_str(&json).unwrap();
+    assert_eq!(
+        round_tripped.targets[0].no_paths_hints,
+        target.no_paths_hints
+    );
+
+    // a target that does find a path carries no diagnosis
+    let pe = build_pe(flavor, &cps);
+    let report = tokio_test::block_on(validate_targets(
+        &pe,
+        &cps,
+        &targets,
+        &ValidateOpts::default(),
+        None,
+    ));
+    assert_eq!(report.targets[0].status, TargetStatus::Valid);
+    assert!(report.targets[0].no_paths_hints.is_empty());
+}
+
 #[cfg(feature = "revocation")]
 #[test]
 fn validate_targets_revocation_undetermined_rollup() {

--- a/pittv3-wasm/README.md
+++ b/pittv3-wasm/README.md
@@ -8,8 +8,12 @@ All processing occurs in the browser; certificates never leave the page.
 A hosted instance is available at <https://pittv3.redhoundsoftware.com>; no local build is required
 to try it.
 
-Trust anchor and CA certificate stores for several PKITS editions (ML-DSA-44, ML-DSA-65, ML-DSA-87
-and SLH-DSA-SHA2-128s) are baked into the application as CBOR. Trust anchors and intermediate CA
+Trust anchor and CA certificate stores are shipped as CBOR files in `resources/`, which Trunk
+copies into `dist/` and the app fetches by relative URL when a store is selected (rather than
+embedding them, which would be paid on every page load): an ML-DSA-44 PKITS edition, the Web PKI
+(Mozilla roots and CCADB intermediates) and U.S. DoD (NIPR). The two trust-community stores are
+regenerated from their provider crates by `build.rs`; see `resources/NOTICE` for what each artifact
+is, where it came from and the terms it travels under. Trust anchors and intermediate CA
 certificates can also be uploaded and are used together with the selected built-in store (or alone
 when no store is selected) to validate certificates from other sources, e.g., artifacts produced by
 other implementations during interoperability testing. Uploads and certificates to validate

--- a/pittv3-wasm/build.rs
+++ b/pittv3-wasm/build.rs
@@ -27,6 +27,10 @@ struct Artifact {
     ca: Option<&'static str>,
 }
 
+/// Adding an entry here adds a redistributed trust set to `dist/`, so it also
+/// wants a paragraph in `resources/NOTICE` — that file is the attribution for
+/// everything this build script writes, and for the Mozilla material it is the
+/// MPL-2.0 Exhibit A notice the CBOR itself cannot carry.
 fn artifacts() -> Vec<Artifact> {
     vec![
         Artifact {

--- a/pittv3-wasm/resources/NOTICE
+++ b/pittv3-wasm/resources/NOTICE
@@ -1,0 +1,85 @@
+PITTv3 WASM — trust material in resources/
+Third-party attribution
+
+The application itself is licensed Apache-2.0 OR MIT (see the repository
+README). The files in this directory are not application code: they are trust
+material generated from, or derived from, third-party sources, and some of it
+is redistributed under different terms. This file records what each artifact
+is, where it came from, and under what license it travels.
+
+The artifacts are binary CBOR and DER, so none of them can carry a license
+header in the file itself. As MPL-2.0 Exhibit A provides for, the notice is
+placed where a recipient would look for it instead. Trunk copies this whole
+directory verbatim into dist/ (index.html: rel="copy-dir"), so this file is
+published alongside the artifacts it describes and is fetched from the same
+URL prefix.
+
+The CBOR stores are regenerated from their provider crates by build.rs; only
+the ML-DSA-44 PKITS material below is a committed file with no provider.
+
+
+webpki_ta.cbor, webpki_ca.cbor — Mozilla Root Store / CCADB
+-----------------------------------------------------------
+
+This Source Code Form is subject to the terms of the Mozilla Public License,
+v. 2.0. If a copy of the MPL was not distributed with these files, You can
+obtain one at https://mozilla.org/MPL/2.0/.
+
+Generated from certval_stores_mozilla (MPL-2.0),
+https://github.com/carl-wallace/certval-stores-mozilla, which embeds trust
+material published by the Mozilla Foundation as part of the Mozilla Root Store
+and redistributes it under the same license Mozilla applies to that material
+in NSS. CCADB snapshot 2026-08-13.
+
+  webpki_ta.cbor
+    The 170 trust anchors of that crate's MOZILLA_ALL environment: every root
+    in the Mozilla Root Store carrying a websites or an email trust bit (172
+    included roots, less the two that carry neither). Source:
+    https://ccadb.my.salesforce-sites.com/mozilla/IncludedRootCertificateReportPEMCSV
+
+  webpki_ca.cbor
+    2,563 CCADB-disclosed intermediate CA certificates plus the partial
+    certification paths over them. Source, as a union of two reports:
+    https://ccadb.my.salesforce-sites.com/mozilla/PublicAllIntermediateCertsWithPEMCSV
+    https://ccadb.my.salesforce-sites.com/mozilla/MozillaIntermediateCertsCSVReport
+
+The individual root and intermediate certificates are the works of the
+certification authorities that issued them. Mozilla's contribution, and what
+these stores reproduce, is the selection of those certificates and the trust
+decisions recorded beside them.
+
+What these two files do NOT carry is Mozilla's out-of-band policy: the
+per-root trust bits (websites/email), any distrust-for-TLS-after date, and any
+Mozilla-applied name constraints live in the provider crate's metadata table
+and have no representation in a certval CBOR store. A path that validates
+against an anchor here has satisfied RFC 5280, which is not the same as the
+root being trusted by Mozilla for the purpose at hand.
+
+CCADB publishes its reports under its own data usage terms, which are separate
+from and additional to the MPL-2.0 terms above. See https://www.ccadb.org/.
+
+
+dod_nipr_prod_ta.cbor, dod_nipr_prod_ca.cbor — U.S. DoD PKI (NIPR)
+-------------------------------------------------------------------
+
+Generated from certval_stores_nipr (Apache-2.0 OR MIT),
+https://github.com/carl-wallace/certval-stores: the three production DoD
+roots (DoD Root CA 3, 5 and 6) and the 37 intermediate CAs beneath them, with
+one partial path each. The certificates are public artifacts of the U.S.
+Department of Defense PKI and are the works of the CAs that issued them.
+
+
+pkits_ml_dsa_44_ta.cbor, pkits_ml_dsa_44_ca.cbor,
+sample_valid_ml_dsa_44.der, sample_invalid_ml_dsa_44.der — PKITS, ML-DSA-44
+-----------------------------------------------------------------------------
+
+Test collateral, not trust material. Derived from the NIST Public Key
+Interoperability Test Suite (PKITS), a work of the U.S. Government published
+by NIST for interoperability testing, re-issued with ML-DSA-44 (FIPS 204) keys
+and signatures; the certificates keep the PKITS distinguished names ("Test
+Certificates 2011") and the PKITS 2010–2030 validity period, so the PKITS
+reference time of interest applies to them unchanged.
+
+The two sample end entity certificates are the PKITS 4.1 cases: the valid
+path test and the bad-end-entity-signature test. Nothing in this group is
+intended to be trusted for any purpose outside this application.

--- a/pittv3-wasm/src/validate.rs
+++ b/pittv3-wasm/src/validate.rs
@@ -29,8 +29,14 @@ pub const STORES: &[Store] = &[
         ta_url: "resources/pkits_ml_dsa_44_ta.cbor",
         ca_url: Some("resources/pkits_ml_dsa_44_ca.cbor"),
     },
+    // The anchors are the provider's MOZILLA_ALL environment — every root carrying a websites
+    // OR an email trust bit — so the anchor set does not gate purpose: a TLS certificate can
+    // validate here against a root Mozilla trusts only for S/MIME, and vice versa. The label
+    // says "TLS + S/MIME" for that reason. Judging the purpose means reading the trust bits
+    // Mozilla records beside each root, which are out-of-band policy that RFC 5280 processing
+    // cannot see and a certval CBOR store does not carry.
     Store {
-        label: "Web PKI (Mozilla roots + CCADB intermediates)",
+        label: "Web PKI (Mozilla roots, TLS + S/MIME, + CCADB intermediates)",
         ta_url: "resources/webpki_ta.cbor",
         // CCADB intermediate set with precomputed partial paths; AIA fallback (once the
         // fetch proxy lands) will cover anything not preloaded here

--- a/pittv3-wasm/src/validate.rs
+++ b/pittv3-wasm/src/validate.rs
@@ -3,7 +3,7 @@
 use std::io::{Cursor, Read};
 
 use certval::*;
-use pittv3_lib::report::{CertSummary, PathReport, TargetReport};
+use pittv3_lib::report::{CertSummary, NoPathsContext, PathReport, TargetReport};
 use serde::{Deserialize, Serialize};
 use web_time::Instant;
 
@@ -377,6 +377,28 @@ pub fn validate_prepared(
     (reports, out)
 }
 
+/// Reports a target for which the builder produced no candidate path, carrying the diagnosis of
+/// why. The environment is queried here rather than at display time because it holds the trust
+/// material the run actually used, which is the thing the answer turns on.
+///
+/// Chasing is reported as unavailable (`None`) rather than off: the browser build has no fetch path
+/// for AIA and SIA, so proposing it would name an option this frontend does not have.
+fn no_paths_report(
+    pe: &PkiEnvironment,
+    target: &PDVCertificate,
+    toi: TimeOfInterest,
+    ee_name: &str,
+    target_summary: CertSummary,
+) -> TargetReport {
+    TargetReport {
+        name: ee_name.to_string(),
+        target: Some(target_summary),
+        status: TargetReport::compute_status(&[], false),
+        paths: vec![],
+        no_paths_hints: NoPathsContext::collect(pe, target, toi, None).hints(),
+    }
+}
+
 /// Builds and validates certification path(s) for a single target certificate against a fully
 /// prepared [`PkiEnvironment`](certval::PkiEnvironment), returning a structured report for the
 /// target (absent when the certificate could not be parsed) along with displayable notes
@@ -454,34 +476,21 @@ fn validate_target(
                     target: Some(target_summary),
                     status: TargetReport::compute_status(std::slice::from_ref(&path), true),
                     paths: vec![path],
+                    no_paths_hints: vec![],
                 }),
                 out,
             );
         }
         out.push(err(format!("Failed to find certification paths: {e:?}")));
-        return (
-            Some(TargetReport {
-                name: ee_name.to_string(),
-                target: Some(target_summary),
-                status: TargetReport::compute_status(&[], false),
-                paths: vec![],
-            }),
-            out,
-        );
+        let report = no_paths_report(pe, &target, toi, ee_name, target_summary);
+        out.extend(report.no_paths_hints.iter().map(|h| err(h.clone())));
+        return (Some(report), out);
     }
     if paths.is_empty() {
-        out.push(err(
-            "No certification paths found (check trust anchors and time of interest)".to_string(),
-        ));
-        return (
-            Some(TargetReport {
-                name: ee_name.to_string(),
-                target: Some(target_summary),
-                status: TargetReport::compute_status(&[], false),
-                paths: vec![],
-            }),
-            out,
-        );
+        out.push(err("No certification paths found".to_string()));
+        let report = no_paths_report(pe, &target, toi, ee_name, target_summary);
+        out.extend(report.no_paths_hints.iter().map(|h| err(h.clone())));
+        return (Some(report), out);
     }
 
     let mut valid = 0;
@@ -559,6 +568,7 @@ fn validate_target(
             target: Some(target_summary),
             status,
             paths: path_reports,
+            no_paths_hints: vec![],
         }),
         out,
     )


### PR DESCRIPTION
- Change ta_valid_at_time so TrustAnchorInfo objects with no embedded cert are accepted
- Add notice and comments re: usage of certificates from Mozilla program 