### PR TITLE
Expand a leading ~ in GUI path inputs

### DIFF
--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -926,6 +926,10 @@ pub fn EditSettingsFile(path: String, on_close: EventHandler<()>) -> Element {
         move || SettingsModel::from_cps(&FileSettingsStore::new(path).load())
     });
 
+    // A failed write is reported here rather than only logged. Saving closes the form, so a silent
+    // failure looks exactly like a successful save until the settings are next read back.
+    let mut save_error = use_signal(String::new);
+
     let save_path = path.clone();
     let on_save = move |edited: SettingsModel| {
         let store = FileSettingsStore::new(save_path.clone());
@@ -934,11 +938,18 @@ pub fn EditSettingsFile(path: String, on_close: EventHandler<()>) -> Element {
         edited.apply(&mut cps);
         if let Err(e) = store.save(&cps) {
             error!("{e}");
+            // leave the form open so the edits are not lost with the file they could not reach
+            save_error.set(e);
+            return;
         }
+        save_error.set(String::new());
         on_close.call(());
     };
 
     rsx! {
+        if !save_error().is_empty() {
+            p { class: "capability-notice", "{save_error}" }
+        }
         EditSettings {
             initial,
             caps: Capabilities::desktop(),

--- a/pittv3-gui-lib/src/settings_store.rs
+++ b/pittv3-gui-lib/src/settings_store.rs
@@ -55,19 +55,50 @@ pub fn default_settings_path() -> Option<String> {
     Some(app_home()?.join("settings.json").to_str()?.to_string())
 }
 
+/// Resolves a leading `~` in `path` against the user's home directory, returning any other path
+/// unchanged.
+///
+/// Paths reach a GUI by hand at least as often as they do through a file dialog, and a typed
+/// `~/settings.json` is not a path the file system understands: `~` is an ordinary directory name
+/// to it, so reading such a path yields the defaults for a file that is not there and writing one
+/// fails outright for want of a parent directory. A shell expands the tilde before a command line
+/// utility ever sees it; a text box has no shell behind it, so the expansion has to happen here.
+/// `~user` is left alone, since resolving another user's home directory is a shell feature rather
+/// than a file system one.
+#[cfg(feature = "std")]
+pub fn expand_tilde(path: &str) -> String {
+    let Some(after) = path.strip_prefix('~') else {
+        return path.to_string();
+    };
+    let rest = after.trim_start_matches(['/', '\\']);
+    if !after.is_empty() && rest.len() == after.len() {
+        return path.to_string();
+    }
+    let Some(home) = home::home_dir() else {
+        return path.to_string();
+    };
+    if rest.is_empty() {
+        return home.to_string_lossy().to_string();
+    }
+    home.join(rest).to_string_lossy().to_string()
+}
+
 /// A [`SettingsStore`] backed by a JSON file holding a [`CertificationPathSettings`] — the format
 /// the CLI reads via `--settings` and the desktop app has always written.
 #[cfg(feature = "std")]
 pub struct FileSettingsStore {
-    /// Path to the settings JSON
+    /// Path to the settings JSON, with any leading `~` already resolved
     pub path: String,
 }
 
 #[cfg(feature = "std")]
 impl FileSettingsStore {
-    /// Creates a store over the settings file at `path`
+    /// Creates a store over the settings file at `path`, resolving a leading `~` so a path typed
+    /// into a text box names the same file a shell would have named
     pub fn new(path: impl Into<String>) -> Self {
-        Self { path: path.into() }
+        Self {
+            path: expand_tilde(&path.into()),
+        }
     }
 }
 
@@ -86,5 +117,62 @@ impl SettingsStore for FileSettingsStore {
             .map_err(|e| format!("Failed to create file to receive settings: {e}"))?;
         file.write_all(json.as_bytes())
             .map_err(|e| format!("Failed to save settings: {e}"))
+    }
+}
+
+#[cfg(all(test, feature = "std"))]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn tilde_expands_only_where_a_shell_would() {
+        let home = home::home_dir().expect("home directory");
+        let home_str = home.to_string_lossy().to_string();
+
+        assert_eq!(
+            expand_tilde("~/.pittv3.json"),
+            home.join(".pittv3.json").to_string_lossy()
+        );
+        assert_eq!(expand_tilde("~"), home_str);
+
+        // absolute and relative paths, and another user's home, are the shell's business or
+        // nobody's
+        assert_eq!(expand_tilde("/etc/pittv3.json"), "/etc/pittv3.json");
+        assert_eq!(expand_tilde("settings.json"), "settings.json");
+        assert_eq!(
+            expand_tilde("~someone/settings.json"),
+            "~someone/settings.json"
+        );
+        // a tilde anywhere but the front is a legitimate file name character
+        assert_eq!(
+            expand_tilde("backup/~settings.json"),
+            "backup/~settings.json"
+        );
+    }
+
+    #[test]
+    fn file_store_resolves_a_typed_tilde() {
+        let home = home::home_dir().expect("home directory");
+        assert_eq!(
+            FileSettingsStore::new("~/.pittv3.json").path,
+            home.join(".pittv3.json").to_string_lossy()
+        );
+    }
+
+    #[test]
+    fn file_store_round_trips_through_an_expanded_path() {
+        let path = std::env::temp_dir().join("pittv3-settings-store-test.json");
+        let _ = std::fs::remove_file(&path);
+
+        let store = FileSettingsStore::new(path.to_string_lossy().to_string());
+        // a missing file reads as "all defaults" rather than as an error
+        assert!(store.load().0.is_empty());
+
+        let mut cps = CertificationPathSettings::new();
+        cps.set_check_revocation_status(false);
+        store.save(&cps).expect("save");
+
+        assert!(!store.load().get_check_revocation_status());
+        let _ = std::fs::remove_file(&path);
     }
 }

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -19,7 +19,7 @@ use pittv3_gui_lib::gui_shell::AppShell;
 use pittv3_gui_lib::gui_utils::{
     clear_log_sink, read_saved_args, save_args, set_log_sink, ChannelAppender,
 };
