### PR TITLE
Begin working toward UI convergence by sharing one tabbed settings view across the desktop and wasm apps

### DIFF
--- a/pittv3-gui-lib/assets/pittv3.css
+++ b/pittv3-gui-lib/assets/pittv3.css
@@ -93,6 +93,15 @@ input[type="checkbox"] {
   padding-left: 0.5rem;
 }
 
+/* Explains that a group of settings cannot take effect in this frontend. Set apart from a plain
+   hint because it qualifies everything below it rather than annotating one field. */
+.capability-notice {
+  border-left: 3px solid var(--muted);
+  padding: 0.4rem 0.6rem;
+  margin: 0.5rem 0;
+  max-width: 60rem;
+}
+
 button[type="submit"] {
   font-size: 1rem;
   padding: 0.35rem 1.5rem;

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -10,20 +10,181 @@
 //! certval default), editing a field records an override, and Reset to defaults discards all
 //! overrides. The revocation tab presents a composed mode selection with the individual settings
 //! under an advanced disclosure.
+//!
+//! Every frontend presents every tab, including settings it cannot act on: a browser has no
+//! filesystem and, until a fetch relay exists, no way to retrieve CRLs or OCSP responses. Those
+//! groups carry a [`CapabilityNotice`] saying so rather than being hidden, for two reasons. A user
+//! who learned the form in one frontend finds the same tabs in the next, and the settings file is
+//! shared across all of them (`pittv3 -s`, the desktop editor, the browser's import/export), so
+//! authoring a value that only takes effect elsewhere is a legitimate thing to do. What each
+//! frontend can actually act on is declared by [`Capabilities`].
 
 use dioxus::prelude::*;
 
 use certval::{NameConstraintsSettings, OcspNonceSetting};
+use x509_cert::der::DateTime;
 use x509_cert::ext::pkix::KeyUsages;
 
 use crate::gui_settings_model::{RevocationMode, SettingsModel};
 
 #[cfg(feature = "std")]
-use certval::read_settings;
+use crate::settings_store::{FileSettingsStore, SettingsStore};
 #[cfg(feature = "std")]
 use log::error;
+
+/// What the hosting frontend can act on, so the form can present every setting while marking the
+/// groups that cannot take effect where it is running.
+///
+/// This is deliberately a statement about the *environment*, not about a privacy tier or a
+/// packaging choice: a browser gains `network` when a fetch relay is available to it, and the
+/// hosted variant selecting a different mode is one of the things that can flip that bit. Keeping
+/// the form's input in these terms means a tier selector becomes something that *sets*
+/// capabilities rather than something the form has to know about.
+///
+/// [`Default`] is the most restrictive combination — a browser with no relay — so a frontend that
+/// says nothing gets accurate notices rather than silently promising more than it can do.
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct Capabilities {
+    /// Local filesystem paths are meaningful, so the folders and files settings can take effect
+    pub filesystem: bool,
+    /// Outbound requests are available, directly or through a relay, so CRLs, OCSP responses and
+    /// AIA/SIA certificates can be retrieved
+    pub network: bool,
+    /// certval was built with revocation support, so revocation settings are honored at all
+    pub revocation: bool,
+}
+
+impl Capabilities {
+    /// Everything available: the desktop and CLI frontends, built with `std` and `remote`
+    pub fn desktop() -> Self {
+        Self {
+            filesystem: true,
+            network: true,
+            revocation: true,
+        }
+    }
+
+    /// A browser with no relay: no filesystem, no outbound requests, and certval built without
+    /// revocation support. Same as [`Default`], named for the call sites that mean it explicitly.
+    pub fn browser_local() -> Self {
+        Self::default()
+    }
+}
+
+/// Explains that a group of settings is recorded but cannot take effect in this frontend. Rendered
+/// above the group rather than in place of it — see the module documentation for why the fields
+/// stay visible and editable.
+#[component]
+fn CapabilityNotice(message: String) -> Element {
+    rsx! {
+        p { class: "hint capability-notice", "{message}" }
+    }
+}
+
+/// Formats Unix-epoch seconds as a `datetime-local` value (`YYYY-MM-DDTHH:MM:SS`) in UTC.
+///
+/// Built on `der::DateTime` rather than a platform clock API so the same rendering serves the
+/// desktop and the browser; the browser previously showed local time here and the desktop UTC,
+/// which made the same stored setting read differently in the two frontends.
+fn epoch_to_datetime_local(secs: u64) -> String {
+    match DateTime::from_unix_duration(core::time::Duration::from_secs(secs)) {
+        Ok(dt) => format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+            dt.year(),
+            dt.month(),
+            dt.day(),
+            dt.hour(),
+            dt.minutes(),
+            dt.seconds()
+        ),
+        Err(_) => String::new(),
+    }
+}
+
+/// Parses a `datetime-local` value (`YYYY-MM-DDTHH:MM` or `...:SS`, interpreted as UTC) back to
+/// Unix-epoch seconds; inverse of [`epoch_to_datetime_local`].
+fn datetime_local_to_epoch(value: &str) -> Option<u64> {
+    let v = value.trim();
+    let rfc3339 = match v.len() {
+        16 => format!("{v}:00Z"), // picker omitted the seconds component
+        19 => format!("{v}Z"),
+        _ => return None,
+    };
+    rfc3339
+        .parse::<DateTime>()
+        .ok()
+        .map(|dt| dt.unix_duration().as_secs())
+}
+
+/// Table row for the time of interest: the epoch value, a Now button, and a human-readable picker
+/// mirroring it. An empty value clears the override, which means "the time of the run".
+#[component]
+fn TimeOfInterestRow(value: Option<u64>, now: u64, onchange: EventHandler<Option<u64>>) -> Element {
+    let display = value.map(|v| v.to_string()).unwrap_or_default();
+    // Empty while the value is absent or disabled (0), so the picker does not claim a time that is
+    // not in effect.
+    let picker = match value {
+        Some(secs) if secs != 0 => epoch_to_datetime_local(secs),
+        _ => String::new(),
+    };
+    rsx! {
+        tr {
+            td { label { "Time of interest (Unix epoch, 0 disables): " } }
+            td {
+                input {
+                    r#type: "number",
+                    min: "0",
+                    value: display,
+                    placeholder: "run time",
+                    oninput: move |ev| {
+                        let v = ev.value();
+                        if v.trim().is_empty() {
+                            onchange.call(None);
+                        } else if let Ok(parsed) = v.trim().parse::<u64>() {
+                            onchange.call(Some(parsed));
+                        }
+                    },
+                }
+                button {
+                    r#type: "button",
+                    onclick: move |_| onchange.call(Some(now)),
+                    "Now"
+                }
+                // onchange fires only on a complete datetime, so it never clobbers a mid-edit epoch
+                input {
+                    r#type: "datetime-local",
+                    step: "1",
+                    value: picker,
+                    onchange: move |ev| {
+                        if let Some(secs) = datetime_local_to_epoch(&ev.value()) {
+                            onchange.call(Some(secs));
+                        }
+                    },
+                }
+            }
+            td {
+                span { class: "hint",
+                    if value.is_some() {
+                        "override (UTC)"
+                    } else {
+                        "default: the time of the run"
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// Current time in Unix-epoch seconds, for the time-of-interest Now button. `web_time` so the same
+/// call works in the browser and on the host. Only the file-backed wrapper needs it; frontends that
+/// mount [`EditSettings`] directly pass their own `now`.
 #[cfg(feature = "std")]
-use std::io::Write;
+fn now_as_unix_epoch() -> u64 {
+    match web_time::SystemTime::now().duration_since(web_time::UNIX_EPOCH) {
+        Ok(n) => n.as_secs(),
+        Err(_) => 0,
+    }
+}
 
 /// Returns true if `s` is plausibly a dotted-decimal OID
 fn looks_like_oid(s: &str) -> bool {
@@ -407,12 +568,14 @@ const TABS: &[(SettingsTab, &str)] = &[
 ];
 
 /// Renderer-agnostic settings editor over a [`SettingsModel`]. The `on_save` handler receives the
-/// edited model; persistence (file, server, browser storage) is the frontend's concern. Set
-/// `show_folders` to present the desktop-only folders/files tab.
+/// edited model; persistence (file, server, browser storage) is the frontend's concern. `caps`
+/// declares what this frontend can act on, which drives the per-group notices; it defaults to the
+/// most restrictive combination.
 #[component]
 pub fn EditSettings(
     initial: SettingsModel,
-    #[props(default)] show_folders: bool,
+    #[props(default)] caps: Capabilities,
+    now: u64,
     on_save: EventHandler<SettingsModel>,
     on_close: EventHandler<()>,
 ) -> Element {
@@ -426,16 +589,14 @@ pub fn EditSettings(
         div { class: "settings-editor",
             div { class: "tab-bar",
                 for (t , label) in TABS.iter() {
-                    if *t != SettingsTab::Folders || show_folders {
-                        button {
-                            r#type: "button",
-                            class: if tab() == *t { "tab tab-active" } else { "tab" },
-                            onclick: {
-                                let t = *t;
-                                move |_| tab.set(t)
-                            },
-                            "{label}"
-                        }
+                    button {
+                        r#type: "button",
+                        class: if tab() == *t { "tab tab-active" } else { "tab" },
+                        onclick: {
+                            let t = *t;
+                            move |_| tab.set(t)
+                        },
+                        "{label}"
                     }
                 }
             }
@@ -554,10 +715,9 @@ pub fn EditSettings(
                                 overridden: m.enforce_alg_and_key_size_constraints.is_some(),
                                 onchange: move |v| model.write().enforce_alg_and_key_size_constraints = Some(v),
                             }
-                            NumberRow {
-                                label: "Time of interest (Unix epoch, 0 disables)",
+                            TimeOfInterestRow {
                                 value: m.time_of_interest,
-                                placeholder: "run time",
+                                now,
                                 onchange: move |v| model.write().time_of_interest = v,
                             }
                             BoolRow {
@@ -570,6 +730,23 @@ pub fn EditSettings(
                     }
                 },
                 SettingsTab::Revocation => rsx! {
+                    // Two distinct reasons revocation can be inert, reported separately because
+                    // the remedies differ: one is how certval was built, the other is whether
+                    // anything can reach a responder from here.
+                    if !caps.revocation {
+                        CapabilityNotice {
+                            message: "This frontend was built without revocation support, so these settings are \
+                                      recorded in the settings file but not applied to a run here."
+                                .to_string(),
+                        }
+                    } else if !caps.network {
+                        CapabilityNotice {
+                            message: "Retrieving CRLs and OCSP responses needs outbound network access, which is \
+                                      not available here. Revocation data supplied with the certificates is still \
+                                      honored; these settings otherwise apply only where the tool can fetch."
+                                .to_string(),
+                        }
+                    }
                     div { class: "radio-group",
                         strong { "Revocation mode: " }
                         for (value , label) in [
@@ -669,6 +846,15 @@ pub fn EditSettings(
                     }
                 },
                 SettingsTab::Fetching => rsx! {
+                    if !caps.network {
+                        CapabilityNotice {
+                            message: "Chasing AIA and SIA needs outbound network access, which is not available \
+                                      here: certificate repositories are served over plain http and send no CORS \
+                                      headers, so a browser cannot reach them without a relay. Paths are built \
+                                      from the selected store and any uploaded certificates instead."
+                                .to_string(),
+                        }
+                    }
                     table {
                         tbody {
                             BoolRow {
@@ -715,6 +901,14 @@ pub fn EditSettings(
                     }
                 },
                 SettingsTab::Folders => rsx! {
+                    if !caps.filesystem {
+                        CapabilityNotice {
+                            message: "This frontend has no filesystem access, so these paths do not resolve here. \
+                                      They are kept in the settings file, which is the same format the CLI and the \
+                                      desktop app read, so a path set here takes effect when the file is used there."
+                                .to_string(),
+                        }
+                    }
                     table {
                         tbody {
                             TextRow {
@@ -777,31 +971,17 @@ pub fn EditSettings(
 pub fn EditSettingsFile(path: String, on_close: EventHandler<()>) -> Element {
     let initial = use_hook({
         let path = path.clone();
-        move || {
-            let cps = read_settings(&Some(path)).unwrap_or_default();
-            SettingsModel::from_cps(&cps)
-        }
+        move || SettingsModel::from_cps(&FileSettingsStore::new(path).load())
     });
 
     let save_path = path.clone();
     let on_save = move |edited: SettingsModel| {
-        // start from the file contents so settings not surfaced in the form are preserved
-        let mut cps = read_settings(&Some(save_path.clone())).unwrap_or_default();
+        let store = FileSettingsStore::new(save_path.clone());
+        // start from the stored contents so settings not surfaced in the form are preserved
+        let mut cps = store.load();
         edited.apply(&mut cps);
-        match serde_json::to_string(&cps) {
-            Ok(json_ps) => match std::fs::File::create(&save_path) {
-                Ok(mut final_file) => {
-                    if let Err(e) = final_file.write_all(json_ps.as_bytes()) {
-                        error!("Failed to save settings: {e}");
-                    }
-                }
-                Err(e) => {
-                    error!("Failed to create file to receive settings: {e}");
-                }
-            },
-            Err(e) => {
-                error!("Failed to encode settings: {e}");
-            }
+        if let Err(e) = store.save(&cps) {
+            error!("{e}");
         }
         on_close.call(());
     };
@@ -809,7 +989,8 @@ pub fn EditSettingsFile(path: String, on_close: EventHandler<()>) -> Element {
     rsx! {
         EditSettings {
             initial,
-            show_folders: true,
+            caps: Capabilities::desktop(),
+            now: now_as_unix_epoch(),
             on_save,
             on_close: move |_| on_close.call(()),
         }

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -13,7 +13,7 @@
 //!
 //! Every frontend presents every tab, including settings it cannot act on: a browser has no
 //! filesystem and, until a fetch relay exists, no way to retrieve CRLs or OCSP responses. Those
-//! groups carry a [`CapabilityNotice`] saying so rather than being hidden, for two reasons. A user
+//! groups carry a notice saying so rather than being hidden, for two reasons. A user
 //! who learned the form in one frontend finds the same tabs in the next, and the settings file is
 //! shared across all of them (`pittv3 -s`, the desktop editor, the browser's import/export), so
 //! authoring a value that only takes effect elsewhere is a legitimate thing to do. What each

--- a/pittv3-gui-lib/src/gui_utils.rs
+++ b/pittv3-gui-lib/src/gui_utils.rs
@@ -6,12 +6,13 @@ use dioxus::prelude::*;
 #[cfg(feature = "std")]
 use std::fs;
 #[cfg(feature = "std")]
-use std::fs::{create_dir_all, File};
+use std::fs::File;
 
 #[cfg(feature = "std")]
-use home::home_dir;
-#[cfg(feature = "std")]
 use log::error;
+
+#[cfg(feature = "std")]
+use crate::settings_store::app_home;
 
 #[cfg(feature = "std")]
 use certval::{Error, Result};
@@ -23,12 +24,8 @@ use pittv3_lib::args::Pittv3Args;
 /// there is no home directory, no saved configuration or the saved configuration cannot be parsed.
 #[cfg(feature = "std")]
 pub fn read_saved_args() -> Result<Pittv3Args> {
-    if let Some(hd) = home_dir() {
-        let app_home = hd.join(".pittv3");
-        if !app_home.exists() {
-            let _ = create_dir_all(app_home);
-        }
-        let app_cfg = hd.join(".pittv3").join("pittv3.cfg");
+    if let Some(app_home) = app_home() {
+        let app_cfg = app_home.join("pittv3.cfg");
         if let Ok(f) = File::open(app_cfg) {
             if let Ok(a) = serde_json::from_reader(&f) {
                 return Ok(a);
@@ -44,8 +41,8 @@ pub fn read_saved_args() -> Result<Pittv3Args> {
 /// user's home directory.
 #[cfg(feature = "std")]
 pub fn save_args(args: &Pittv3Args) -> Result<()> {
-    if let Some(hd) = home_dir() {
-        let app_cfg = hd.join(".pittv3").join("pittv3.cfg");
+    if let Some(app_home) = app_home() {
+        let app_cfg = app_home.join("pittv3.cfg");
         if let Ok(json_args) = serde_json::to_string(&args) {
             if let Err(e) = fs::write(app_cfg, json_args) {
                 error!("Unable to write args to file: {e}");

--- a/pittv3-gui-lib/src/lib.rs
+++ b/pittv3-gui-lib/src/lib.rs
@@ -10,6 +10,7 @@ pub mod gui_settings;
 pub mod gui_settings_model;
 pub mod gui_shell;
 pub mod gui_utils;
+pub mod settings_store;
 pub mod validate;
 
 /// Shared stylesheet for GUI frontends; embed via a `style` element so each frontend ships one

--- a/pittv3-gui-lib/src/settings_store.rs
+++ b/pittv3-gui-lib/src/settings_store.rs
@@ -1,0 +1,90 @@
+//! Persistence seam for the shared settings form.
+//!
+//! [`EditSettings`](crate::gui_settings::EditSettings) is deliberately persistence-free: it takes a
+//! model in and hands an edited model back. Where those settings live differs per frontend — a JSON
+//! file on desktop and the CLI, browser storage in the wasm app, and a server-side session for a
+//! hosted variant — so each frontend supplies a [`SettingsStore`].
+//!
+//! The trait trades in [`CertificationPathSettings`] rather than
+//! [`SettingsModel`](crate::gui_settings_model::SettingsModel) on purpose. That type is the format
+//! the CLI's `--settings` argument already reads and the desktop editor already writes, so every
+//! frontend stores, exports and imports the same artifact instead of inventing a private encoding.
+//! Round-tripping through it also preserves settings the form does not surface (`PS_CERTIFICATES`,
+//! for instance), which a model-shaped store would silently drop.
+//!
+//! This module is Dioxus-free.
+
+use certval::CertificationPathSettings;
+
+/// Where a frontend keeps its settings between runs.
+///
+/// Implementations are expected to be best-effort: browser storage can be unavailable or full and a
+/// file can be unreadable, and in neither case should the form refuse to open. `load` therefore
+/// falls back to the certval defaults rather than reporting an error, and `save` reports failure
+/// only so the frontend can surface a status line.
+pub trait SettingsStore {
+    /// Reads the stored settings, yielding the certval defaults when nothing is stored yet or the
+    /// stored value cannot be read.
+    fn load(&self) -> CertificationPathSettings;
+
+    /// Writes settings back to the store, returning a human-readable message on failure.
+    fn save(&self, cps: &CertificationPathSettings) -> Result<(), String>;
+}
+
+/// The application's home directory, `.pittv3` beneath the user's home, created if absent. None
+/// when there is no home directory to work from.
+#[cfg(feature = "std")]
+pub fn app_home() -> Option<std::path::PathBuf> {
+    let app_home = home::home_dir()?.join(".pittv3");
+    if !app_home.exists() {
+        let _ = std::fs::create_dir_all(&app_home);
+    }
+    Some(app_home)
+}
+
+/// The default settings file, `settings.json` in [`app_home`].
+///
+/// Having a default is what lets a file-backed frontend behave like the browser one, where settings
+/// are always present because localStorage always answers. Without it the desktop app could only
+/// show its settings form once the user had nominated a file, so the same product had settings as
+/// *app state* in one frontend and as *a document you open* in the other. The file need not exist:
+/// `certval::read_settings` yields an empty settings map for a missing path, which is the same
+/// thing as "all defaults".
+#[cfg(feature = "std")]
+pub fn default_settings_path() -> Option<String> {
+    Some(app_home()?.join("settings.json").to_str()?.to_string())
+}
+
+/// A [`SettingsStore`] backed by a JSON file holding a [`CertificationPathSettings`] — the format
+/// the CLI reads via `--settings` and the desktop app has always written.
+#[cfg(feature = "std")]
+pub struct FileSettingsStore {
+    /// Path to the settings JSON
+    pub path: String,
+}
+
+#[cfg(feature = "std")]
+impl FileSettingsStore {
+    /// Creates a store over the settings file at `path`
+    pub fn new(path: impl Into<String>) -> Self {
+        Self { path: path.into() }
+    }
+}
+
+#[cfg(feature = "std")]
+impl SettingsStore for FileSettingsStore {
+    fn load(&self) -> CertificationPathSettings {
+        certval::read_settings(&Some(self.path.clone())).unwrap_or_default()
+    }
+
+    fn save(&self, cps: &CertificationPathSettings) -> Result<(), String> {
+        use std::io::Write;
+
+        let json =
+            serde_json::to_string(cps).map_err(|e| format!("Failed to encode settings: {e}"))?;
+        let mut file = std::fs::File::create(&self.path)
+            .map_err(|e| format!("Failed to create file to receive settings: {e}"))?;
+        file.write_all(json.as_bytes())
+            .map_err(|e| format!("Failed to save settings: {e}"))
+    }
+}

--- a/pittv3-gui-lib/src/validate.rs
+++ b/pittv3-gui-lib/src/validate.rs
@@ -10,59 +10,7 @@ use std::io::{Cursor, Read};
 
 use certval::*;
 use pittv3_lib::report::{CertSummary, NoPathsContext, PathReport, TargetReport};
-use serde::{Deserialize, Serialize};
 use web_time::Instant;
-
-/// User-editable values that feed the RFC 5280 path validation inputs plus app-level options.
-///
-/// Serialized only as the localStorage snapshot that persists the settings tab across reloads: it
-/// carries app-level state (the custom-time flag and validate-all) that the interchange format does
-/// not. The downloadable settings file uses certval's `CertificationPathSettings` JSON instead —
-/// the same format the CLI and desktop apps read.
-#[derive(Clone, Serialize, Deserialize)]
-pub struct ValidationSettings {
-    /// True when `toi` is a time the user chose, as opposed to the run-time default. Only a custom
-    /// time is restored on reload; otherwise the time of interest is recomputed as the current time.
-    #[serde(default)]
-    pub toi_custom: bool,
-    /// Time of interest as seconds since Unix epoch; 0 disables validity period checks
-    pub toi: u64,
-    /// Validate every discovered path instead of stopping at the first valid one
-    pub validate_all: bool,
-    /// initial-explicit-policy input
-    pub initial_explicit_policy: bool,
-    /// initial-policy-mapping-inhibit input
-    pub initial_policy_mapping_inhibit: bool,
-    /// initial-any-policy-inhibit input
-    pub initial_inhibit_any_policy: bool,
-    /// user-initial-policy-set input as whitespace- or comma-separated OIDs; empty means anyPolicy
-    pub initial_policy_set: String,
-    /// Enforce constraints expressed in trust anchors per RFC 5937
-    pub enforce_trust_anchor_constraints: bool,
-    /// Require trust anchors to be valid at the time of interest
-    pub enforce_trust_anchor_validity: bool,
-    /// RFC 5280 initial-permitted-subtrees, one entry per line per name form
-    pub permitted_subtrees: NameConstraintInputs,
-    /// RFC 5280 initial-excluded-subtrees, one entry per line per name form
-    pub excluded_subtrees: NameConstraintInputs,
-}
-
-/// Raw text (one entry per line) for the name-constraint forms exposed in the UI. UPN and the
-/// "not supported" catch-all are omitted: UPN has been removed from certval, and the
-/// unsupported-forms bucket needs custom enforcement.
-#[derive(Default, Clone, Serialize, Deserialize)]
-pub struct NameConstraintInputs {
-    /// dNSName subtrees
-    pub dns_name: String,
-    /// rfc822Name (email) subtrees
-    pub rfc822_name: String,
-    /// directoryName (DN) subtrees
-    pub directory_name: String,
-    /// uniformResourceIdentifier subtrees
-    pub uniform_resource_identifier: String,
-    /// iPAddress subtrees (CIDR form)
-    pub ip_address: String,
-}
 
 // Re-exported so callers taking the validation API from this module keep getting the line type it
 // returns; the type itself lives beside the other UI-facing run output.
@@ -93,88 +41,6 @@ fn maybe_pem(bytes: &[u8]) -> Result<Vec<u8>> {
             Err(_e) => Err(Error::Unrecognized),
         }
     }
-}
-
-/// Returns true if `s` is plausibly a dotted-decimal OID
-fn looks_like_oid(s: &str) -> bool {
-    s.contains('.') && s.chars().all(|c| c.is_ascii_digit() || c == '.')
-}
-
-/// Splits a textarea value into one entry per non-empty trimmed line (line-per-entry avoids
-/// ambiguity with directoryName values, which contain commas). None when there are no entries.
-fn lines_to_vec(s: &str) -> Option<Vec<String>> {
-    let v: Vec<String> = s
-        .lines()
-        .map(str::trim)
-        .filter(|l| !l.is_empty())
-        .map(str::to_string)
-        .collect();
-    (!v.is_empty()).then_some(v)
-}
-
-/// Builds a [`NameConstraintsSettings`] from the UI inputs, or None when every form is empty.
-fn to_name_constraints(nc: &NameConstraintInputs) -> Option<NameConstraintsSettings> {
-    let s = NameConstraintsSettings {
-        rfc822_name: lines_to_vec(&nc.rfc822_name),
-        dns_name: lines_to_vec(&nc.dns_name),
-        directory_name: lines_to_vec(&nc.directory_name),
-        uniform_resource_identifier: lines_to_vec(&nc.uniform_resource_identifier),
-        ip_address: lines_to_vec(&nc.ip_address),
-        ..Default::default()
-    };
-    let empty = s.rfc822_name.is_none()
-        && s.dns_name.is_none()
-        && s.directory_name.is_none()
-        && s.uniform_resource_identifier.is_none()
-        && s.ip_address.is_none();
-    (!empty).then_some(s)
-}
-
-/// Builds a [`CertificationPathSettings`] from user-supplied
-/// values, appending a note for any value that could not be applied as given
-pub fn make_cps(vs: &ValidationSettings, out: &mut Vec<ResultLine>) -> CertificationPathSettings {
-    let toi = match TimeOfInterest::from_unix_secs(vs.toi) {
-        Ok(t) => t,
-        Err(_) => TimeOfInterest::disabled(),
-    };
-    if toi.is_disabled() {
-        out.push(info(
-            "Time of interest is 0 (or invalid): validity period checks are disabled".to_string(),
-        ));
-    }
-    let mut cps = CertificationPathSettings::default();
-    cps.set_time_of_interest(toi);
-    cps.set_initial_explicit_policy_indicator(vs.initial_explicit_policy);
-    cps.set_initial_policy_mapping_inhibit_indicator(vs.initial_policy_mapping_inhibit);
-    cps.set_initial_inhibit_any_policy_indicator(vs.initial_inhibit_any_policy);
-    cps.set_enforce_trust_anchor_constraints(vs.enforce_trust_anchor_constraints);
-    cps.set_enforce_trust_anchor_validity(vs.enforce_trust_anchor_validity);
-    if let Some(p) = to_name_constraints(&vs.permitted_subtrees) {
-        cps.set_initial_permitted_subtrees(p);
-    }
-    if let Some(e) = to_name_constraints(&vs.excluded_subtrees) {
-        cps.set_initial_excluded_subtrees(e);
-    }
-
-    let mut oids = vec![];
-    for tok in vs
-        .initial_policy_set
-        .split(|c: char| c.is_whitespace() || c == ',')
-        .filter(|s| !s.is_empty())
-    {
-        if looks_like_oid(tok) {
-            oids.push(tok.to_string());
-        } else {
-            out.push(err(format!(
-                "Ignoring initial policy set entry that is not a dotted-decimal OID: {tok}"
-            )));
-        }
-    }
-    // when no usable OIDs are given, leave the default in place (anyPolicy)
-    if !oids.is_empty() {
-        cps.set_initial_policy_set(oids);
-    }
-    cps
 }
 
 /// A [`PkiEnvironment`] prepared for validation: trust anchors and CA
@@ -555,7 +421,8 @@ fn validate_self_signed(pe: &PkiEnvironment, name: &str, der: &[u8]) -> Vec<Resu
 pub fn validate_hackathon_zip(
     zip_name: &str,
     bytes: Vec<u8>,
-    vs: &ValidationSettings,
+    cps: &CertificationPathSettings,
+    validate_all: bool,
 ) -> (Vec<TargetReport>, Vec<ResultLine>) {
     let mut out = vec![];
     let mut reports = vec![];
@@ -630,7 +497,6 @@ pub fn validate_hackathon_zip(
         });
     }
 
-    let cps = make_cps(vs, &mut out);
     if let Err(e) = ta_store.initialize() {
         out.push(err(format!("Failed to initialize TA store: {e:?}")));
         return (reports, out);
@@ -642,7 +508,7 @@ pub fn validate_hackathon_zip(
     // path building for TA-issued targets happens in the certificate source, so one must be
     // registered even though the R5 format carries no intermediate CA certificates
     let mut cert_source = CertSource::new();
-    if let Err(e) = cert_source.initialize(&cps) {
+    if let Err(e) = cert_source.initialize(cps) {
         out.push(err(format!("Failed to initialize CA store: {e:?}")));
         return (reports, out);
     }
@@ -654,7 +520,7 @@ pub fn validate_hackathon_zip(
         out.extend(validate_self_signed(&pe, name, der));
     }
     for (name, der) in &ees {
-        let (report, lines) = validate_target(&pe, &cps, name, der, vs.validate_all);
+        let (report, lines) = validate_target(&pe, cps, name, der, validate_all);
         out.extend(lines);
         if let Some(report) = report {
             reports.push(report);

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -18,6 +18,7 @@ use pittv3_gui_lib::gui_shell::AppShell;
 use pittv3_gui_lib::gui_utils::{
     clear_log_sink, read_saved_args, save_args, set_log_sink, ChannelAppender,
 };
+use pittv3_gui_lib::settings_store::default_settings_path;
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
 use pittv3_lib::options_std::options_std;
@@ -514,7 +515,16 @@ pub(crate) fn App() -> Element {
     let s_end_entity_file = use_signal(|| sa.end_entity_file.clone().unwrap_or_default());
     let s_end_entity_folder = use_signal(|| sa.end_entity_folder.clone().unwrap_or_default());
     let s_results_folder = use_signal(|| sa.results_folder.clone().unwrap_or_default());
-    let mut s_settings = use_signal(|| sa.settings.clone().unwrap_or_default());
+    // Effective settings file. Saved args win; otherwise the default in ~/.pittv3 so the app always
+    // has settings, matching the browser frontend where localStorage always answers. The file need
+    // not exist — read_settings treats a missing path as "all defaults".
+    let mut s_settings = use_signal(|| {
+        sa.settings
+            .clone()
+            .filter(|p| !p.is_empty())
+            .or_else(default_settings_path)
+            .unwrap_or_default()
+    });
     let s_crl_folder = use_signal(|| sa.crl_folder.clone().unwrap_or_default());
     let s_cleanup = use_signal(|| sa.cleanup);
     let s_ta_cleanup = use_signal(|| sa.ta_cleanup);
@@ -772,6 +782,21 @@ pub(crate) fn App() -> Element {
                                             }
                                         }
                                     }
+                                    // A run honors this file, so name it rather than leaving the
+                                    // user to infer it from a path field they never filled in.
+                                    tr {
+                                        td { }
+                                        td { class: "grow",
+                                            span { class: "hint",
+                                                if s_settings().is_empty() {
+                                                    "This run will use certval defaults."
+                                                } else {
+                                                    "This run will use the settings above."
+                                                }
+                                            }
+                                        }
+                                        td { }
+                                    }
                                 }
                             }
                             table {
@@ -1007,9 +1032,13 @@ pub(crate) fn App() -> Element {
                                     }
                                 }
                             }
+                            // Always shown: settings are app state, not a document you must open
+                            // first. The path above selects which file backs them and defaults to
+                            // ~/.pittv3/settings.json, which is created on save if it does not
+                            // exist. The empty case is only reachable with no home directory.
                             if s_settings().is_empty() {
                                 p { class: "hint",
-                                    "Choose (or type the path of) a JSON settings file to edit. A new file is created on save if it does not exist."
+                                    "No home directory is available, so there is no default settings file. Choose (or type the path of) a JSON settings file to edit."
                                 }
                             } else {
                                 EditSettingsFile {

--- a/pittv3-wasm/src/bin/ziptest.rs
+++ b/pittv3-wasm/src/bin/ziptest.rs
@@ -5,28 +5,21 @@
 #[path = "../validate.rs"]
 mod validate;
 
-use validate::{validate_hackathon_zip, ValidationSettings};
+use certval::{CertificationPathSettings, TimeOfInterest};
+use validate::validate_hackathon_zip;
 
 fn main() {
     let path = std::env::args().nth(1).expect("usage: ziptest <zip>");
     let bytes = std::fs::read(&path).expect("failed to read zip");
-    let vs = ValidationSettings {
-        toi: std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .unwrap()
-            .as_secs(),
-        toi_custom: false,
-        validate_all: true,
-        initial_explicit_policy: false,
-        initial_policy_mapping_inhibit: false,
-        initial_inhibit_any_policy: false,
-        initial_policy_set: "2.5.29.32.0".to_string(),
-        enforce_trust_anchor_constraints: false,
-        enforce_trust_anchor_validity: true,
-        permitted_subtrees: Default::default(),
-        excluded_subtrees: Default::default(),
-    };
-    let (reports, lines) = validate_hackathon_zip(&path, bytes, &vs);
+    // certval defaults, with the time of interest pinned to now: an absent value means
+    // TimeOfInterest::disabled() in this no-std configuration, which would skip validity checking.
+    let mut cps = CertificationPathSettings::default();
+    let now = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .unwrap()
+        .as_secs();
+    cps.set_time_of_interest(TimeOfInterest::from_unix_secs(now).expect("valid time"));
+    let (reports, lines) = validate_hackathon_zip(&path, bytes, &cps, true);
     for line in lines {
         println!("[{}] {}", line.class, line.text);
     }

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -7,28 +7,35 @@ mod validate;
 use dioxus::prelude::*;
 use web_time::{SystemTime, UNIX_EPOCH};
 
-use certval::{CertificationPathSettings, PS_TIME_OF_INTEREST};
+use certval::{CertificationPathSettings, TimeOfInterest};
 use pittv3_gui_lib::gui_results::ResultsView;
+use pittv3_gui_lib::gui_settings::{Capabilities, EditSettings};
 use pittv3_gui_lib::gui_settings_model::SettingsModel;
 use pittv3_gui_lib::gui_shell::AppShell;
+use pittv3_gui_lib::settings_store::SettingsStore;
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::report::{TargetReport, ValidationReport};
 
 use crate::validate::{
-    make_cps, prepare_validation, validate_hackathon_zip, validate_prepared, NameConstraintInputs,
-    PreparedValidation, ResultLine, ValidationSettings, SAMPLE_INVALID, SAMPLE_VALID, STORES,
+    prepare_validation, validate_hackathon_zip, validate_prepared, PreparedValidation, ResultLine,
+    SAMPLE_INVALID, SAMPLE_VALID, STORES,
 };
 
 /// Store selection value indicating no baked-in store, i.e., uploaded trust anchors only
 const NO_STORE: usize = usize::MAX;
 
-/// OID for anyPolicy, the default user-initial-policy-set value
-const ANY_POLICY_OID: &str = "2.5.29.32.0";
-
-/// localStorage key under which the settings tab is persisted across reloads (used only by the
-/// wasm-gated storage helpers, hence unused on the host test build)
+/// localStorage key under which the settings are persisted across reloads, as the same
+/// `CertificationPathSettings` JSON the CLI's `--settings` reads and the Download button writes
+/// (used only by the wasm-gated storage helpers, hence unused on the host test build)
 #[cfg_attr(not(target_family = "wasm"), allow(dead_code))]
 const SETTINGS_KEY: &str = "pittv3.settings";
+
+/// localStorage key for the validate-all choice. Separate from [`SETTINGS_KEY`] because it is not a
+/// `CertificationPathSettings` value — it selects how many paths a run explores, not what a path
+/// must satisfy — and keeping it out preserves the settings key as an exact copy of the shared
+/// interchange format.
+#[cfg_attr(not(target_family = "wasm"), allow(dead_code))]
+const VALIDATE_ALL_KEY: &str = "pittv3.validate_all";
 
 /// Sidebar views in display order
 const VIEW_LABELS: &[&str] = &[
@@ -50,99 +57,83 @@ fn now_as_unix_epoch() -> u64 {
     }
 }
 
-/// The settings tab's default state: the certval defaults plus the current time as the (non-custom)
-/// time of interest. Used for a fresh visit and by Reset to defaults.
-fn default_settings() -> ValidationSettings {
-    ValidationSettings {
-        toi: now_as_unix_epoch(),
-        toi_custom: false,
-        validate_all: true,
-        initial_explicit_policy: false,
-        initial_policy_mapping_inhibit: false,
-        initial_inhibit_any_policy: false,
-        initial_policy_set: ANY_POLICY_OID.to_string(),
-        enforce_trust_anchor_constraints: false,
-        enforce_trust_anchor_validity: true,
-        permitted_subtrees: NameConstraintInputs::default(),
-        excluded_subtrees: NameConstraintInputs::default(),
+/// Reads a string from localStorage. None when storage is unavailable or the key is absent; native
+/// builds (cargo check/test on the host) have no browser storage, and the app only runs as wasm.
+#[cfg(target_family = "wasm")]
+fn storage_get(key: &str) -> Option<String> {
+    web_sys::window()?
+        .local_storage()
+        .ok()??
+        .get_item(key)
+        .ok()?
+}
+
+/// Writes a string to localStorage. Best-effort: storage may be unavailable or full.
+#[cfg(target_family = "wasm")]
+fn storage_set(key: &str, value: &str) -> Result<(), String> {
+    let storage = web_sys::window()
+        .and_then(|w| w.local_storage().ok().flatten())
+        .ok_or_else(|| "Browser storage is unavailable".to_string())?;
+    storage
+        .set_item(key, value)
+        .map_err(|_| "Browser storage is full or blocked".to_string())
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn storage_get(_key: &str) -> Option<String> {
+    None
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn storage_set(_key: &str, _value: &str) -> Result<(), String> {
+    Ok(())
+}
+
+/// The browser frontend's [`SettingsStore`]: localStorage holding the same
+/// `CertificationPathSettings` JSON that the CLI reads, the desktop editor writes and this app's
+/// own Download/Load controls exchange. Storing the interchange format rather than a private
+/// encoding is what lets a settings file move between the frontends unchanged.
+struct LocalStorageSettingsStore;
+
+impl SettingsStore for LocalStorageSettingsStore {
+    fn load(&self) -> CertificationPathSettings {
+        storage_get(SETTINGS_KEY)
+            .and_then(|json| serde_json::from_str(&json).ok())
+            .unwrap_or_default()
+    }
+
+    fn save(&self, cps: &CertificationPathSettings) -> Result<(), String> {
+        let json =
+            serde_json::to_string(cps).map_err(|e| format!("Failed to encode settings: {e}"))?;
+        storage_set(SETTINGS_KEY, &json)
     }
 }
 
-/// Reads the persisted settings tab from localStorage, or None when absent, unreadable or invalid.
-#[cfg(target_family = "wasm")]
-fn load_persisted_settings() -> Option<ValidationSettings> {
-    let storage = web_sys::window()?.local_storage().ok()??;
-    let json = storage.get_item(SETTINGS_KEY).ok()??;
-    serde_json::from_str(&json).ok()
+/// Reads the persisted validate-all choice, defaulting to true (explore every discovered path)
+fn load_validate_all() -> bool {
+    storage_get(VALIDATE_ALL_KEY)
+        .map(|v| v == "true")
+        .unwrap_or(true)
 }
 
-/// Writes the settings tab to localStorage so it survives a reload. Best-effort: storage may be
-/// unavailable or full, in which case persistence is silently skipped.
-#[cfg(target_family = "wasm")]
-fn persist_settings(vs: &ValidationSettings) {
-    if let Ok(json) = serde_json::to_string(vs) {
-        if let Some(storage) = web_sys::window().and_then(|w| w.local_storage().ok().flatten()) {
-            let _ = storage.set_item(SETTINGS_KEY, &json);
+/// Builds the settings for a run from the edited model.
+///
+/// A model with no time of interest means "use the current time", and this is where that is
+/// materialized. It matters because certval's default for an absent `PS_TIME_OF_INTEREST` is
+/// `TimeOfInterest::disabled()` in a no-std build like this one but `TimeOfInterest::now()` under
+/// std: leaving the value out would silently disable validity-period checking in the browser while
+/// the very same settings file checked against the current time on the desktop. Filling it in at
+/// run time keeps the two frontends in agreement and still leaves the stored file portable, since
+/// the value is not written back to the model.
+fn run_settings(model: &SettingsModel) -> CertificationPathSettings {
+    let mut cps = CertificationPathSettings::default();
+    model.apply(&mut cps);
+    if model.time_of_interest.is_none() {
+        if let Ok(toi) = TimeOfInterest::from_unix_secs(now_as_unix_epoch()) {
+            cps.set_time_of_interest(toi);
         }
     }
-}
-
-// Native builds (cargo check/test on the host) have no browser storage; the app only runs as wasm.
-#[cfg(not(target_family = "wasm"))]
-fn load_persisted_settings() -> Option<ValidationSettings> {
-    None
-}
-
-#[cfg(not(target_family = "wasm"))]
-fn persist_settings(_vs: &ValidationSettings) {}
-
-/// Parses a `datetime-local` value (local time) into Unix-epoch seconds. None on host builds.
-#[cfg(target_family = "wasm")]
-fn datetime_local_to_epoch(value: &str) -> Option<u64> {
-    let ms = js_sys::Date::parse(value);
-    if ms.is_nan() {
-        None
-    } else {
-        Some((ms / 1000.0) as u64)
-    }
-}
-
-#[cfg(not(target_family = "wasm"))]
-fn datetime_local_to_epoch(_value: &str) -> Option<u64> {
-    None
-}
-
-/// Formats Unix-epoch seconds as a `datetime-local` value (`YYYY-MM-DDTHH:MM:SS`) in local time,
-/// the inverse of [`datetime_local_to_epoch`]. Empty on host builds.
-#[cfg(target_family = "wasm")]
-fn epoch_to_datetime_local(secs: u64) -> String {
-    // new_0() then set_time avoids needing a JsValue import just to build the Date from millis.
-    let date = js_sys::Date::new_0();
-    date.set_time(secs as f64 * 1000.0);
-    format!(
-        "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
-        date.get_full_year(),
-        date.get_month() + 1, // getMonth is 0-based
-        date.get_date(),
-        date.get_hours(),
-        date.get_minutes(),
-        date.get_seconds(),
-    )
-}
-
-#[cfg(not(target_family = "wasm"))]
-fn epoch_to_datetime_local(_secs: u64) -> String {
-    String::new()
-}
-
-/// The `datetime-local` value mirroring the time-of-interest epoch string, so the picker shows the
-/// selected time and the user need not decode the number. Empty when the time is disabled (0) or
-/// not yet a valid epoch (e.g. mid-edit in the epoch field).
-fn toi_datetime_value(toi: &str) -> String {
-    match toi.trim().parse::<u64>() {
-        Ok(secs) if secs != 0 => epoch_to_datetime_local(secs),
-        _ => String::new(),
-    }
+    cps
 }
 
 fn main() {
@@ -227,47 +218,16 @@ fn App() -> Element {
     let mut view = use_signal(|| 0usize);
     let mut mode = use_signal(|| 0usize);
 
-    // Restore the settings tab from localStorage (or fall back to defaults) so a custom time of
-    // interest and the RFC 5280 inputs survive a reload. Destructure once and seed each signal.
-    let ValidationSettings {
-        toi_custom: init_toi_custom,
-        toi: init_toi,
-        validate_all: init_validate_all,
-        initial_explicit_policy: init_iep,
-        initial_policy_mapping_inhibit: init_ipmi,
-        initial_inhibit_any_policy: init_iiap,
-        initial_policy_set: init_ips,
-        enforce_trust_anchor_constraints: init_etac,
-        enforce_trust_anchor_validity: init_etav,
-        permitted_subtrees: init_perm,
-        excluded_subtrees: init_excl,
-    } = use_hook(|| load_persisted_settings().unwrap_or_else(default_settings));
-    let NameConstraintInputs {
-        dns_name: init_perm_dns,
-        rfc822_name: init_perm_email,
-        directory_name: init_perm_dn,
-        uniform_resource_identifier: init_perm_uri,
-        ip_address: init_perm_ip,
-    } = init_perm;
-    let NameConstraintInputs {
-        dns_name: init_excl_dns,
-        rfc822_name: init_excl_email,
-        directory_name: init_excl_dn,
-        uniform_resource_identifier: init_excl_uri,
-        ip_address: init_excl_ip,
-    } = init_excl;
-
-    // A custom time of interest is restored as-is; otherwise it is (re)initialized to the current
-    // time so a stale stored time cannot silently drive validation. `toi_custom` tracks which.
-    let mut toi_custom = use_signal(move || init_toi_custom);
-    let mut toi = use_signal(move || {
-        if init_toi_custom {
-            init_toi.to_string()
-        } else {
-            now_as_unix_epoch().to_string()
-        }
-    });
-    let mut validate_all = use_signal(move || init_validate_all);
+    // The settings are held as a single SettingsModel, edited through the shared EditSettings form
+    // and persisted as CertificationPathSettings JSON. A stored time of interest is restored as-is;
+    // its absence means "current time", which run_settings materializes per run, so a stale stored
+    // time can never silently drive validation.
+    let mut settings = use_signal(|| SettingsModel::from_cps(&LocalStorageSettingsStore.load()));
+    // Bumped whenever the model is replaced wholesale (loading a settings file, Reset). EditSettings
+    // seeds its own working copy from `initial` once per mount, so the form is keyed on this to
+    // remount and pick the new values up.
+    let mut form_gen = use_signal(|| 0usize);
+    let mut validate_all = use_signal(load_validate_all);
     // Transient status line for the settings-file load/save controls (cleared on next action)
     let mut settings_status = use_signal(String::new);
     let mut targets = use_signal(Vec::<TargetReport>::new);
@@ -294,58 +254,24 @@ fn App() -> Element {
     // because nothing is prepared yet.
     let mut env_dirty = use_signal(|| true);
 
-    // RFC 5280 path validation inputs (defaults match CertificationPathSettings::default())
-    let mut initial_explicit_policy = use_signal(move || init_iep);
-    let mut initial_policy_mapping_inhibit = use_signal(move || init_ipmi);
-    let mut initial_inhibit_any_policy = use_signal(move || init_iiap);
-    let mut initial_policy_set = use_signal(move || init_ips);
-    let mut enforce_ta_constraints = use_signal(move || init_etac);
-    let mut enforce_ta_validity = use_signal(move || init_etav);
-
-    // RFC 5280 initial-permitted / initial-excluded subtrees, one entry per line per name form
-    let mut perm_dns = use_signal(move || init_perm_dns);
-    let mut perm_email = use_signal(move || init_perm_email);
-    let mut perm_dn = use_signal(move || init_perm_dn);
-    let mut perm_uri = use_signal(move || init_perm_uri);
-    let mut perm_ip = use_signal(move || init_perm_ip);
-    let mut excl_dns = use_signal(move || init_excl_dns);
-    let mut excl_email = use_signal(move || init_excl_email);
-    let mut excl_dn = use_signal(move || init_excl_dn);
-    let mut excl_uri = use_signal(move || init_excl_uri);
-    let mut excl_ip = use_signal(move || init_excl_ip);
-
-    let current_settings = move || ValidationSettings {
-        toi: toi().parse::<u64>().unwrap_or_else(|_| now_as_unix_epoch()),
-        toi_custom: toi_custom(),
-        validate_all: validate_all(),
-        initial_explicit_policy: initial_explicit_policy(),
-        initial_policy_mapping_inhibit: initial_policy_mapping_inhibit(),
-        initial_inhibit_any_policy: initial_inhibit_any_policy(),
-        initial_policy_set: initial_policy_set(),
-        enforce_trust_anchor_constraints: enforce_ta_constraints(),
-        enforce_trust_anchor_validity: enforce_ta_validity(),
-        permitted_subtrees: NameConstraintInputs {
-            dns_name: perm_dns(),
-            rfc822_name: perm_email(),
-            directory_name: perm_dn(),
-            uniform_resource_identifier: perm_uri(),
-            ip_address: perm_ip(),
-        },
-        excluded_subtrees: NameConstraintInputs {
-            dns_name: excl_dns(),
-            rfc822_name: excl_email(),
-            directory_name: excl_dn(),
-            uniform_resource_identifier: excl_uri(),
-            ip_address: excl_ip(),
-        },
-    };
-
-    // Persist the settings tab to localStorage whenever any of its inputs change, and mark the
-    // prepared environment stale (settings can affect partial-path discovery). Reading every field
-    // through current_settings() subscribes this effect to all of them, so any edit fires it.
+    // Persist the settings whenever the model changes, and mark the prepared environment stale
+    // (settings can affect partial-path discovery). Reading the model here subscribes this effect
+    // to every field at once — the single-signal equivalent of the per-field reads this replaced.
     use_effect(move || {
-        persist_settings(&current_settings());
+        let mut cps = LocalStorageSettingsStore.load();
+        settings().apply(&mut cps);
+        if let Err(e) = LocalStorageSettingsStore.save(&cps) {
+            settings_status.set(e);
+        }
         env_dirty.set(true);
+    });
+
+    // Validate-all is persisted separately; it is not a CertificationPathSettings value.
+    use_effect(move || {
+        let _ = storage_set(
+            VALIDATE_ALL_KEY,
+            if validate_all() { "true" } else { "false" },
+        );
     });
 
     // The store selection and uploaded trust anchors / CA certificates also feed the prepared
@@ -357,24 +283,19 @@ fn App() -> Element {
         env_dirty.set(true);
     });
 
-    // Restores every setting to its initial default (time of interest reset to the current time).
-    let reset_settings = move |_| {
-        toi.set(now_as_unix_epoch().to_string());
-        toi_custom.set(false);
-        validate_all.set(true);
-        initial_explicit_policy.set(false);
-        initial_policy_mapping_inhibit.set(false);
-        initial_inhibit_any_policy.set(false);
-        initial_policy_set.set(ANY_POLICY_OID.to_string());
-        enforce_ta_constraints.set(false);
-        enforce_ta_validity.set(true);
-        settings_status.set(String::new());
-        for mut s in [
-            perm_dns, perm_email, perm_dn, perm_uri, perm_ip, excl_dns, excl_email, excl_dn,
-            excl_uri, excl_ip,
-        ] {
-            s.set(String::new());
-        }
+    // Replaces the whole model, remounting the form so it reseeds from the new values. Used by
+    // Reset to defaults and by loading a settings file.
+    let mut replace_settings = move |model: SettingsModel| {
+        settings.set(model);
+        form_gen += 1;
+    };
+
+    // The time a run validates against, for stamping reports: the chosen time of interest, or the
+    // current time when none is set. Mirrors what run_settings materializes into the settings.
+    let effective_toi = move || {
+        settings()
+            .time_of_interest
+            .unwrap_or_else(now_as_unix_epoch)
     };
 
     // Ensures the selected built-in store's CBOR is available, fetching (and caching) it on first
@@ -418,10 +339,7 @@ fn App() -> Element {
     // downloads the accumulated results as a JSON-serialized ValidationReport via a synthesized
     // anchor click
     let save_results = move |_| {
-        let report = ValidationReport::from_targets(
-            &targets.read(),
-            toi().parse::<u64>().unwrap_or_else(|_| now_as_unix_epoch()),
-        );
+        let report = ValidationReport::from_targets(&targets.read(), effective_toi());
         let json = serde_json::to_string_pretty(&report).unwrap_or_default();
         let uri = format!(
             "data:application/json;charset=utf-8,{}",
@@ -439,12 +357,10 @@ fn App() -> Element {
     // time of interest is omitted so the file stays portable (the reader supplies its own current
     // time); an explicitly set one is written so it travels with the file.
     let save_settings_file = move |_| {
-        let vs = current_settings();
-        let mut discard = vec![];
-        let mut cps = make_cps(&vs, &mut discard);
-        if !vs.toi_custom {
-            cps.0.remove(PS_TIME_OF_INTEREST);
-        }
+        // Written from the model, not from run_settings: a time of interest the user did not choose
+        // stays absent so the file remains portable, and the reader supplies its own current time.
+        let mut cps = LocalStorageSettingsStore.load();
+        settings().apply(&mut cps);
         let json = serde_json::to_string_pretty(&cps).unwrap_or_default();
         let uri = format!(
             "data:application/json;charset=utf-8,{}",
@@ -458,11 +374,10 @@ fn App() -> Element {
         settings_status.set("Settings downloaded".to_string());
     };
 
-    // loads settings from a certval CertificationPathSettings JSON file (the CLI/desktop format),
-    // replacing every field above. A setting absent from the file takes its certval default, so the
-    // loaded state matches the file exactly. The time of interest is honored (and marked custom)
-    // when present, or reset to the current time when absent; validate-all is not part of the format
-    // and is left unchanged.
+    // loads settings from a certval CertificationPathSettings JSON file (the same format the CLI's
+    // --settings reads and the desktop editor writes), replacing the model wholesale. A setting
+    // absent from the file takes its certval default, so the loaded state matches the file exactly.
+    // Validate-all is not part of the format and is left unchanged.
     let load_settings_file = move |ev: FormEvent| async move {
         let Some((name, bytes)) = read_files(&ev).await.into_iter().next() else {
             return;
@@ -481,57 +396,7 @@ fn App() -> Element {
                 return;
             }
         };
-        let m = SettingsModel::from_cps(&cps);
-        match m.time_of_interest {
-            Some(secs) => {
-                toi.set(secs.to_string());
-                toi_custom.set(true);
-            }
-            None => {
-                toi.set(now_as_unix_epoch().to_string());
-                toi_custom.set(false);
-            }
-        }
-        initial_explicit_policy.set(m.initial_explicit_policy_indicator.unwrap_or(false));
-        initial_policy_mapping_inhibit
-            .set(m.initial_policy_mapping_inhibit_indicator.unwrap_or(false));
-        initial_inhibit_any_policy.set(m.initial_inhibit_any_policy_indicator.unwrap_or(false));
-        initial_policy_set.set(
-            m.initial_policy_set
-                .map(|v| v.join(" "))
-                .unwrap_or_else(|| ANY_POLICY_OID.to_string()),
-        );
-        enforce_ta_constraints.set(m.enforce_trust_anchor_constraints.unwrap_or(false));
-        enforce_ta_validity.set(m.enforce_trust_anchor_validity.unwrap_or(true));
-        // one entry per line per name form; the unsupported-forms bucket is not surfaced
-        let perm = m.initial_permitted_subtrees.unwrap_or_default();
-        perm_dns.set(perm.dns_name.map(|v| v.join("\n")).unwrap_or_default());
-        perm_email.set(perm.rfc822_name.map(|v| v.join("\n")).unwrap_or_default());
-        perm_dn.set(
-            perm.directory_name
-                .map(|v| v.join("\n"))
-                .unwrap_or_default(),
-        );
-        perm_uri.set(
-            perm.uniform_resource_identifier
-                .map(|v| v.join("\n"))
-                .unwrap_or_default(),
-        );
-        perm_ip.set(perm.ip_address.map(|v| v.join("\n")).unwrap_or_default());
-        let excl = m.initial_excluded_subtrees.unwrap_or_default();
-        excl_dns.set(excl.dns_name.map(|v| v.join("\n")).unwrap_or_default());
-        excl_email.set(excl.rfc822_name.map(|v| v.join("\n")).unwrap_or_default());
-        excl_dn.set(
-            excl.directory_name
-                .map(|v| v.join("\n"))
-                .unwrap_or_default(),
-        );
-        excl_uri.set(
-            excl.uniform_resource_identifier
-                .map(|v| v.join("\n"))
-                .unwrap_or_default(),
-        );
-        excl_ip.set(excl.ip_address.map(|v| v.join("\n")).unwrap_or_default());
+        replace_settings(SettingsModel::from_cps(&cps));
         settings_status.set(format!("Loaded settings from {name}"));
     };
 
@@ -547,9 +412,9 @@ fn App() -> Element {
         // each Validate replaces the prior results rather than appending to them
         targets.write().clear();
         notes.write().clear();
-        let vs = current_settings();
+        let cps = run_settings(&settings());
         for (name, bytes) in loaded_zips() {
-            let (reports, lines) = validate_hackathon_zip(&name, bytes, &vs);
+            let (reports, lines) = validate_hackathon_zip(&name, bytes, &cps, validate_all());
             notes.write().extend(lines);
             targets.write().extend(reports);
         }
@@ -572,9 +437,8 @@ fn App() -> Element {
         #[cfg(target_family = "wasm")]
         gloo_timers::future::TimeoutFuture::new(16).await;
 
-        let vs = current_settings();
-        let mut base_notes = vec![];
-        let cps = make_cps(&vs, &mut base_notes);
+        let base_notes: Vec<ResultLine> = vec![];
+        let cps = run_settings(&settings());
 
         // Rebuild the prepared environment only when it is stale (or absent); otherwise reuse the
         // cached one, skipping the store fetch, reparse and partial-path discovery.
@@ -615,7 +479,7 @@ fn App() -> Element {
         let guard = prepared_env.read();
         let (prepared, prep_notes) = guard.as_ref().unwrap();
         notes.write().extend(prep_notes.iter().cloned());
-        let (reports, lines) = validate_prepared(prepared, &cps, &loaded_ees(), vs.validate_all);
+        let (reports, lines) = validate_prepared(prepared, &cps, &loaded_ees(), validate_all());
         drop(guard);
         notes.write().extend(lines);
         targets.write().extend(reports);
@@ -753,6 +617,23 @@ fn App() -> Element {
                             }
                         }
 
+                        // Validate All sits beside the Validate button rather than in Settings: it
+                        // chooses how much of a run to do, not what a path must satisfy, and it is
+                        // not a CertificationPathSettings value. The desktop app surfaces it the
+                        // same way, on its Validate view.
+                        div { class: "controls center-row",
+                            label { r#for: "validate-all", "Validate all paths: " }
+                            input {
+                                id: "validate-all",
+                                r#type: "checkbox",
+                                checked: validate_all(),
+                                onchange: move |ev| validate_all.set(ev.checked()),
+                            }
+                            span { class: "hint",
+                                "Off stops at the first valid path; on reports every path found."
+                            }
+                        }
+
                         div { class: "controls center-row",
                             button {
                                 class: "validate-button",
@@ -767,147 +648,20 @@ fn App() -> Element {
                         }
                     },
                     1 => rsx! {
-                        fieldset {
-                            legend { "Path validation settings (RFC 5280 / RFC 5937 inputs)" }
-                            fieldset {
-                                legend { "General" }
-                                div { class: "controls",
-                                    label { r#for: "toi", "Time of interest (Unix epoch): " }
-                                    span {
-                                        input {
-                                            id: "toi",
-                                            r#type: "text",
-                                            value: "{toi}",
-                                            oninput: move |ev| {
-                                                toi.set(ev.value());
-                                                toi_custom.set(true);
-                                            },
-                                        }
-                                        button {
-                                            onclick: move |_| {
-                                                toi.set(now_as_unix_epoch().to_string());
-                                                toi_custom.set(false);
-                                            },
-                                            "Now"
-                                        }
-                                        // Value mirrors the epoch field so the picker shows the selected
-                                        // time (no need to decode the number). Controlled binding is safe
-                                        // here because only onchange (a complete datetime) writes back:
-                                        // editing the sub-fields triggers no re-render until commit, so the
-                                        // value is not reset mid-edit. step=1 keeps second precision.
-                                        input {
-                                            r#type: "datetime-local",
-                                            step: "1",
-                                            value: toi_datetime_value(&toi()),
-                                            onchange: move |ev| {
-                                                if let Some(secs) = datetime_local_to_epoch(&ev.value()) {
-                                                    toi.set(secs.to_string());
-                                                    toi_custom.set(true);
-                                                }
-                                            },
-                                        }
-                                    }
-
-                                    label { r#for: "validate-all", "Validate all paths: " }
-                                    input {
-                                        id: "validate-all",
-                                        r#type: "checkbox",
-                                        checked: validate_all(),
-                                        onchange: move |ev| validate_all.set(ev.checked()),
-                                    }
-
-                                    label { r#for: "enforce-ta-constraints", "Enforce trust anchor constraints: " }
-                                    input {
-                                        id: "enforce-ta-constraints",
-                                        r#type: "checkbox",
-                                        checked: enforce_ta_constraints(),
-                                        onchange: move |ev| enforce_ta_constraints.set(ev.checked()),
-                                    }
-
-                                    label { r#for: "enforce-ta-validity", "Enforce trust anchor validity: " }
-                                    input {
-                                        id: "enforce-ta-validity",
-                                        r#type: "checkbox",
-                                        checked: enforce_ta_validity(),
-                                        onchange: move |ev| enforce_ta_validity.set(ev.checked()),
-                                    }
-                                }
-                            }
-                            fieldset {
-                                legend { "Certificate Policy-related constraints" }
-                                div { class: "controls",
-                                    label { r#for: "initial-explicit-policy", "Require explicit policy: " }
-                                    input {
-                                        id: "initial-explicit-policy",
-                                        r#type: "checkbox",
-                                        checked: initial_explicit_policy(),
-                                        onchange: move |ev| initial_explicit_policy.set(ev.checked()),
-                                    }
-
-                                    label { r#for: "inhibit-policy-mapping", "Inhibit policy mapping: " }
-                                    input {
-                                        id: "inhibit-policy-mapping",
-                                        r#type: "checkbox",
-                                        checked: initial_policy_mapping_inhibit(),
-                                        onchange: move |ev| initial_policy_mapping_inhibit.set(ev.checked()),
-                                    }
-
-                                    label { r#for: "inhibit-any-policy", "Inhibit anyPolicy: " }
-                                    input {
-                                        id: "inhibit-any-policy",
-                                        r#type: "checkbox",
-                                        checked: initial_inhibit_any_policy(),
-                                        onchange: move |ev| initial_inhibit_any_policy.set(ev.checked()),
-                                    }
-
-                                    label { r#for: "initial-policy-set", "Initial policy set (OIDs): " }
-                                    input {
-                                        id: "initial-policy-set",
-                                        r#type: "text",
-                                        value: "{initial_policy_set}",
-                                        oninput: move |ev| initial_policy_set.set(ev.value()),
-                                    }
-
-                                    span { class: "hint",
-                                        "Separate policy OIDs with spaces or commas; {ANY_POLICY_OID} is anyPolicy."
-                                    }
-                                }
-                            }
-                            // Initial permitted/excluded subtrees are RFC 5280 name-constraint inputs,
-                            // so they live inside the RFC 5280 group rather than as standalone boxes.
-                            fieldset {
-                                legend { "Initial permitted subtrees (name constraints)" }
-                                div { class: "controls",
-                                    label { "dNSName: " }
-                                    textarea { rows: "2", value: "{perm_dns}", oninput: move |ev| perm_dns.set(ev.value()) }
-                                    label { "rfc822Name (email): " }
-                                    textarea { rows: "2", value: "{perm_email}", oninput: move |ev| perm_email.set(ev.value()) }
-                                    label { "directoryName (DN): " }
-                                    textarea { rows: "2", value: "{perm_dn}", oninput: move |ev| perm_dn.set(ev.value()) }
-                                    label { "URI: " }
-                                    textarea { rows: "2", value: "{perm_uri}", oninput: move |ev| perm_uri.set(ev.value()) }
-                                    label { "iPAddress (CIDR): " }
-                                    textarea { rows: "2", value: "{perm_ip}", oninput: move |ev| perm_ip.set(ev.value()) }
-                                    span { class: "hint",
-                                        "One entry per line; an empty box imposes no initial permitted constraint for that name form."
-                                    }
-                                }
-                            }
-                            fieldset {
-                                legend { "Initial excluded subtrees (name constraints)" }
-                                div { class: "controls",
-                                    label { "dNSName: " }
-                                    textarea { rows: "2", value: "{excl_dns}", oninput: move |ev| excl_dns.set(ev.value()) }
-                                    label { "rfc822Name (email): " }
-                                    textarea { rows: "2", value: "{excl_email}", oninput: move |ev| excl_email.set(ev.value()) }
-                                    label { "directoryName (DN): " }
-                                    textarea { rows: "2", value: "{excl_dn}", oninput: move |ev| excl_dn.set(ev.value()) }
-                                    label { "URI: " }
-                                    textarea { rows: "2", value: "{excl_uri}", oninput: move |ev| excl_uri.set(ev.value()) }
-                                    label { "iPAddress (CIDR): " }
-                                    textarea { rows: "2", value: "{excl_ip}", oninput: move |ev| excl_ip.set(ev.value()) }
-                                    span { class: "hint", "One entry per line." }
-                                }
+                        // The shared settings form, the same component the desktop app mounts. It
+                        // presents every tab including the ones this frontend cannot act on, each
+                        // carrying a notice saying so — see Capabilities. Keyed on form_gen so a
+                        // wholesale model replacement (Reset, or loading a file) remounts it.
+                        div { key: "{form_gen}",
+                            EditSettings {
+                                initial: settings(),
+                                caps: Capabilities::browser_local(),
+                                now: now_as_unix_epoch(),
+                                on_save: move |edited| {
+                                    settings.set(edited);
+                                    settings_status.set("Settings saved".to_string());
+                                },
+                                on_close: move |_| view.set(0),
                             }
                         }
                         fieldset {
@@ -932,9 +686,6 @@ fn App() -> Element {
                                     span { class: "hint", "{settings_status}" }
                                 }
                             }
-                        }
-                        div { class: "controls center-row",
-                            button { onclick: reset_settings, "Reset to defaults" }
                         }
                     },
                     2 => rsx! {
@@ -965,7 +716,7 @@ fn App() -> Element {
                                 ResultsView {
                                     report: ValidationReport::from_targets(
                                         &targets.read(),
-                                        toi().parse::<u64>().unwrap_or_else(|_| now_as_unix_epoch()),
+                                        effective_toi(),
                                     ),
                                 }
                             }

--- a/pittv3-wasm/src/validate.rs
+++ b/pittv3-wasm/src/validate.rs
@@ -70,6 +70,7 @@ mod tests {
     // glob-importing certval the way the pre-split file did.
     use super::*;
     use certval::*;
+    use pittv3_gui_lib::gui_settings_model::SettingsModel;
     use pittv3_lib::report::{TargetReport, TargetStatus};
 
     // The app fetches store CBOR at runtime; the native tests read it straight from the resources
@@ -80,21 +81,16 @@ mod tests {
         include_bytes!("../resources/pkits_ml_dsa_44_ca.cbor"),
     );
 
-    fn test_settings() -> ValidationSettings {
-        ValidationSettings {
+    /// The settings a test run uses, built through the same SettingsModel the settings form edits.
+    fn test_settings() -> CertificationPathSettings {
+        let model = SettingsModel {
             // 0 disables validity period checks so the baked PKITS edition stays usable
-            toi: 0,
-            toi_custom: false,
-            validate_all: true,
-            initial_explicit_policy: false,
-            initial_policy_mapping_inhibit: false,
-            initial_inhibit_any_policy: false,
-            initial_policy_set: String::new(),
-            enforce_trust_anchor_constraints: false,
-            enforce_trust_anchor_validity: true,
-            permitted_subtrees: NameConstraintInputs::default(),
-            excluded_subtrees: NameConstraintInputs::default(),
-        }
+            time_of_interest: Some(0),
+            ..SettingsModel::default()
+        };
+        let mut cps = CertificationPathSettings::default();
+        model.apply(&mut cps);
+        cps
     }
 
     /// Prepares an environment for `store` and validates `ees` against it in one call, as the
@@ -102,13 +98,12 @@ mod tests {
     fn validate_batch(
         store: (&str, &[u8], &[u8]),
         ees: &[(String, Vec<u8>)],
-        vs: &ValidationSettings,
+        cps: &CertificationPathSettings,
     ) -> (Vec<TargetReport>, Vec<ResultLine>) {
         let mut notes = vec![];
-        let cps = make_cps(vs, &mut notes);
-        let (prepared, prep_notes) = prepare_validation(Some(store), &[], &[], &cps).unwrap();
+        let (prepared, prep_notes) = prepare_validation(Some(store), &[], &[], cps).unwrap();
         notes.extend(prep_notes);
-        let (reports, lines) = validate_prepared(&prepared, &cps, ees, vs.validate_all);
+        let (reports, lines) = validate_prepared(&prepared, cps, ees, true);
         notes.extend(lines);
         (reports, notes)
     }
@@ -155,15 +150,14 @@ mod tests {
 
     #[test]
     fn cps_json_round_trips_no_std() {
-        let vs = ValidationSettings {
-            toi: 1647264981,
-            toi_custom: true,
-            initial_explicit_policy: true,
-            initial_policy_set: "2.16.840.1.101.3.2.1.48.1".to_string(),
-            ..test_settings()
+        let model = SettingsModel {
+            time_of_interest: Some(1647264981),
+            initial_explicit_policy_indicator: Some(true),
+            initial_policy_set: Some(vec!["2.16.840.1.101.3.2.1.48.1".to_string()]),
+            ..SettingsModel::default()
         };
-        let mut notes = vec![];
-        let cps = make_cps(&vs, &mut notes);
+        let mut cps = CertificationPathSettings::default();
+        model.apply(&mut cps);
         let json = serde_json::to_string(&cps).unwrap();
         // current certval stores the time of interest as the TimeOfInterest variant (a bare u64),
         // not the legacy psTimeOfInterest {"U64": ...} form that predates the TimeOfInterest type


### PR DESCRIPTION
A Capabilities struct (filesystem, network, revocation) replaces the show_folders flag in preparation for give flavors of pittv3 (cli, desktop, wasm, wasm+proxy, server-hosted).

Added a new a new SettingsStore trait in pittv3-gui-lib to facilitate usage of a common settings format across all variants.