### PR TITLE
Accept a single file wherever a trust anchor or CA folder is accepted

### DIFF
--- a/certval/src/builder/file_utils.rs
+++ b/certval/src/builder/file_utils.rs
@@ -65,6 +65,175 @@ pub fn cert_folder_to_vec(
     cert_or_ta_folder_to_vec(pe, certs_dir, certs_vec, time_of_interest, false)
 }
 
+/// `ta_file_to_vec` is used to help process a single file containing one or more DER- or PEM-encoded
+/// trust anchors for use as a trust anchor source.
+///
+/// It is the single-file counterpart of [`ta_folder_to_vec`], for callers that let a user nominate
+/// an anchor directly rather than a folder to search. The file may hold several concatenated PEM
+/// objects, each of which is accepted or rejected on its own. Unlike the folder walk, the file name
+/// is not required to carry a recognized extension: the caller named this file, so refusing to read
+/// it on the strength of its name would be unhelpful. Objects that do not parse as a
+/// [`TrustAnchorChoice`], or that are not valid at the time of interest, are dropped. Pass 0 for
+/// `time_of_interest` to skip the validity check. Returns the number of items added.
+#[cfg(feature = "std")]
+pub fn ta_file_to_vec(
+    pe: &PkiEnvironment,
+    ta_file: &str,
+    tas_vec: &mut dyn CertVector,
+    time_of_interest: TimeOfInterest,
+) -> Result<usize> {
+    cert_or_ta_file_to_vec(pe, ta_file, tas_vec, time_of_interest, true)
+}
+
+/// `cert_file_to_vec` is used to help process a single file containing one or more DER- or PEM-encoded
+/// certificates for use as a certificate source.
+///
+/// It is the single-file counterpart of [`cert_folder_to_vec`], for callers that let a user nominate
+/// a certificate (or a PEM bundle such as a fullchain) directly rather than a folder to search. See
+/// [`ta_file_to_vec`] for the shared rules; here objects are read as [`Certificate`] and self-signed
+/// certificates are excluded, as they are when a folder is read. Returns the number of items added.
+#[cfg(feature = "std")]
+pub fn cert_file_to_vec(
+    pe: &PkiEnvironment,
+    cert_file: &str,
+    certs_vec: &mut dyn CertVector,
+    time_of_interest: TimeOfInterest,
+) -> Result<usize> {
+    cert_or_ta_file_to_vec(pe, cert_file, certs_vec, time_of_interest, false)
+}
+
+/// `cert_or_ta_file_to_vec` is used by [`ta_file_to_vec`] and [`cert_file_to_vec`] to read one file,
+/// returning [`Error::NotFound`] when the path is not a file (including when it is a folder, which
+/// the folder-taking functions handle instead).
+#[cfg(feature = "std")]
+fn cert_or_ta_file_to_vec(
+    pe: &PkiEnvironment,
+    filename: &str,
+    certsvec: &mut dyn CertVector,
+    time_of_interest: TimeOfInterest,
+    collect_tas: bool,
+) -> Result<usize> {
+    let path = Path::new(filename);
+    if !Path::is_file(path) {
+        error!("{filename} does not exist or is not a file");
+        return Err(Error::NotFound);
+    }
+    Ok(add_file_to_vec(
+        pe,
+        path,
+        certsvec,
+        time_of_interest,
+        collect_tas,
+        false,
+    ))
+}
+
+/// `add_file_to_vec` reads one file into `certsvec` and returns the number of objects it added.
+///
+/// This is the per-file half of the folder walk, shared with the single-file entry points so that
+/// one file is filtered by exactly the same rules whether it was reached by walking a folder or
+/// named outright. `check_extension` is the one difference between those two cases: a folder walk
+/// skips files whose extension does not suggest certificate material, while a named file is read on
+/// its merits.
+///
+/// A file that cannot be read or decoded is skipped rather than reported: during a folder walk one
+/// stray file must not empty the store (with `?` it did), and for a named file the count of zero
+/// tells the caller as much as an error would. A file may hold several concatenated PEM objects (a
+/// fullchain or root-CA bundle), so each object is accepted or rejected on its own.
+#[cfg(feature = "std")]
+fn add_file_to_vec(
+    pe: &PkiEnvironment,
+    path: &Path,
+    certsvec: &mut dyn CertVector,
+    time_of_interest: TimeOfInterest,
+    collect_tas: bool,
+    check_extension: bool,
+) -> usize {
+    let initial_count = certsvec.len();
+
+    if check_extension {
+        let file_exts = if collect_tas {
+            vec!["der", "crt", "cer", "ta"]
+        } else {
+            vec!["der", "crt", "cer"]
+        };
+        match path.extension().and_then(OsStr::to_str) {
+            Some(ext) => {
+                if !file_exts.contains(&ext) {
+                    return 0;
+                }
+            }
+            None => return 0,
+        }
+    }
+
+    let buffers = match get_file_as_der_certs_pem(path) {
+        Ok(buffers) => buffers,
+        Err(e) => {
+            error!(
+                "Ignoring {} as it could not be read or decoded: {e:?}",
+                path.display()
+            );
+            return 0;
+        }
+    };
+
+    for buffer in buffers {
+        // make sure it parses before saving buffer; a rejected object skips only
+        // itself, not the rest of a bundle.
+        if collect_tas {
+            // Every TrustAnchorChoice alternative is a trust anchor here, not only
+            // the Certificate one: an RFC 5914 TrustAnchorInfo is how trust anchor
+            // constraints are expressed, which is most of the reason to hold anchors
+            // in this form at all, and .ta is an accepted extension for exactly that
+            // material. An anchor asserting no validity period (Ok(None)) is kept --
+            // there is nothing to check, which is not the same as failing a check.
+            let ta = match TrustAnchorChoice::<Raw>::from_der(buffer.as_slice()) {
+                Ok(ta) => ta,
+                Err(_e) => continue,
+            };
+            if ta_valid_at_time(&ta, time_of_interest, true).is_err() {
+                error!(
+                    "Ignored an object in {} as not valid at indicated time of interest",
+                    path.to_str().unwrap_or("")
+                );
+                continue;
+            }
+        } else {
+            let r = CertificateInner::from_der(buffer.as_slice());
+            if let Ok(cert) = r {
+                let r = valid_at_time(cert.tbs_certificate(), time_of_interest, true);
+                if let Err(_e) = r {
+                    error!(
+                        "Ignored an object in {} as not valid at indicated time of interest",
+                        path.to_str().unwrap_or("")
+                    );
+                    continue;
+                }
+
+                if is_self_signed_with_buffer(pe, &cert, buffer.as_slice()) {
+                    if let Some(s) = path.to_str() {
+                        info!("Ignoring a self-signed object in {s}");
+                    }
+                    continue;
+                }
+            } else {
+                continue;
+            }
+        }
+
+        let cf = CertFile {
+            filename: path.to_str().unwrap_or("").to_string(),
+            bytes: buffer,
+        };
+        if !certsvec.contains(&cf) {
+            certsvec.push(cf);
+        }
+    }
+
+    certsvec.len() - initial_count
+}
+
 /// `cert_or_ta_folder_to_vec` is used by [`ta_folder_to_vec`] and [`cert_folder_to_vec`] to recursively traverse
 /// a folder in search of [`Certificate`] or [`TrustAnchorChoice`] objects, as appropriate.
 fn cert_or_ta_folder_to_vec(
@@ -102,87 +271,10 @@ fn cert_or_ta_folder_to_vec(
                     }
                     continue;
                 } else {
-                    let file_exts = if collect_tas {
-                        vec!["der", "crt", "cer", "ta"]
-                    } else {
-                        vec!["der", "crt", "cer"]
-                    };
-                    if let Some(ext) = path.extension().and_then(OsStr::to_str) {
-                        if !file_exts.contains(&ext) {
-                            continue;
-                        }
-                    } else {
-                        continue;
-                    }
-
-                    // A file that cannot be read or PEM-decoded must not abort the whole folder
-                    // scan (with `?` a single stray file left the store empty); skip it and go on.
-                    // A file may hold several concatenated PEM objects (a fullchain or root-CA
-                    // bundle); load every one, deferring per-object accept/reject to the loop below.
-                    let buffers = match get_file_as_der_certs_pem(path) {
-                        Ok(buffers) => buffers,
-                        Err(e) => {
-                            error!(
-                                "Ignoring {} as it could not be read or decoded: {e:?}",
-                                path.display()
-                            );
-                            continue;
-                        }
-                    };
-
-                    for buffer in buffers {
-                        // make sure it parses before saving buffer; a rejected object skips only
-                        // itself, not the rest of a bundle.
-                        if collect_tas {
-                            // Every TrustAnchorChoice alternative is a trust anchor here, not only
-                            // the Certificate one: an RFC 5914 TrustAnchorInfo is how trust anchor
-                            // constraints are expressed, which is most of the reason to hold anchors
-                            // in this form at all, and .ta is an accepted extension for exactly that
-                            // material. An anchor asserting no validity period (Ok(None)) is kept --
-                            // there is nothing to check, which is not the same as failing a check.
-                            let ta = match TrustAnchorChoice::<Raw>::from_der(buffer.as_slice()) {
-                                Ok(ta) => ta,
-                                Err(_e) => continue,
-                            };
-                            if ta_valid_at_time(&ta, time_of_interest, true).is_err() {
-                                error!(
-                                    "Ignored an object in {} as not valid at indicated time of interest",
-                                    path.to_str().unwrap_or("")
-                                );
-                                continue;
-                            }
-                        } else {
-                            let r = CertificateInner::from_der(buffer.as_slice());
-                            if let Ok(cert) = r {
-                                let r =
-                                    valid_at_time(cert.tbs_certificate(), time_of_interest, true);
-                                if let Err(_e) = r {
-                                    error!(
-                                        "Ignored an object in {} as not valid at indicated time of interest",
-                                        path.to_str().unwrap_or("")
-                                    );
-                                    continue;
-                                }
-
-                                if is_self_signed_with_buffer(pe, &cert, buffer.as_slice()) {
-                                    if let Some(s) = path.to_str() {
-                                        info!("Ignoring a self-signed object in {s}");
-                                    }
-                                    continue;
-                                }
-                            } else {
-                                continue;
-                            }
-                        }
-
-                        let cf = CertFile {
-                            filename: path.to_str().unwrap_or("").to_string(),
-                            bytes: buffer,
-                        };
-                        if !certsvec.contains(&cf) {
-                            certsvec.push(cf);
-                        }
-                    }
+                    // Files reached by walking a folder are filtered by extension: the folder was
+                    // nominated, not the file, so anything that does not look like certificate
+                    // material is passed over rather than reported.
+                    add_file_to_vec(pe, path, certsvec, time_of_interest, collect_tas, true);
                 }
             }
             _ => {

--- a/certval/src/builder/file_utils.rs
+++ b/certval/src/builder/file_utils.rs
@@ -90,7 +90,8 @@ pub fn ta_file_to_vec(
 ///
 /// It is the single-file counterpart of [`cert_folder_to_vec`], for callers that let a user nominate
 /// a certificate (or a PEM bundle such as a fullchain) directly rather than a folder to search. See
-/// [`ta_file_to_vec`] for the shared rules; here objects are read as [`Certificate`] and self-signed
+/// [`ta_file_to_vec`] for the shared rules; here objects are read as
+/// [`Certificate`](x509_cert::certificate::Certificate) and self-signed
 /// certificates are excluded, as they are when a folder is read. Returns the number of items added.
 #[cfg(feature = "std")]
 pub fn cert_file_to_vec(

--- a/certval/tests/file_utils.rs
+++ b/certval/tests/file_utils.rs
@@ -1,0 +1,99 @@
+//! Tests for the single-file trust anchor and certificate readers, which exist so a caller can let
+//! a user nominate one certificate instead of requiring a folder built around it.
+#![cfg(feature = "std")]
+
+use std::fs;
+
+use certval::*;
+
+/// The p256 PKITS fixtures are used throughout: reading a certificate needs no signature
+/// verification, but excluding a self-signed one does, and ECDSA is available by default.
+const CERTS: &str = "tests/examples/PKITS_data_p256/certs";
+
+fn toi() -> TimeOfInterest {
+    // 0 disables the validity check, so these tests cannot expire out from under the fixtures
+    TimeOfInterest::from_unix_secs(0).unwrap()
+}
+
+fn pe() -> PkiEnvironment {
+    let mut pe = PkiEnvironment::default();
+    pe.populate_5280_pki_environment();
+    pe
+}
+
+#[test]
+fn cert_file_reads_one_certificate() {
+    let mut certs = CertSource::new();
+    let added =
+        cert_file_to_vec(&pe(), &format!("{CERTS}/GoodCACert.crt"), &mut certs, toi()).unwrap();
+    assert_eq!(1, added);
+    assert_eq!(1, certs.len());
+}
+
+#[test]
+fn ta_file_reads_one_anchor() {
+    let mut tas = TaSource::new();
+    let added = ta_file_to_vec(
+        &pe(),
+        &format!("{CERTS}/TrustAnchorRootCertificate.crt"),
+        &mut tas,
+        toi(),
+    )
+    .unwrap();
+    assert_eq!(1, added);
+}
+
+/// The rules that govern a file reached by walking a folder govern a file named outright, so a
+/// self-signed certificate is excluded from a certificate source either way. This is the one that
+/// would catch the single-file path being written as a bare read.
+#[test]
+fn cert_file_excludes_a_self_signed_certificate() {
+    let mut certs = CertSource::new();
+    let added = cert_file_to_vec(
+        &pe(),
+        &format!("{CERTS}/TrustAnchorRootCertificate.crt"),
+        &mut certs,
+        toi(),
+    )
+    .unwrap();
+    assert_eq!(0, added, "a self-signed certificate is not an intermediate");
+}
+
+/// A folder is not a file. The two entry points are separate so that a caller dispatching on the
+/// path gets a clear answer from whichever one it chose, rather than an empty result.
+#[test]
+fn a_folder_is_not_a_file() {
+    let mut certs = CertSource::new();
+    assert!(matches!(
+        cert_file_to_vec(&pe(), CERTS, &mut certs, toi()),
+        Err(Error::NotFound)
+    ));
+
+    let mut tas = TaSource::new();
+    assert!(matches!(
+        ta_file_to_vec(&pe(), CERTS, &mut tas, toi()),
+        Err(Error::NotFound)
+    ));
+}
+
+/// A named file is read on its merits, while a folder walk filters by extension — the one
+/// deliberate difference between the two paths. A user who picks a file in a dialog has said which
+/// file they mean; a folder walk has only the name to go on.
+#[test]
+fn a_named_file_needs_no_recognized_extension() {
+    let dir = tempfile::tempdir().unwrap();
+    let odd = dir.path().join("intermediate.bin");
+    fs::copy(format!("{CERTS}/GoodCACert.crt"), &odd).unwrap();
+
+    let mut named = CertSource::new();
+    let added = cert_file_to_vec(&pe(), odd.to_str().unwrap(), &mut named, toi()).unwrap();
+    assert_eq!(1, added);
+
+    let mut walked = CertSource::new();
+    let added =
+        cert_folder_to_vec(&pe(), dir.path().to_str().unwrap(), &mut walked, toi()).unwrap();
+    assert_eq!(
+        0, added,
+        "a folder walk still passes over a file whose extension says nothing"
+    );
+}

--- a/pittv3-gui-lib/src/gui_rows.rs
+++ b/pittv3-gui-lib/src/gui_rows.rs
@@ -112,6 +112,11 @@ pub fn TextRow(
 
 /// Table row with a labeled text input and a browse button. The browse action is supplied by the
 /// frontend, since choosing a file or folder is the one part of this row that is not portable.
+///
+/// An input that accepts either a file or a folder can supply a second action as `on_browse_alt`,
+/// rendered as an extra button labeled `alt_label`. That is for the frontends whose native dialog
+/// chooses one kind or the other: where a single dialog can offer both, the row keeps one button
+/// and the platform difference stays inside the frontend.
 #[component]
 pub fn BrowseRow(
     label: String,
@@ -119,6 +124,8 @@ pub fn BrowseRow(
     sig: Signal<String>,
     on_browse: EventHandler<()>,
     #[props(default)] title: String,
+    #[props(default)] on_browse_alt: Option<EventHandler<()>>,
+    #[props(default)] alt_label: String,
 ) -> Element {
     let title = tooltip(title, &name);
     rsx! {
@@ -141,6 +148,13 @@ pub fn BrowseRow(
                     r#type: "button",
                     onclick: move |_| on_browse.call(()),
                     "..."
+                }
+                if let Some(on_browse_alt) = on_browse_alt {
+                    button {
+                        r#type: "button",
+                        onclick: move |_| on_browse_alt.call(()),
+                        "{alt_label}"
+                    }
                 }
             }
         }

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -39,6 +39,20 @@ async fn pick_folder_into(mut sig: Signal<String>) {
     }
 }
 
+/// Presents a selection dialog that accepts either a file or a folder and assigns the selection,
+/// if any, to `sig`. macOS only: `rfd` implements the combined dialog for that platform alone, so
+/// other platforms offer the two dialogs as separate buttons instead (see [`PathRow`]).
+#[cfg(target_os = "macos")]
+async fn pick_file_or_folder_into(mut sig: Signal<String>) {
+    let picked = AsyncFileDialog::new()
+        .set_directory(home_dir().unwrap_or("/".into()))
+        .pick_file_or_folder()
+        .await;
+    if let Some(picked) = picked {
+        sig.set(picked.path().to_string_lossy().to_string());
+    }
+}
+
 /// Presents a file selection dialog limited to files of the indicated type and assigns the
 /// selection, if any, to `sig`
 async fn pick_file_into(
@@ -115,6 +129,58 @@ fn FolderRow(
         }
     }
 }
+
+/// Table row for an input that accepts either a folder of certificates or a single certificate
+/// file, which is what the trust anchor and CA inputs take.
+///
+/// macOS can offer both in one dialog, so there the `...` button does; every other platform has to
+/// choose a dialog kind up front, so the row carries a second button. The distinction is only about
+/// how the path is chosen — a typed or pasted path of either kind works everywhere, because the run
+/// decides from the path itself rather than from which button produced it.
+#[component]
+fn PathRow(
+    label: String,
+    name: String,
+    sig: Signal<String>,
+    #[props(default)] title: String,
+) -> Element {
+    #[cfg(target_os = "macos")]
+    return rsx! {
+        BrowseRow {
+            label,
+            name,
+            sig,
+            title,
+            on_browse: move |_| {
+                spawn(pick_file_or_folder_into(sig));
+            },
+        }
+    };
+
+    #[cfg(not(target_os = "macos"))]
+    return rsx! {
+        BrowseRow {
+            label,
+            name,
+            sig,
+            title,
+            on_browse: move |_| {
+                spawn(pick_folder_into(sig));
+            },
+            on_browse_alt: move |_| {
+                spawn(pick_file_into(sig, "Certificate File", CERT_EXTENSIONS));
+            },
+            alt_label: "File...",
+        }
+    };
+}
+
+/// Extensions offered when picking a certificate file as a trust anchor or CA input. `ta` is an
+/// RFC 5914 TrustAnchorInfo, which is how anchor constraints travel. Only the platforms that need a
+/// separate file dialog filter by extension; the combined macOS dialog does not, since a folder has
+/// no extension to match.
+#[cfg(not(target_os = "macos"))]
+const CERT_EXTENSIONS: &[&str] = &["der", "crt", "cer", "pem", "ta"];
 
 /// Table row with a labeled text input and a file selection dialog limited to files of the
 /// indicated type. Thin wrapper over the shared [`BrowseRow`], as with [`FolderRow`].
@@ -708,11 +774,10 @@ pub(crate) fn App() -> Element {
                                 tbody {
                                     StoreRow { sig: s_store }
                                     StoreHint { selection: s_store() }
-                                    FolderRow {
-                                        label: "TA Folder",
+                                    PathRow {
+                                        label: "TA Folder or File",
                                         name: "ta-folder",
                                         sig: s_ta_folder,
-                                        title: "Full path of folder containing binary DER-encoded trust anchors to use when generating CBOR file containing partial certification paths and when validating certification paths.",
                                     }
                                     // Shown only for a custom selection: a built-in store is itself
                                     // a trust anchor CBOR, and the run writes its path here.
@@ -743,11 +808,10 @@ pub(crate) fn App() -> Element {
                                     // same field below as the folder fetched certificates are
                                     // written to.
                                     if !s_dynamic_build() {
-                                        FolderRow {
-                                            label: "CA Folder",
+                                        PathRow {
+                                            label: "CA Folder or File",
                                             name: "ca-folder",
                                             sig: s_ca_folder,
-                                            title: "Full path of folder containing binary DER-encoded intermediate CA certificates. These are added to the graph built for path validation, augmenting the CA CBOR store when one is also supplied.",
                                         }
                                     }
                                     FileRow {

--- a/pittv3-lib/src/args.rs
+++ b/pittv3-lib/src/args.rs
@@ -9,8 +9,9 @@ use std::time::{SystemTime, UNIX_EPOCH};
 /// like a GUI, can populate it directly; the CLI converts clap-parsed arguments into this type.
 #[derive(Clone, Debug, Serialize, Deserialize, Default)]
 pub struct Pittv3Args {
-    /// Full path of folder containing binary DER-encoded trust anchors to use when generating CBOR
-    /// file containing partial certification paths and when validating certification paths.
+    /// Full path of a folder containing binary DER-encoded trust anchors, or of a single such file,
+    /// to use when generating CBOR file containing partial certification paths and when validating
+    /// certification paths. A file may hold several concatenated PEM objects.
     #[cfg(feature = "std")]
     pub ta_folder: Option<String>,
 
@@ -51,10 +52,11 @@ pub struct Pittv3Args {
     #[cfg(feature = "std")]
     pub download_folder: Option<String>,
 
-    /// Full path of folder containing binary, DER-encoded intermediate CA certificates. Required
-    /// when generate action is performed. When path validation is performed, the certificates in
-    /// this folder are added to the graph that is built, augmenting any CBOR store in use, and the
-    /// folder doubles as a place to store downloaded files when dynamic building is used and
+    /// Full path of a folder containing binary, DER-encoded intermediate CA certificates, or of a
+    /// single such file (which may hold several concatenated PEM objects, e.g. a fullchain).
+    /// Required when generate action is performed. When path validation is performed, these
+    /// certificates are added to the graph that is built, augmenting any CBOR store in use. A folder
+    /// also doubles as a place to store downloaded files when dynamic building is used and
     /// download_folder is not specified.
     #[cfg(feature = "std")]
     pub ca_folder: Option<String>,

--- a/pittv3-lib/src/help.rs
+++ b/pittv3-lib/src/help.rs
@@ -15,8 +15,9 @@
 pub fn arg_help(name: &str) -> &'static str {
     match name {
         "ta-folder" => concat!(
-            "Full path of folder containing binary DER-encoded trust anchors to use when generating CBOR ",
-            "file containing partial certification paths and when validating certification paths.",
+            "Full path of a folder containing binary DER-encoded trust anchors, or of a single such ",
+            "file, to use when generating CBOR file containing partial certification paths and when ",
+            "validating certification paths. A file may hold several concatenated PEM objects.",
         ),
         "ta-cbor" => concat!(
             "Full path and filename of a CBOR-formatted trust anchor store, i.e., the form written by ",
@@ -48,10 +49,11 @@ pub fn arg_help(name: &str) -> &'static str {
             "where exported buffers are written by dump_cert_at_index or list_buffers.",
         ),
         "ca-folder" => concat!(
-            "Full path of folder containing binary, DER-encoded intermediate CA certificates. Required ",
-            "when generate action is performed. When path validation is performed, the certificates in ",
-            "this folder are added to the graph that is built, augmenting any CBOR store in use, and the ",
-            "folder doubles as a place to store downloaded files when dynamic building is used and ",
+            "Full path of a folder containing binary, DER-encoded intermediate CA certificates, or of a ",
+            "single such file (which may hold several concatenated PEM objects, e.g. a fullchain). ",
+            "Required when generate action is performed. When path validation is performed, these ",
+            "certificates are added to the graph that is built, augmenting any CBOR store in use. A ",
+            "folder also doubles as a place to store downloaded files when dynamic building is used and ",
             "download_folder is not specified.",
         ),
         "generate" => concat!(

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -939,9 +939,15 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         if 0 == pass && !args.generate {
             if let Some(ca_folder) = &args.ca_folder {
                 let before = cert_source.len();
-                if let Err(e) =
-                    cert_folder_to_vec(&pe, ca_folder, &mut cert_source, cps.get_time_of_interest())
-                {
+                // Either a folder of intermediates or a single file naming one, matching the trust
+                // anchor side; a PEM bundle such as a fullchain counts as the single file.
+                let toi = cps.get_time_of_interest();
+                let r = if Path::new(ca_folder).is_file() {
+                    cert_file_to_vec(&pe, ca_folder, &mut cert_source, toi)
+                } else {
+                    cert_folder_to_vec(&pe, ca_folder, &mut cert_source, toi)
+                };
+                if let Err(e) = r {
                     error!("Failed to read certificates from {ca_folder}: {e:?}");
                 }
                 ca_folder_certs = cert_source.len() - before;

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -78,7 +78,17 @@ pub fn load_trust_anchors(
     }
 
     if let Some(ta_folder) = &args.ta_folder {
-        if let Err(e) = ta_folder_to_vec(pe, ta_folder, &mut ta_store, time_of_interest) {
+        // A single anchor is as reasonable a thing to nominate as a folder of them — the material
+        // often arrives as one file — so the argument takes either and the path itself says which.
+        // Naming a file is not a lesser case: an anchor store assembled from several sources is
+        // reached by naming them, and the alternative is asking the user to build a directory
+        // around one certificate.
+        let r = if Path::new(ta_folder).is_file() {
+            ta_file_to_vec(pe, ta_folder, &mut ta_store, time_of_interest)
+        } else {
+            ta_folder_to_vec(pe, ta_folder, &mut ta_store, time_of_interest)
+        };
+        if let Err(e) = r {
             return Err(format!(
                 "failed to load trust anchors from {ta_folder} with error {e:?}"
             ));

--- a/pittv3-lib/tests/ca_folder_validation.rs
+++ b/pittv3-lib/tests/ca_folder_validation.rs
@@ -83,6 +83,51 @@ fn ca_folder_supplies_intermediates() {
     assert_eq!(3, report.targets[0].paths[0].certs.len());
 }
 
+/// Both inputs also take a single file, so nothing has to be assembled into a directory first. The
+/// fixtures are the reason this matters: PKITS ships no folder holding only its root, so validating
+/// against it used to mean building one.
+#[test]
+fn trust_anchor_and_ca_can_be_single_files() {
+    let dir = tempfile::tempdir().unwrap();
+
+    let report = validate(
+        dir.path(),
+        Some(
+            example("TrustAnchorRootCertificate.crt")
+                .to_str()
+                .unwrap()
+                .to_string(),
+        ),
+        Some(example("GoodCACert.crt").to_str().unwrap().to_string()),
+    );
+
+    assert_eq!(None, report.error);
+    assert_eq!(1, report.totals.valid_paths);
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+    assert_eq!(3, report.targets[0].paths[0].certs.len());
+}
+
+/// A file and a folder are interchangeable on either side, so the mixed forms have to work too —
+/// this is the shape a GUI produces when one input was picked and the other typed.
+#[test]
+fn a_file_and_a_folder_mix() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_folder = folder_with(&dir.path().join("ca"), &["GoodCACert.crt"]);
+
+    let report = validate(
+        dir.path(),
+        Some(
+            example("TrustAnchorRootCertificate.crt")
+                .to_str()
+                .unwrap()
+                .to_string(),
+        ),
+        Some(ca_folder),
+    );
+
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+}
+
 /// The same run without the CA folder is the control: the intermediate is the only thing missing,
 /// so the outcome must be no paths rather than a path found some other way.
 #[test]

--- a/pittv3/src/cliargs.rs
+++ b/pittv3/src/cliargs.rs
@@ -9,8 +9,9 @@ use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
 #[command(arg_required_else_help(true))]
 #[clap(author, version, about, long_about = None)]
 pub struct Pittv3CliArgs {
-    /// Full path of folder containing binary DER-encoded trust anchors to use when generating CBOR
-    /// file containing partial certification paths and when validating certification paths.
+    /// Full path of a folder containing binary DER-encoded trust anchors, or of a single such file,
+    /// to use when generating CBOR file containing partial certification paths and when validating
+    /// certification paths. A file may hold several concatenated PEM objects.
     #[cfg(feature = "std")]
     #[clap(short, long, help_heading = "COMMON OPTIONS")]
     pub ta_folder: Option<String>,
@@ -59,10 +60,11 @@ pub struct Pittv3CliArgs {
     #[clap(long, short, help_heading = "COMMON OPTIONS")]
     pub download_folder: Option<String>,
 
-    /// Full path of folder containing binary, DER-encoded intermediate CA certificates. Required
-    /// when generate action is performed. When path validation is performed, the certificates in
-    /// this folder are added to the graph that is built, augmenting any CBOR store in use, and the
-    /// folder doubles as a place to store downloaded files when dynamic building is used and
+    /// Full path of a folder containing binary, DER-encoded intermediate CA certificates, or of a
+    /// single such file (which may hold several concatenated PEM objects, e.g. a fullchain).
+    /// Required when generate action is performed. When path validation is performed, these
+    /// certificates are added to the graph that is built, augmenting any CBOR store in use. A folder
+    /// also doubles as a place to store downloaded files when dynamic building is used and
     /// download_folder is not specified.
     #[cfg(feature = "std")]
     #[clap(short, long, help_heading = "COMMON OPTIONS")]

--- a/pittv3/tests/examples/SeparatedPKITS/README.md
+++ b/pittv3/tests/examples/SeparatedPKITS/README.md
@@ -1,0 +1,33 @@
+# SeparatedPKITS
+
+The NIST PKITS end entity certificates, split into one folder per **settings group** —
+`default` plus `1` through `10` — matching the groups NIST defines in PKITS §4.8.1, §4.10.1
+and §4.12.3, where the same certificate is meant to be validated under different initial
+policy inputs.
+
+The settings that go with each folder are the sibling directory:
+
+| this folder | its settings |
+|---|---|
+| `SeparatedPKITS/default` | `../pkits_settings/default.json` |
+| `SeparatedPKITS/1` … `10` | `../pkits_settings/settings1.json` … `settings10.json` |
+
+The rest of the material, also siblings: `../pkits_ta_store` (trust anchors),
+`../pkits_crls` (CRLs), `../pkits.cbor` (a prebuilt graph; a folder of CA certificates
+also works as a validation input).
+
+Expected outcomes are in `good.txt` and `bad.txt`, labelled by group, and are asserted
+per group by `pkits_separated` in `pittv3/tests/pittv3.rs`, which is also the worked
+example of driving all of this:
+
+    pittv3 --cbor tests/examples/pkits.cbor \
+           -t tests/examples/pkits_ta_store \
+           --crl-folder tests/examples/pkits_crls \
+           -s tests/examples/pkits_settings/settings3.json \
+           -f tests/examples/SeparatedPKITS/3
+
+**Each settings file pins `psTimeOfInterest`** (March 2022), which is what makes these
+runs deterministic — and what keeps `pkits_crls` intact. Validating this material at the
+*current* time instead prunes CRLs: a CRL that is stale at the time of interest is
+deleted from the folder given to `--crl-folder` (see `CrlSourceFolders::index_crls`), so
+run these with the supplied settings, or point the CRL folder at a copy.


### PR DESCRIPTION
Previously it was necessary to create a folder containing a single TA when a single TA was desired. Now a file or folder can be elected