### PR TITLE
Move time-related helpers and rows into pittv3-gui-lib and improve tooltips

### DIFF
--- a/pittv3-gui-lib/src/gui_rows.rs
+++ b/pittv3-gui-lib/src/gui_rows.rs
@@ -1,0 +1,220 @@
+//! Labeled input rows shared by the GUI frontends.
+//!
+//! These are the building blocks of the argument-shaped forms (Validate, Generate, Diagnostics on
+//! the desktop) as distinct from the override-aware settings form in
+//! [`gui_settings`](crate::gui_settings), whose rows carry `Option` values and a default/override
+//! hint. Both kinds exist on purpose; a row here binds a [`Signal`] directly because the value it
+//! edits always has one.
+//!
+//! Everything here is renderer-agnostic and free of filesystem access, so it compiles for wasm32 as
+//! well as the host. Choosing a file or folder is the one part that is not portable, so
+//! [`BrowseRow`] takes the browse action as a callback and each frontend supplies its own — a
+//! native dialog on the desktop, and nothing (or an upload control) in the browser.
+
+use dioxus::prelude::*;
+
+use pittv3_lib::help::arg_help;
+
+/// The tooltip for a row: an explicit `title` when the frontend supplies one, otherwise the help
+/// text for the argument the row's `name` identifies. Defaulting this way means a control is
+/// described in the same words as the CLI flag that sets it, without every call site repeating the
+/// description, and a row whose name is not an argument simply gets no tooltip.
+fn tooltip(title: String, name: &str) -> String {
+    if title.is_empty() {
+        arg_help(name).to_string()
+    } else {
+        title
+    }
+}
+
+/// Current time in Unix-epoch seconds. Uses `web_time` so the same call works in the browser and on
+/// the host.
+pub fn now_as_unix_epoch() -> u64 {
+    match web_time::SystemTime::now().duration_since(web_time::UNIX_EPOCH) {
+        Ok(n) => n.as_secs(),
+        Err(_) => 0,
+    }
+}
+
+/// Formats Unix-epoch seconds as a `datetime-local` value (`YYYY-MM-DDTHH:MM:SS`) in UTC.
+///
+/// Built on `der::DateTime` rather than a platform clock API so the same rendering serves the
+/// desktop and the browser; the browser previously showed local time here and the desktop UTC,
+/// which made the same stored setting read differently in the two frontends.
+pub fn epoch_to_datetime_local(secs: u64) -> String {
+    match x509_cert::der::DateTime::from_unix_duration(core::time::Duration::from_secs(secs)) {
+        Ok(dt) => format!(
+            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
+            dt.year(),
+            dt.month(),
+            dt.day(),
+            dt.hour(),
+            dt.minutes(),
+            dt.seconds()
+        ),
+        Err(_) => String::new(),
+    }
+}
+
+/// Parses a `datetime-local` value (`YYYY-MM-DDTHH:MM` or `...:SS`, interpreted as UTC) back to
+/// Unix-epoch seconds; inverse of [`epoch_to_datetime_local`].
+pub fn datetime_local_to_epoch(value: &str) -> Option<u64> {
+    let v = value.trim();
+    let rfc3339 = match v.len() {
+        16 => format!("{v}:00Z"), // picker omitted the seconds component
+        19 => format!("{v}Z"),
+        _ => return None,
+    };
+    rfc3339
+        .parse::<x509_cert::der::DateTime>()
+        .ok()
+        .map(|dt| dt.unix_duration().as_secs())
+}
+
+/// The `datetime-local` value mirroring a time-of-interest epoch string, so a picker shows the
+/// selected time; empty when the time is disabled (0) or mid-edit (not yet a valid epoch).
+pub fn toi_datetime_value(toi: &str) -> String {
+    match toi.trim().parse::<u64>() {
+        Ok(secs) if secs != 0 => epoch_to_datetime_local(secs),
+        _ => String::new(),
+    }
+}
+
+/// Table row with a labeled text input and no accompanying selection dialog.
+///
+/// `title` overrides the label's tooltip; left empty it falls back to the argument help for `name`.
+#[component]
+pub fn TextRow(
+    label: String,
+    name: String,
+    sig: Signal<String>,
+    #[props(default)] title: String,
+) -> Element {
+    let title = tooltip(title, &name);
+    rsx! {
+        tr {
+            td {
+                div { title, class: "visible",
+                    label { r#for: name.clone(), "{label}: " }
+                }
+            }
+            td { class: "grow",
+                input {
+                    r#type: "text",
+                    name,
+                    value: "{sig}",
+                    oninput: move |ev| sig.set(ev.value()),
+                }
+            }
+        }
+    }
+}
+
+/// Table row with a labeled text input and a browse button. The browse action is supplied by the
+/// frontend, since choosing a file or folder is the one part of this row that is not portable.
+#[component]
+pub fn BrowseRow(
+    label: String,
+    name: String,
+    sig: Signal<String>,
+    on_browse: EventHandler<()>,
+    #[props(default)] title: String,
+) -> Element {
+    let title = tooltip(title, &name);
+    rsx! {
+        tr {
+            td {
+                div { title, class: "visible",
+                    label { r#for: name.clone(), "{label}: " }
+                }
+            }
+            td { class: "grow",
+                input {
+                    r#type: "text",
+                    name,
+                    value: "{sig}",
+                    oninput: move |ev| sig.set(ev.value()),
+                }
+            }
+            td { class: "nowrap",
+                button {
+                    r#type: "button",
+                    onclick: move |_| on_browse.call(()),
+                    "..."
+                }
+            }
+        }
+    }
+}
+
+/// Table row for a time of interest held as an epoch string: the epoch field, a Now button, and a
+/// human-readable picker mirroring it in UTC.
+#[component]
+pub fn TimeRow(
+    label: String,
+    name: String,
+    sig: Signal<String>,
+    #[props(default)] title: String,
+) -> Element {
+    let title = tooltip(title, &name);
+    rsx! {
+        tr {
+            td {
+                div { title, class: "visible",
+                    label { r#for: name.clone(), "{label}: " }
+                }
+            }
+            td { class: "grow",
+                input {
+                    r#type: "text",
+                    name,
+                    value: "{sig}",
+                    oninput: move |ev| sig.set(ev.value()),
+                }
+            }
+            td { class: "nowrap",
+                button {
+                    r#type: "button",
+                    onclick: move |_| sig.set(now_as_unix_epoch().to_string()),
+                    "Now"
+                }
+                // Editable human-readable picker mirroring the epoch field (UTC). onchange fires
+                // only on a complete datetime, so it never clobbers a mid-edit epoch value.
+                input {
+                    r#type: "datetime-local",
+                    step: "1",
+                    value: toi_datetime_value(&sig()),
+                    onchange: move |ev| {
+                        if let Some(secs) = datetime_local_to_epoch(&ev.value()) {
+                            sig.set(secs.to_string());
+                        }
+                    },
+                }
+            }
+        }
+    }
+}
+
+/// Labeled checkbox cell for use within a table row
+#[component]
+pub fn CheckboxCell(
+    label: String,
+    name: String,
+    sig: Signal<bool>,
+    #[props(default)] title: String,
+) -> Element {
+    let title = tooltip(title, &name);
+    rsx! {
+        td { class: "check",
+            div { title, class: "visible",
+                label { r#for: name.clone(), "{label}: " }
+                input {
+                    r#type: "checkbox",
+                    name,
+                    checked: sig(),
+                    onchange: move |ev| sig.set(ev.checked()),
+                }
+            }
+        }
+    }
+}

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -22,9 +22,9 @@
 use dioxus::prelude::*;
 
 use certval::{NameConstraintsSettings, OcspNonceSetting};
-use x509_cert::der::DateTime;
 use x509_cert::ext::pkix::KeyUsages;
 
+use crate::gui_rows::{datetime_local_to_epoch, epoch_to_datetime_local, now_as_unix_epoch};
 use crate::gui_settings_model::{RevocationMode, SettingsModel};
 
 #[cfg(feature = "std")]
@@ -81,45 +81,10 @@ fn CapabilityNotice(message: String) -> Element {
     }
 }
 
-/// Formats Unix-epoch seconds as a `datetime-local` value (`YYYY-MM-DDTHH:MM:SS`) in UTC.
-///
-/// Built on `der::DateTime` rather than a platform clock API so the same rendering serves the
-/// desktop and the browser; the browser previously showed local time here and the desktop UTC,
-/// which made the same stored setting read differently in the two frontends.
-fn epoch_to_datetime_local(secs: u64) -> String {
-    match DateTime::from_unix_duration(core::time::Duration::from_secs(secs)) {
-        Ok(dt) => format!(
-            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
-            dt.year(),
-            dt.month(),
-            dt.day(),
-            dt.hour(),
-            dt.minutes(),
-            dt.seconds()
-        ),
-        Err(_) => String::new(),
-    }
-}
-
-/// Parses a `datetime-local` value (`YYYY-MM-DDTHH:MM` or `...:SS`, interpreted as UTC) back to
-/// Unix-epoch seconds; inverse of [`epoch_to_datetime_local`].
-fn datetime_local_to_epoch(value: &str) -> Option<u64> {
-    let v = value.trim();
-    let rfc3339 = match v.len() {
-        16 => format!("{v}:00Z"), // picker omitted the seconds component
-        19 => format!("{v}Z"),
-        _ => return None,
-    };
-    rfc3339
-        .parse::<DateTime>()
-        .ok()
-        .map(|dt| dt.unix_duration().as_secs())
-}
-
 /// Table row for the time of interest: the epoch value, a Now button, and a human-readable picker
 /// mirroring it. An empty value clears the override, which means "the time of the run".
 #[component]
-fn TimeOfInterestRow(value: Option<u64>, now: u64, onchange: EventHandler<Option<u64>>) -> Element {
+fn TimeOfInterestRow(value: Option<u64>, onchange: EventHandler<Option<u64>>) -> Element {
     let display = value.map(|v| v.to_string()).unwrap_or_default();
     // Empty while the value is absent or disabled (0), so the picker does not claim a time that is
     // not in effect.
@@ -147,7 +112,7 @@ fn TimeOfInterestRow(value: Option<u64>, now: u64, onchange: EventHandler<Option
                 }
                 button {
                     r#type: "button",
-                    onclick: move |_| onchange.call(Some(now)),
+                    onclick: move |_| onchange.call(Some(now_as_unix_epoch())),
                     "Now"
                 }
                 // onchange fires only on a complete datetime, so it never clobbers a mid-edit epoch
@@ -172,17 +137,6 @@ fn TimeOfInterestRow(value: Option<u64>, now: u64, onchange: EventHandler<Option
                 }
             }
         }
-    }
-}
-
-/// Current time in Unix-epoch seconds, for the time-of-interest Now button. `web_time` so the same
-/// call works in the browser and on the host. Only the file-backed wrapper needs it; frontends that
-/// mount [`EditSettings`] directly pass their own `now`.
-#[cfg(feature = "std")]
-fn now_as_unix_epoch() -> u64 {
-    match web_time::SystemTime::now().duration_since(web_time::UNIX_EPOCH) {
-        Ok(n) => n.as_secs(),
-        Err(_) => 0,
     }
 }
 
@@ -280,7 +234,7 @@ fn NumberRow(
 
 /// Table row with a labeled text input; an empty value clears the override
 #[component]
-fn TextRow(
+fn SettingTextRow(
     label: &'static str,
     value: Option<String>,
     onchange: EventHandler<Option<String>>,
@@ -575,7 +529,6 @@ const TABS: &[(SettingsTab, &str)] = &[
 pub fn EditSettings(
     initial: SettingsModel,
     #[props(default)] caps: Capabilities,
-    now: u64,
     on_save: EventHandler<SettingsModel>,
     on_close: EventHandler<()>,
 ) -> Element {
@@ -717,7 +670,6 @@ pub fn EditSettings(
                             }
                             TimeOfInterestRow {
                                 value: m.time_of_interest,
-                                now,
                                 onchange: move |v| model.write().time_of_interest = v,
                             }
                             BoolRow {
@@ -911,27 +863,27 @@ pub fn EditSettings(
                     }
                     table {
                         tbody {
-                            TextRow {
+                            SettingTextRow {
                                 label: "Trust anchor folder",
                                 value: m.trust_anchor_folder.clone(),
                                 onchange: move |v| model.write().trust_anchor_folder = v,
                             }
-                            TextRow {
+                            SettingTextRow {
                                 label: "CA folder",
                                 value: m.certification_authority_folder.clone(),
                                 onchange: move |v| model.write().certification_authority_folder = v,
                             }
-                            TextRow {
+                            SettingTextRow {
                                 label: "Download folder",
                                 value: m.download_folder.clone(),
                                 onchange: move |v| model.write().download_folder = v,
                             }
-                            TextRow {
+                            SettingTextRow {
                                 label: "Last-modified map file",
                                 value: m.last_modified_map_file.clone(),
                                 onchange: move |v| model.write().last_modified_map_file = v,
                             }
-                            TextRow {
+                            SettingTextRow {
                                 label: "URI blocklist file",
                                 value: m.uri_blocklist_file.clone(),
                                 onchange: move |v| model.write().uri_blocklist_file = v,
@@ -990,7 +942,6 @@ pub fn EditSettingsFile(path: String, on_close: EventHandler<()>) -> Element {
         EditSettings {
             initial,
             caps: Capabilities::desktop(),
-            now: now_as_unix_epoch(),
             on_save,
             on_close: move |_| on_close.call(()),
         }

--- a/pittv3-gui-lib/src/lib.rs
+++ b/pittv3-gui-lib/src/lib.rs
@@ -6,6 +6,7 @@
 
 pub mod gui_help;
 pub mod gui_results;
+pub mod gui_rows;
 pub mod gui_settings;
 pub mod gui_settings_model;
 pub mod gui_shell;

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -13,6 +13,7 @@ use rfd::AsyncFileDialog;
 
 use pittv3_gui_lib::gui_help::HelpView;
 use pittv3_gui_lib::gui_results::{ResultsView, RunEvent};
+use pittv3_gui_lib::gui_rows::{BrowseRow, CheckboxCell, TextRow, TimeRow};
 use pittv3_gui_lib::gui_settings::EditSettingsFile;
 use pittv3_gui_lib::gui_shell::AppShell;
 use pittv3_gui_lib::gui_utils::{
@@ -90,103 +91,9 @@ fn usize_or_none(sig: Signal<String>) -> Option<usize> {
     }
 }
 
-/// Formats Unix-epoch seconds as a `datetime-local` value (`YYYY-MM-DDTHH:MM:SS`), or empty if
-/// unparseable. UTC, to match the RFC 3339 `Z` rendering shown alongside it.
-fn epoch_to_datetime_local(secs: u64) -> String {
-    match der::DateTime::from_unix_duration(core::time::Duration::from_secs(secs)) {
-        Ok(dt) => format!(
-            "{:04}-{:02}-{:02}T{:02}:{:02}:{:02}",
-            dt.year(),
-            dt.month(),
-            dt.day(),
-            dt.hour(),
-            dt.minutes(),
-            dt.seconds()
-        ),
-        Err(_) => String::new(),
-    }
-}
-
-/// Parses a `datetime-local` value (`YYYY-MM-DDTHH:MM` or `...:SS`, interpreted as UTC) back to
-/// Unix-epoch seconds; inverse of [`epoch_to_datetime_local`].
-fn datetime_local_to_epoch(value: &str) -> Option<u64> {
-    let v = value.trim();
-    let rfc3339 = match v.len() {
-        16 => format!("{v}:00Z"), // picker omitted the seconds component
-        19 => format!("{v}Z"),
-        _ => return None,
-    };
-    rfc3339
-        .parse::<der::DateTime>()
-        .ok()
-        .map(|dt| dt.unix_duration().as_secs())
-}
-
-/// The `datetime-local` value mirroring the time-of-interest epoch string, so the picker shows the
-/// selected time; empty when the time is disabled (0) or mid-edit (not yet a valid epoch).
-fn toi_datetime_value(toi: &str) -> String {
-    match toi.trim().parse::<u64>() {
-        Ok(secs) if secs != 0 => epoch_to_datetime_local(secs),
-        _ => String::new(),
-    }
-}
-
-/// Table row featuring the time of interest with a human-readable rendering and a Now button
-#[component]
-fn TimeRow(label: String, name: String, sig: Signal<String>) -> Element {
-    rsx! {
-        tr {
-            td { label { r#for: name.clone(), "{label}: " } }
-            td { class: "grow",
-                input {
-                    r#type: "text",
-                    name,
-                    value: "{sig}",
-                    oninput: move |ev| sig.set(ev.value()),
-                }
-            }
-            td { class: "nowrap",
-                button {
-                    r#type: "button",
-                    onclick: move |_| sig.set(get_now_as_unix_epoch().to_string()),
-                    "Now"
-                }
-                // Editable human-readable picker mirroring the epoch field (UTC). onchange fires
-                // only on a complete datetime, so it never clobbers a mid-edit epoch value.
-                input {
-                    r#type: "datetime-local",
-                    step: "1",
-                    value: toi_datetime_value(&sig()),
-                    onchange: move |ev| {
-                        if let Some(secs) = datetime_local_to_epoch(&ev.value()) {
-                            sig.set(secs.to_string());
-                        }
-                    },
-                }
-            }
-        }
-    }
-}
-
-/// Table row featuring a labeled text input with no accompanying selection dialog
-#[component]
-fn TextRow(label: String, name: String, sig: Signal<String>) -> Element {
-    rsx! {
-        tr {
-            td { label { r#for: name.clone(), "{label}: " } }
-            td { class: "grow",
-                input {
-                    r#type: "text",
-                    name,
-                    value: "{sig}",
-                    oninput: move |ev| sig.set(ev.value()),
-                }
-            }
-        }
-    }
-}
-
-/// Table row featuring a labeled text input with a folder selection dialog
+/// Table row with a labeled text input and a folder selection dialog. Thin wrapper over the shared
+/// [`BrowseRow`] supplying the native picker, which is the only part of the row that is not
+/// portable.
 #[component]
 fn FolderRow(
     label: String,
@@ -195,29 +102,20 @@ fn FolderRow(
     #[props(default)] title: String,
 ) -> Element {
     rsx! {
-        tr {
-            td {
-                div { title, class: "visible",
-                    label { r#for: name.clone(), "{label}: " }
-                }
-            }
-            td { class: "grow",
-                input {
-                    r#type: "text",
-                    name,
-                    value: "{sig}",
-                    oninput: move |ev| sig.set(ev.value()),
-                }
-            }
-            td { class: "nowrap",
-                button { r#type: "button", onclick: move |_| pick_folder_into(sig), "..." }
-            }
+        BrowseRow {
+            label,
+            name,
+            sig,
+            title,
+            on_browse: move |_| {
+                spawn(pick_folder_into(sig));
+            },
         }
     }
 }
 
-/// Table row featuring a labeled text input with a file selection dialog limited to files of the
-/// indicated type
+/// Table row with a labeled text input and a file selection dialog limited to files of the
+/// indicated type. Thin wrapper over the shared [`BrowseRow`], as with [`FolderRow`].
 #[component]
 fn FileRow(
     label: String,
@@ -225,41 +123,17 @@ fn FileRow(
     sig: Signal<String>,
     filter_name: &'static str,
     extensions: &'static [&'static str],
+    #[props(default)] title: String,
 ) -> Element {
     rsx! {
-        tr {
-            td { label { r#for: name.clone(), "{label}: " } }
-            td { class: "grow",
-                input {
-                    r#type: "text",
-                    name,
-                    value: "{sig}",
-                    oninput: move |ev| sig.set(ev.value()),
-                }
-            }
-            td { class: "nowrap",
-                button {
-                    r#type: "button",
-                    onclick: move |_| pick_file_into(sig, filter_name, extensions),
-                    "..."
-                }
-            }
-        }
-    }
-}
-
-/// Labeled checkbox cell for use within a table row
-#[component]
-fn CheckboxCell(label: String, name: String, sig: Signal<bool>) -> Element {
-    rsx! {
-        td { class: "check",
-            label { r#for: name.clone(), "{label}: " }
-            input {
-                r#type: "checkbox",
-                name,
-                checked: sig(),
-                onchange: move |ev| sig.set(ev.checked()),
-            }
+        BrowseRow {
+            label,
+            name,
+            sig,
+            title,
+            on_browse: move |_| {
+                spawn(pick_file_into(sig, filter_name, extensions));
+            },
         }
     }
 }

--- a/pittv3-lib/src/help.rs
+++ b/pittv3-lib/src/help.rs
@@ -1,0 +1,185 @@
+//! Help text for the [`Pittv3Args`](crate::args::Pittv3Args) fields, keyed by the argument name.
+//!
+//! The CLI describes a flag in its `--help` output; a GUI describes the same thing in a tooltip on
+//! the control that sets it. Both should say the same thing, so the wording lives here rather than
+//! being written once per frontend. The text is taken from the `Pittv3Args` field documentation,
+//! which is the canonical description of what each argument does.
+//!
+//! Names are the kebab-case form the frontends already use for their form controls, which is also
+//! the CLI's long-flag spelling. Where a field exists as cfg-gated variants with different wording
+//! (`validate_all` is the one today), this uses the `std_app` spelling, since that is what the CLI
+//! and the GUI frontends build.
+
+/// Returns the help text for `name`, or an empty string when the name is not a PITTv3 argument —
+/// a form control that does not correspond to one, for instance.
+pub fn arg_help(name: &str) -> &'static str {
+    match name {
+        "ta-folder" => concat!(
+            "Full path of folder containing binary DER-encoded trust anchors to use when generating CBOR ",
+            "file containing partial certification paths and when validating certification paths.",
+        ),
+        "webpki-tas" => "Use trust anchors from webpki-roots crate (which are from Mozilla)",
+        "cbor" => concat!(
+            "Full path and filename of file to provide and/or receive CBOR-formatted representation of ",
+            "buffers containing binary DER-encoded CA certificates and map containing set of partial ",
+            "certification paths.",
+        ),
+        "time-of-interest" => concat!(
+            "Time to use for path validation expressed as the number of seconds since Unix epoch ",
+            "(defaults to current system time).",
+        ),
+        "logging-config" => concat!(
+            "Full path and filename of YAML-formatted configuration file for log4rs logging mechanism. ",
+            "See <https://docs.rs/log4rs/latest/log4rs/> for details.",
+        ),
+        "error-folder" => concat!(
+            "Full path of folder to receive binary DER-encoded certificates from paths that fail path ",
+            "validation. If absent, errant files are not saved for review.",
+        ),
+        "download-folder" => concat!(
+            "Full path and filename of folder to receive downloaded binary DER-encoded certificates, if ",
+            "absent at generate time, the ca_folder is used. Additionally, this is used to designate ",
+            "where exported buffers are written by dump_cert_at_index or list_buffers.",
+        ),
+        "ca-folder" => concat!(
+            "Full path of folder containing binary, DER-encoded intermediate CA certificates. Required ",
+            "when generate action is performed. This is not used when path validation is performed other ",
+            "than as a place to store downloaded files when dynamic building is used and download_folder ",
+            "is not specified.",
+        ),
+        "generate" => concat!(
+            "Flag that indicates a fresh CBOR-formatted file containing buffers of CA certificates and ",
+            "map containing set of partial certification paths should be generated and saved to location ",
+            "indicated by cbor parameter.",
+        ),
+        "chase-aia-and-sia" => concat!(
+            "Flag that indicates whether AIA and SIA URIs should be consulted when performing generate ",
+            "action.",
+        ),
+        "cbor-ta-store" => concat!(
+            "Flag that indicates generated CBOR file will contain only trust anchors (so no need for ",
+            "partial paths and no need to exclude self-signed certificates).",
+        ),
+        "validate-all" => "Flag that indicates all available certification paths should be validated for each target.",
+        "validate-self-signed" => "Check if certificate passed as end_entity_file is self-signed.",
+        "dynamic-build" => concat!(
+            "Process AIA and SIA during path validation, as appropriate. Either ca_folder or ",
+            "download_folder must be specified when using this flag to provide a place to store ",
+            "downloaded artifacts.",
+        ),
+        "end-entity-file" => "Full path and filename of a binary DER-encoded certificate to validate.",
+        "end-entity-folder" => concat!(
+            "Full path folder to recursively traverse for binary DER-encoded certificates to validate. ",
+            "Only files with .der, .crt or cert as file extension are processed.",
+        ),
+        "results-folder" => concat!(
+            "Full path and filename of folder to receive binary DER-encoded certificates from ",
+            "certification paths. Folders will be created beneath this using a hash of the target ",
+            "certificate. Within that folder, folders will be created with a number indicating each path, ",
+            "i.e., the number indicates the order in which the path was returned for consideration. For ",
+            "best results, this folder should be cleaned in between runs. PITTv3 does not perform hygiene ",
+            "on this folder or its contents.",
+        ),
+        "settings" => "Full path and filename of JSON-formatted certification path validation settings.",
+        "crl-folder" => concat!(
+            "Full path of folder containing binary, DER-encoded intermediate CA certificates. Required ",
+            "when generate action is performed. This is not used when path validation is performed other ",
+            "than as a place to store downloaded files when dynamic building is used and download_folder ",
+            "is not specified.",
+        ),
+        "keep-crl-entries-in-memory" => concat!(
+            "When set together with crl_folder, retain the revoked serial numbers of each verified ",
+            "full/direct CRL in memory so subsequent certificates under the same scope are answered ",
+            "without re-parsing or re-verifying the CRL.",
+        ),
+        "cleanup" => concat!(
+            "Paired with ca_folder to remove expired, unparseable certificates, self-signed certificates ",
+            "and non-CA certificates from consideration. When paired with error_folder, the errant files ",
+            "are moved instead of deleted. After cleanup completes, the application exits with no other ",
+            "parameters acted upon.",
+        ),
+        "ta-cleanup" => concat!(
+            "Paired with ta_folder to remove expired or unparseable certificatesfrom consideration. When ",
+            "paired with error_folder, the errant files are moved instead of deleted. After cleanup ",
+            "completes, the application exits with no other parameters acted upon.",
+        ),
+        "report-only" => concat!(
+            "Pair with cleanup to generate list of files that would be cleaned up by cleanup operation ",
+            "without actually deleting or moving files.",
+        ),
+        "list-partial-paths" => concat!(
+            "Outputs all partial paths present in CBOR file. If a ta_folder is provided, the CBOR file ",
+            "will be re-evaluated using ta_folder and time_of_interest (possibly changing the set of ",
+            "partial paths relative to that read from CBOR). Use of a logging-config option is ",
+            "recommended for large CBOR files.",
+        ),
+        "list-buffers" => "Outputs all buffers present in CBOR file.",
+        "list-aia-and-sia" => concat!(
+            "Outputs all URIs from AIA and SIA extensions found in certificates present in CBOR file. Add ",
+            "downloads_folder to save certificates that are valid as of time_of_interest from the ",
+            "downloaded artifacts (use time_of_interest=0 to download all). Specify a blocklist or ",
+            "last_modified_map if desired via CertificationPathSettings or rely on default files that ",
+            "will be generated and managed in folder used to download artifacts.",
+        ),
+        "list-name-constraints" => "Outputs all name constraints found in certificates present in CBOR file.",
+        "check-uris" => concat!(
+            "Checks the HTTP URIs carried in the AIA, SIA, CRL DP and freshest-CRL extensions of the ",
+            "certificate at the given path, reporting per-URI reachability and correctness (the SIA/AIA ",
+            "URI checker). Runs independently of certification path processing; no CBOR store or trust ",
+            "anchors are required.",
+        ),
+        "issuer" => concat!(
+            "Optional issuer certificate (path) used by `check_uris` to verify CRL signatures and check ",
+            "OCSP URIs. When absent, the issuer is auto-discovered from AIA caIssuers unless ",
+            "`no_auto_discover` is set.",
+        ),
+        "no-auto-discover" => "Disables auto-discovery of the issuer certificate from AIA caIssuers during `check_uris`.",
+        "list-trust-anchors" => "Outputs all buffers present in trust anchors folder.",
+        "dump-cert-at-index" => concat!(
+            "Outputs the certificate at the specified index to a file names `<index>.der` in the ",
+            "download_folder if specified, else current working directory.",
+        ),
+        "list-partial-paths-for-target" => concat!(
+            "Outputs all partial paths present in CBOR file relative to the indicated target. If a ",
+            "ta_folder is provided, the CBOR file will be re-evaluated using ta_folder and ",
+            "time_of_interest (possibly changing the set of partial paths relative to that read from ",
+            "CBOR).",
+        ),
+        "list-partial-paths-for-leaf-ca" => concat!(
+            "Outputs all partial paths present in CBOR file relative to the indicated leaf CA. If a ",
+            "ta_folder is provided, the CBOR file will be re-evaluated using ta_folder and ",
+            "time_of_interest (possibly changing the set of partial paths relative to that read from ",
+            "CBOR).",
+        ),
+        "mozilla-csv" => concat!(
+            "Parses the given CSV file and saves files to folder indicated by the ca_folder parameter. ",
+            "The CSV file is assumed to be as posted as the \"Non-revoked, non-expired Intermediate CA ",
+            "Certificates chaining up to roots in Mozilla's program with the Websites trust bit set (CSV ",
+            "with PEM of raw certificate data)\" report available on the Mozilla wiki page at ",
+            "<https://wiki.mozilla.org/CA/Intermediate_Certificates>.",
+        ),
+        _ => "",
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn known_args_have_help_and_unknown_ones_do_not() {
+        assert!(arg_help("ta-folder").contains("trust anchors"));
+        assert!(arg_help("ca-folder").contains("intermediate CA certificates"));
+        assert_eq!(arg_help("not-an-argument"), "");
+    }
+
+    /// `validate_all` is declared twice in `Pittv3Args` behind opposing `std_app` gates. The help
+    /// must carry the `std_app` wording, which is what the CLI and GUI frontends build, and must
+    /// not be emitted twice.
+    #[test]
+    fn cfg_gated_duplicate_uses_the_std_app_wording() {
+        let help = arg_help("validate-all");
+        assert!(help.contains("all available certification paths should be validated"));
+        assert!(!help.contains("compiled into the app"));
+    }
+}

--- a/pittv3-lib/src/lib.rs
+++ b/pittv3-lib/src/lib.rs
@@ -6,6 +6,7 @@
 extern crate alloc;
 
 pub mod args;
+pub mod help;
 pub mod no_std_utils;
 pub mod options_no_std;
 pub mod options_std;

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -656,7 +656,6 @@ fn App() -> Element {
                             EditSettings {
                                 initial: settings(),
                                 caps: Capabilities::browser_local(),
-                                now: now_as_unix_epoch(),
                                 on_save: move |edited| {
                                     settings.set(edited);
                                     settings_status.set("Settings saved".to_string());


### PR DESCRIPTION
Move time-related helpers and rows from pittv3-gui into pittv3-gui-lib. Add new pittv3_lib::help::arg_help as a source for tooltip information.