-use pittv3_gui_lib::settings_store::default_settings_path;
+use pittv3_gui_lib::settings_store::{default_settings_path, expand_tilde};
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
 use pittv3_lib::options_std::options_std;
@@ -97,6 +97,13 @@ fn string_or_none(sig: Signal<String>) -> Option<String> {
     } else {
         Some(s)
     }
+}
+
+/// Returns the value of `sig` as a path if it is not empty and None otherwise, resolving a leading
+/// `~` against the home directory. Every path here can be typed as readily as it can be chosen
+/// from a file dialog, and there is no shell behind a text box to expand the tilde first.
+fn path_or_none(sig: Signal<String>) -> Option<String> {
+    string_or_none(sig).map(|s| expand_tilde(&s))
 }
 
 /// Returns the value of `sig` as a usize, or None if the value is empty or cannot be parsed
@@ -604,28 +611,28 @@ pub(crate) fn App() -> Element {
         };
 
         let args = Pittv3Args {
-            ta_folder: string_or_none(s_ta_folder),
-            ta_cbor: store_ta_cbor.or_else(|| string_or_none(s_ta_cbor)),
+            ta_folder: path_or_none(s_ta_folder),
+            ta_cbor: store_ta_cbor.or_else(|| path_or_none(s_ta_cbor)),
             webpki_tas: s_webpki_tas(),
-            cbor: store_cbor.or_else(|| string_or_none(s_cbor)),
+            cbor: store_cbor.or_else(|| path_or_none(s_cbor)),
             time_of_interest: s_time_of_interest()
                 .parse::<u64>()
                 .unwrap_or_else(|_| get_now_as_unix_epoch()),
-            logging_config: string_or_none(s_logging_config),
-            error_folder: string_or_none(s_error_folder),
-            download_folder: string_or_none(s_download_folder),
-            ca_folder: string_or_none(s_ca_folder),
+            logging_config: path_or_none(s_logging_config),
+            error_folder: path_or_none(s_error_folder),
+            download_folder: path_or_none(s_download_folder),
+            ca_folder: path_or_none(s_ca_folder),
             generate: s_generate(),
             chase_aia_and_sia: s_chase_aia_and_sia(),
             cbor_ta_store: s_cbor_ta_store(),
             validate_all: s_validate_all(),
             validate_self_signed: s_validate_self_signed(),
             dynamic_build: s_dynamic_build(),
-            end_entity_file: string_or_none(s_end_entity_file),
-            end_entity_folder: string_or_none(s_end_entity_folder),
-            results_folder: string_or_none(s_results_folder),
-            settings: string_or_none(s_settings),
-            crl_folder: string_or_none(s_crl_folder),
+            end_entity_file: path_or_none(s_end_entity_file),
+            end_entity_folder: path_or_none(s_end_entity_folder),
+            results_folder: path_or_none(s_results_folder),
+            settings: path_or_none(s_settings),
+            crl_folder: path_or_none(s_crl_folder),
             keep_crl_entries_in_memory: false,
             cleanup: s_cleanup(),
             ta_cleanup: s_ta_cleanup(),
@@ -636,9 +643,9 @@ pub(crate) fn App() -> Element {
             list_name_constraints: s_list_name_constraints(),
             list_trust_anchors: s_list_trust_anchors(),
             dump_cert_at_index: usize_or_none(s_dump_cert_at_index),
-            list_partial_paths_for_target: string_or_none(s_list_partial_paths_for_target),
+            list_partial_paths_for_target: path_or_none(s_list_partial_paths_for_target),
             list_partial_paths_for_leaf_ca: usize_or_none(s_list_partial_paths_for_leaf_ca),
-            mozilla_csv: string_or_none(s_mozilla_csv),
+            mozilla_csv: path_or_none(s_mozilla_csv),
             check_uris: None,
             issuer: None,
             no_auto_discover: false,


### PR DESCRIPTION
Also report a failed settings write in the form instead of only logging it