### PR TITLE
Various GUI enhancements

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4671,6 +4671,7 @@ dependencies = [
  "pittv3_lib",
  "rfd",
  "serde_json",
+ "tempfile",
  "tokio",
 ]
 

--- a/certval/src/builder/graph_builder.rs
+++ b/certval/src/builder/graph_builder.rs
@@ -6,7 +6,9 @@ use crate::Result;
 
 use log::error;
 
+use crate::builder::file_utils::cert_file_to_vec;
 use crate::builder::file_utils::cert_folder_to_vec;
+use crate::builder::file_utils::ta_file_to_vec;
 use crate::builder::file_utils::ta_folder_to_vec;
 use crate::*;
 
@@ -21,6 +23,11 @@ use std::fs;
 /// DER-encoded CA certificate files, and a time of interest expressed as seconds since Unix epoch
 /// then attempts to find all possible partial certification paths.
 ///
+/// The CA input may name a single file instead of a folder, in which case that file is read on its
+/// merits, extension and all, exactly as it is when one is nominated at validation time. A file may
+/// hold several concatenated PEM objects. Chasing AIA and SIA needs somewhere to write what it
+/// fetches, so a run that chases with a file for its CA input must also set a download folder.
+///
 /// It returns a buffer containing CBOR-encoded partial paths. [BuffersAndPaths] features additional
 /// information regarding serialization of certificate buffers and partial paths.
 ///
@@ -34,6 +41,23 @@ pub async fn build_graph(pe: &PkiEnvironment, cps: &CertificationPathSettings) -
         return Err(Error::NotFound);
     };
 
+    // The CA input may name a single file as well as a folder, as it may at validation time. The
+    // folder-taking functions return NotFound for anything that is not a directory, so the choice
+    // is made here rather than left to them.
+    let named_file = Path::new(&ca_folder).is_file();
+    let collect_tas = cps.get_cbor_ta_store();
+
+    #[cfg(feature = "remote")]
+    let chasing = cps.get_retrieve_from_aia_sia_http() && !collect_tas;
+
+    // Absent a download folder the CA folder receives what is fetched, which a file cannot do. Only
+    // a run that chases has anything to write, so this is an error for those runs alone.
+    #[cfg(feature = "remote")]
+    if named_file && chasing && cps.get_download_folder().is_none() {
+        error!("a download folder is required when AIA and SIA are chased and the CA input names a file rather than a folder");
+        return Err(Error::NotFound);
+    }
+
     #[cfg(feature = "remote")]
     let download_folder = if let Some(download_folder) = cps.get_download_folder() {
         download_folder
@@ -44,10 +68,11 @@ pub async fn build_graph(pe: &PkiEnvironment, cps: &CertificationPathSettings) -
     let toi = cps.get_time_of_interest();
 
     let mut cert_store = CertSource::new();
-    let r = if cps.get_cbor_ta_store() {
-        ta_folder_to_vec(pe, &ca_folder, &mut cert_store, toi)
-    } else {
-        cert_folder_to_vec(pe, &ca_folder, &mut cert_store, toi)
+    let r = match (named_file, collect_tas) {
+        (true, true) => ta_file_to_vec(pe, &ca_folder, &mut cert_store, toi),
+        (true, false) => cert_file_to_vec(pe, &ca_folder, &mut cert_store, toi),
+        (false, true) => ta_folder_to_vec(pe, &ca_folder, &mut cert_store, toi),
+        (false, false) => cert_folder_to_vec(pe, &ca_folder, &mut cert_store, toi),
     };
     if let Err(e) = r {
         error!(
@@ -57,7 +82,7 @@ pub async fn build_graph(pe: &PkiEnvironment, cps: &CertificationPathSettings) -
     }
 
     #[cfg(feature = "remote")]
-    if cps.get_retrieve_from_aia_sia_http() && !cps.get_cbor_ta_store() {
+    if chasing {
         let mut uris = Vec::new();
         let mut certs_count = 0;
         let mut uris_count = 0;

--- a/pittv3-gui-lib/assets/pittv3.css
+++ b/pittv3-gui-lib/assets/pittv3.css
@@ -93,6 +93,25 @@ input[type="checkbox"] {
   padding-left: 0.5rem;
 }
 
+/* Heading for a run of rows within a fieldset, for the cases where the rows share a condition the
+   fields cannot each restate. Legend vocabulary at a smaller weight, so it reads as subordinate to
+   the fieldset rather than competing with it. The rule above it is what closes the group before. */
+td.subgroup {
+  padding-top: 0.6rem;
+  font-size: 0.8rem;
+  text-transform: uppercase;
+  letter-spacing: 0.04em;
+  color: var(--muted);
+  text-align: left;
+  white-space: normal;
+}
+tr.subgroup + tr td {
+  padding-top: 0.1rem;
+}
+tr.subgroup:not(:first-child) td.subgroup {
+  border-top: 1px solid var(--border);
+}
+
 /* Explains that a group of settings cannot take effect in this frontend. Set apart from a plain
    hint because it qualifies everything below it rather than annotating one field. */
 .capability-notice {

--- a/pittv3-gui/Cargo.toml
+++ b/pittv3-gui/Cargo.toml
@@ -51,3 +51,4 @@ tokio = { version = "1.52.3", features = ["rt", "time"] }
 # read; the app itself reaches certval through pittv3_lib.
 [dev-dependencies]
 certval = { path = "../certval", default-features = false, features = ["std"] }
+tempfile = "3.27.0"

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -22,6 +22,7 @@ use pittv3_gui_lib::gui_utils::{
 use pittv3_gui_lib::settings_store::{default_settings_path, expand_tilde};
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
+use pittv3_lib::graph_cache;
 use pittv3_lib::options_std::options_std;
 use pittv3_lib::report::ValidationReport;
 use pittv3_lib::uri_check::{check_uris_from_bytes, UriCheckReport, UriStatus};
@@ -36,6 +37,104 @@ async fn pick_folder_into(mut sig: Signal<String>) {
         .await;
     if let Some(folder) = folder {
         sig.set(folder.path().to_string_lossy().to_string());
+    }
+}
+
+/// Asks for a folder and writes the selected built-in store's material into it, reporting the
+/// outcome through `status` either way — a dialog that closes with nothing said is the shape of
+/// failure this app has already been bitten by once (see the tilde expansion in `settings_store`).
+async fn export_store_into(index: usize, mut status: Signal<String>) {
+    let folder = AsyncFileDialog::new()
+        .set_directory(home_dir().unwrap_or("/".into()))
+        .pick_folder()
+        .await;
+    let Some(folder) = folder else {
+        return;
+    };
+    match stores::export(index, folder.path()) {
+        Ok(e) => {
+            let cas = if e.ca_store {
+                format!(
+                    ", the CA store and {} intermediate CA certificate(s)",
+                    e.intermediates
+                )
+            } else {
+                String::new()
+            };
+            status.set(format!(
+                "Wrote {} trust anchor(s){cas} to {}",
+                e.anchors, e.folder
+            ));
+        }
+        Err(msg) => {
+            error!("{msg}");
+            status.set(format!("Export failed: {msg}"));
+        }
+    }
+}
+
+/// Writes the environment a run over the current inputs validates against, as the two files that
+/// describe it: `ta.cbor`, every anchor the run assembled, and `ca.cbor`, the certificates it
+/// searched together with the partial paths it found among them.
+///
+/// Two files because the anchors sit outside the graph: partial paths terminate at them, but they
+/// live in a `TaSource` that never enters the `CertSource`, so a graph on its own describes paths
+/// to certificates it does not carry. Both come from the run's cache under one key, so they are
+/// necessarily each other's halves — and both are what the validation actually used rather than a
+/// reconstruction, which is the point of exporting them at all. That does mean there has to have
+/// been a run: nothing is cached for inputs nothing has been validated against yet.
+async fn export_environment_into(args: Pittv3Args, mut status: Signal<String>) {
+    let Some(fingerprint) = graph_cache::fingerprint_for_args(&args) else {
+        status.set(
+            "These inputs build no graph to export: a store used on its own already carries its \
+             partial paths, and dynamic build changes the graph as it runs."
+                .to_string(),
+        );
+        return;
+    };
+    let Some(graph) = graph_cache::cached(&fingerprint) else {
+        status.set(
+            "Nothing has been built for these inputs yet — run a validation first, then export."
+                .to_string(),
+        );
+        return;
+    };
+    let anchors = graph_cache::cached_anchors(&fingerprint);
+
+    let folder = AsyncFileDialog::new()
+        .set_directory(home_dir().unwrap_or("/".into()))
+        .pick_folder()
+        .await;
+    let Some(folder) = folder else {
+        return;
+    };
+
+    let ca_path = folder.path().join("ca.cbor");
+    if let Err(e) = std::fs::write(&ca_path, &graph) {
+        error!("Failed to write {}: {e}", ca_path.display());
+        status.set(format!("Export failed: {e}"));
+        return;
+    }
+    // Anchors are cached whenever a run loaded any, so their absence means the run had none of its
+    // own — webpki anchors, which certval builds rather than reads, are the case that reaches here.
+    let Some(anchors) = anchors else {
+        status.set(format!(
+            "Wrote the graph to {}. No trust anchor file: this run's anchors are built by certval \
+             rather than read from material that can be written out.",
+            ca_path.display()
+        ));
+        return;
+    };
+    let ta_path = folder.path().join("ta.cbor");
+    match std::fs::write(&ta_path, &anchors) {
+        Ok(()) => status.set(format!(
+            "Wrote ta.cbor and ca.cbor to {}",
+            folder.path().to_string_lossy()
+        )),
+        Err(e) => {
+            error!("Failed to write {}: {e}", ta_path.display());
+            status.set(format!("Export failed: {e}"));
+        }
     }
 }
 
@@ -297,7 +396,7 @@ fn UriCheckModal(open: Signal<bool>) -> Element {
                     }
                 }
                 p { class: "hint",
-                    "Fetches the HTTP URIs in the target certificate's AIA, SIA, CRL DP and freshest-CRL extensions and reports per-URI reachability and correctness, independent of path processing. Supplying (or auto-discovering) the issuer enables CRL-signature verification and OCSP checks."
+                    "Fetches the HTTP URIs in the certificate's AIA, SIA, CRL DP and freshest-CRL extensions and reports each one, independent of path processing. An issuer, supplied or auto-discovered, adds CRL signature verification and OCSP checks."
                 }
                 table {
                     tbody {
@@ -410,14 +509,23 @@ enum View {
     Help,
 }
 
+/// Sidebar views in display order.
+///
+/// The head of the list is the ordinary path through the app — validate something, read the
+/// outcome, adjust what a run does — and everything after it is a tool for working on the material
+/// rather than a step in that path. Results sat seventh, below every tool, which put the thing a
+/// run navigates to on its own five entries away from the thing that produced it.
+///
+/// Nothing indexes this list positionally; the selected entry and the Results index are both found
+/// by lookup, so the order is presentation only.
 const VIEWS: &[(View, &str)] = &[
     (View::Validate, "Validate"),
+    (View::Results, "Results"),
+    (View::Settings, "Settings"),
     (View::Generate, "Generate"),
     (View::Cleanup, "Cleanup"),
     (View::Diagnostics, "Diagnostics"),
     (View::Tools, "Tools"),
-    (View::Settings, "Settings"),
-    (View::Results, "Results"),
     (View::Help, "Help"),
 ];
 
@@ -428,7 +536,7 @@ const VIEWS: &[(View, &str)] = &[
 /// trust-bit-scoped Mozilla sets selectable at all: nothing in a root's DER says which purposes
 /// CCADB records it for, so a folder of roots cannot express them.
 #[component]
-fn StoreRow(sig: Signal<usize>) -> Element {
+fn StoreRow(sig: Signal<usize>, status: Signal<String>) -> Element {
     let mut sig = sig;
     rsx! {
         tr {
@@ -457,32 +565,87 @@ fn StoreRow(sig: Signal<usize>) -> Element {
                     }
                 }
             }
-            td { class: "nowrap" }
+            // Offered for a built-in store alone: a custom selection is already files on disk, so
+            // there would be nothing to write that the user does not have, and webpki's anchors
+            // are built during a run rather than held here.
+            td { class: "nowrap",
+                if sig() != stores::CUSTOM && !stores::is_webpki(sig()) {
+                    button {
+                        r#type: "button",
+                        title: "Write this store's trust anchors and CBOR stores into a folder",
+                        onclick: move |_| {
+                            spawn(export_store_into(sig(), status));
+                        },
+                        "Export..."
+                    }
+                }
+            }
         }
     }
 }
 
-/// Explains what the selected built-in store supplies, and so which of the inputs beneath it are
-/// still doing work. Renders nothing for a custom selection.
+/// Outcome of the last store export, shown until another one replaces it. A row of its own rather
+/// than part of [`StoreHint`], which describes the store itself and should not be rewritten by an
+/// action taken against it.
+#[component]
+fn StoreStatusRow(status: Signal<String>) -> Element {
+    if status().is_empty() {
+        return rsx! {};
+    }
+    rsx! {
+        tr {
+            td { }
+            td { class: "grow",
+                div { class: "hint", "{status}" }
+            }
+            td { }
+        }
+    }
+}
+
+/// Heading for a run of rows within a fieldset, spanning the full width.
+///
+/// For what the rows have in common and the fields cannot each restate — that everything below is
+/// *additional* to a store already supplying trust material, say. Stating that per field, or worse
+/// per store, is the thing this exists to avoid.
+#[component]
+fn SubgroupRow(title: String) -> Element {
+    rsx! {
+        tr { class: "subgroup",
+            td { class: "subgroup", colspan: "3", "{title}" }
+        }
+    }
+}
+
+/// Says what the selected built-in store is, and whether it carries intermediates as well as
+/// anchors. Renders nothing for a custom selection.
+///
+/// It does **not** say what the fields beneath it do: that is the same sentence for every store, so
+/// it belongs to the group heading rather than to each blurb. The intermediates sentence names the
+/// CA CBOR field only when the store carries none, which is the same condition that puts that row
+/// on the screen — a hint should not send the reader looking for a field the view is not showing.
 #[component]
 fn StoreHint(selection: usize) -> Element {
     if selection == stores::CUSTOM {
         return rsx! {};
     }
+    let Some(store) = stores::STORES.get(selection - 1) else {
+        return rsx! {};
+    };
     let has_ca = stores::has_ca_store(selection);
     rsx! {
         tr {
             td { }
             td { class: "grow",
-                span { class: "hint",
+                // A block rather than a span: `.hint` carries a left padding, and on an inline box
+                // that indents the first line alone, leaving the wrapped lines hanging to its left.
+                div { class: "hint",
                     if has_ca {
-                        "This store supplies the trust anchors and the intermediate CA certificates. "
-                        "A TA folder adds anchors to it and a CA folder adds intermediates; the CA "
-                        "CBOR field is not used."
+                        "Trust anchors and intermediate CAs from {store.pki}. "
                     } else {
-                        "This store supplies trust anchors only. Give intermediates in the CA CBOR "
-                        "or CA folder field, or turn on dynamic build to fetch them."
+                        "Trust anchors from {store.pki}. Supply intermediates below or turn on dynamic build. "
                     }
+                    "{store.note}"
                 }
             }
             td { }
@@ -519,7 +682,7 @@ pub(crate) fn App() -> Element {
     // A run against a built-in store saves the cache paths it wrote into the CBOR arguments. What
     // is restored from that is the selection; showing the cache paths back as if the user had
     // typed them would invite editing a file the next run overwrites.
-    let saved_store = use_hook(|| stores::selection_for(&sa.ta_cbor));
+    let saved_store = use_hook(|| stores::selection_for(&sa.ta_cbor, sa.webpki_tas));
     let from_store = saved_store != stores::CUSTOM;
     let saved_or_empty = |v: &Option<String>| {
         if from_store {
@@ -530,9 +693,13 @@ pub(crate) fn App() -> Element {
     };
 
     let s_ta_folder = use_signal(|| sa.ta_folder.clone().unwrap_or_default());
-    let s_webpki_tas = use_signal(|| sa.webpki_tas);
     let s_cbor = use_signal(|| saved_or_empty(&sa.cbor));
     let s_store = use_signal(|| saved_store);
+    // Outcome of the last store export. Not persisted with the arguments: it describes something
+    // that happened, not something the next run should do.
+    let s_store_export = use_signal(String::new);
+    // The same, for the graph export in the Advanced group
+    let mut s_graph_export = use_signal(String::new);
     let s_ta_cbor = use_signal(|| saved_or_empty(&sa.ta_cbor));
     let s_time_of_interest = use_signal(|| get_now_as_unix_epoch().to_string());
     let s_logging_config = use_signal(|| sa.logging_config.clone().unwrap_or_default());
@@ -591,29 +758,25 @@ pub(crate) fn App() -> Element {
     let mut s_uri_dialog_open = use_signal(|| false);
     let mut s_log = use_signal(Vec::<String>::new);
 
-    let run_command = move |_: ()| {
-        if s_running() {
-            return;
-        }
-        // Resolve the store selection first: a built-in store supplies the trust anchors, and the
-        // intermediates too where its environment carries them. An anchors-only environment
-        // leaves the CA CBOR field in effect, so Mozilla's TLS or S/MIME anchor set can be paired
-        // with intermediates of the user's choosing. The TA folder is never displaced, since
-        // anchors from a store and a folder are combined.
-        let (store_ta_cbor, store_cbor) = match stores::materialize(s_store()) {
-            Ok(paths) => paths,
-            Err(msg) => {
-                error!("{msg}");
-                s_log.write().push(msg);
-                s_view.set(View::Results);
-                return;
-            }
-        };
+    // The arguments the form currently describes. Shared by the run and by anything else that has
+    // to reason about what a run *would* do — exporting the graph asks which graph this form keys
+    // to, and an answer assembled a second way would be an answer to a different question.
+    //
+    // Resolves the store selection first: a built-in store supplies the trust anchors, and the
+    // intermediates too where its environment carries them. An anchors-only environment leaves the
+    // CA CBOR field in effect, so Mozilla's TLS or S/MIME anchor set can be paired with
+    // intermediates of the user's choosing. The TA folder is never displaced, since anchors from a
+    // store and a folder are combined.
+    let current_args = move || -> Result<Pittv3Args, String> {
+        let (store_ta_cbor, store_cbor) = stores::materialize(s_store())?;
 
-        let args = Pittv3Args {
+        Ok(Pittv3Args {
             ta_folder: path_or_none(s_ta_folder),
             ta_cbor: store_ta_cbor.or_else(|| path_or_none(s_ta_cbor)),
-            webpki_tas: s_webpki_tas(),
+            // Set by the store selector alone. As a checkbox this could be combined with any other
+            // anchor set, which is the two-TaSource case load_trust_anchors merges its own inputs
+            // to avoid; a single-select control cannot express it.
+            webpki_tas: stores::is_webpki(s_store()),
             cbor: store_cbor.or_else(|| path_or_none(s_cbor)),
             time_of_interest: s_time_of_interest()
                 .parse::<u64>()
@@ -649,6 +812,21 @@ pub(crate) fn App() -> Element {
             check_uris: None,
             issuer: None,
             no_auto_discover: false,
+        })
+    };
+
+    let run_command = move |_: ()| {
+        if s_running() {
+            return;
+        }
+        let args = match current_args() {
+            Ok(args) => args,
+            Err(msg) => {
+                error!("{msg}");
+                s_log.write().push(msg);
+                s_view.set(View::Results);
+                return;
+            }
         };
 
         let _ = save_args(&args);
@@ -775,12 +953,25 @@ pub(crate) fn App() -> Element {
             {
                 match s_view() {
                     View::Validate => rsx! {
+                        // Two boxes rather than one: the first is the PKI a run is judged against —
+                        // certval's own PkiEnvironment, anchors and intermediates and revocation
+                        // material — and the second is what is judged and how. "Validation" named
+                        // the view rather than either of them.
                         fieldset {
-                            legend { "Validation" }
+                            legend { "PKI Environment" }
                             table {
                                 tbody {
-                                    StoreRow { sig: s_store }
+                                    StoreRow { sig: s_store, status: s_store_export }
                                     StoreHint { selection: s_store() }
+                                    StoreStatusRow { status: s_store_export }
+                                    // "Additional" only when a store is supplying material to add
+                                    // to: for a custom selection these fields are the trust
+                                    // material, not a supplement to it.
+                                    if s_store() == stores::CUSTOM {
+                                        SubgroupRow { title: "Trust Anchors and Certification Authorities" }
+                                    } else {
+                                        SubgroupRow { title: "Additional Trust Anchors and Certification Authorities" }
+                                    }
                                     PathRow {
                                         label: "TA Folder or File",
                                         name: "ta-folder",
@@ -821,6 +1012,15 @@ pub(crate) fn App() -> Element {
                                             sig: s_ca_folder,
                                         }
                                     }
+                                    SubgroupRow { title: "Revocation" }
+                                    FolderRow { label: "CRL Folder", name: "crl-folder", sig: s_crl_folder }
+                                }
+                            }
+                        }
+                        fieldset {
+                            legend { "Target and Settings" }
+                            table {
+                                tbody {
                                     FileRow {
                                         label: "End Entity File",
                                         name: "end-entity-file",
@@ -829,7 +1029,6 @@ pub(crate) fn App() -> Element {
                                         extensions: ["der", "crt"].as_slice(),
                                     }
                                     FolderRow { label: "End Entity Folder", name: "end-entity-folder", sig: s_end_entity_folder }
-                                    FolderRow { label: "CRL Folder", name: "crl-folder", sig: s_crl_folder }
                                     tr {
                                         td { label { r#for: "settings", "Settings: " } }
                                         td { class: "grow",
@@ -865,7 +1064,10 @@ pub(crate) fn App() -> Element {
                                     tr {
                                         td { }
                                         td { class: "grow",
-                                            span { class: "hint",
+                                            // Block, for the reason given on StoreHint: an inline
+                                            // .hint indents its first line only. Both lines here
+                                            // are short enough not to wrap today.
+                                            div { class: "hint",
                                                 if s_settings().is_empty() {
                                                     "This run will use certval defaults."
                                                 } else {
@@ -930,9 +1132,45 @@ pub(crate) fn App() -> Element {
                                 table {
                                     tbody {
                                         tr {
-                                            CheckboxCell { label: "WebPKI TAs", name: "webpki-tas", sig: s_webpki_tas }
+                                            // "WebPKI TAs" was here. It is an anchor set, so it is
+                                            // an entry in the store selector now — see StoreSource.
                                             CheckboxCell { label: "Validate Self-Signed", name: "validate-self-signed", sig: s_validate_self_signed }
                                             td { class: "grow" }
+                                        }
+                                        // The environment the last run over these inputs used,
+                                        // which exists as files only because it is cached: nothing
+                                        // else writes the assembled anchors and the merged graph
+                                        // out as a pair.
+                                        tr {
+                                            td { }
+                                            td { class: "grow",
+                                                button {
+                                                    r#type: "button",
+                                                    title: "Write this run's trust anchors and its certificate graph to a folder, as ta.cbor and ca.cbor",
+                                                    onclick: move |_| {
+                                                        match current_args() {
+                                                            Ok(args) => {
+                                                                spawn(export_environment_into(args, s_graph_export));
+                                                            }
+                                                            Err(msg) => {
+                                                                error!("{msg}");
+                                                                s_graph_export.set(msg);
+                                                            }
+                                                        }
+                                                    },
+                                                    "Export PKI Environment..."
+                                                }
+                                            }
+                                            td { }
+                                        }
+                                        if !s_graph_export().is_empty() {
+                                            tr {
+                                                td { }
+                                                td { class: "grow",
+                                                    div { class: "hint", "{s_graph_export}" }
+                                                }
+                                                td { }
+                                            }
                                         }
                                     }
                                 }
@@ -945,14 +1183,38 @@ pub(crate) fn App() -> Element {
                             legend { "Generation" }
                             table {
                                 tbody {
-                                    FolderRow { label: "TA Folder", name: "ta-folder", sig: s_ta_folder }
-                                    FolderRow { label: "CA Folder", name: "ca-folder", sig: s_ca_folder }
-                                    FileRow {
-                                        label: "CA CBOR",
-                                        name: "cbor",
-                                        sig: s_cbor,
-                                        filter_name: "PITTv3 CBOR-serialized PKI",
-                                        extensions: ["cbor", "pki"].as_slice(),
+                                    PathRow {
+                                        label: "TA Folder or File",
+                                        name: "ta-folder",
+                                        sig: s_ta_folder,
+                                    }
+                                    PathRow {
+                                        label: "CA Folder or File",
+                                        name: "ca-folder",
+                                        sig: s_ca_folder,
+                                    }
+                                    // The file the run writes — labelled as such, since it sits
+                                    // among inputs and is otherwise indistinguishable from one.
+                                    // Which store it holds follows the CBOR TA store checkbox
+                                    // below, so it is named for the row it will be loaded into on
+                                    // the Validate view. (Same "(output)" convention as the
+                                    // Mozilla CSV view's CA Folder.)
+                                    if s_cbor_ta_store() {
+                                        FileRow {
+                                            label: "TA CBOR (output)",
+                                            name: "cbor",
+                                            sig: s_cbor,
+                                            filter_name: "PITTv3 CBOR-serialized trust anchor store",
+                                            extensions: ["cbor", "pki", "ta"].as_slice(),
+                                        }
+                                    } else {
+                                        FileRow {
+                                            label: "CA CBOR (output)",
+                                            name: "cbor",
+                                            sig: s_cbor,
+                                            filter_name: "PITTv3 CBOR-serialized PKI",
+                                            extensions: ["cbor", "pki"].as_slice(),
+                                        }
                                     }
                                     FolderRow { label: "Download Folder", name: "download-folder", sig: s_download_folder }
                                 }
@@ -973,7 +1235,11 @@ pub(crate) fn App() -> Element {
                                 }
                             }
                             p { class: "hint",
-                                "Check Generate to (re)build the CBOR store from the TA and CA folders when running."
+                                if s_cbor_ta_store() {
+                                    "Generate writes a trust anchor store to the TA CBOR path above, read from the CA input; either input may be a single file."
+                                } else {
+                                    "Generate writes the store to the CA CBOR path above, built from the TA and CA inputs; either may be a single file. Check CBOR TA store for a trust anchor store instead."
+                                }
                             }
                         }
                         RunButton { running: s_running(), onrun: run_command }
@@ -1011,8 +1277,9 @@ pub(crate) fn App() -> Element {
                             legend { "Diagnostics" }
                             table {
                                 tbody {
-                                    StoreRow { sig: s_store }
+                                    StoreRow { sig: s_store, status: s_store_export }
                                     StoreHint { selection: s_store() }
+                                    StoreStatusRow { status: s_store_export }
                                     if !stores::has_ca_store(s_store()) {
                                         FileRow {
                                             label: "CA CBOR",
@@ -1022,7 +1289,11 @@ pub(crate) fn App() -> Element {
                                             extensions: ["cbor", "pki"].as_slice(),
                                         }
                                     }
-                                    FolderRow { label: "TA Folder", name: "ta-folder", sig: s_ta_folder }
+                                    PathRow {
+                                        label: "TA Folder or File",
+                                        name: "ta-folder",
+                                        sig: s_ta_folder,
+                                    }
                                     if s_store() == stores::CUSTOM {
                                         FileRow {
                                             label: "TA CBOR",
@@ -1136,7 +1407,7 @@ pub(crate) fn App() -> Element {
                             // exist. The empty case is only reachable with no home directory.
                             if s_settings().is_empty() {
                                 p { class: "hint",
-                                    "No home directory is available, so there is no default settings file. Choose (or type the path of) a JSON settings file to edit."
+                                    "No home directory, so there is no default settings file. Choose or type the path of a JSON settings file to edit."
                                 }
                             } else {
                                 EditSettingsFile {

--- a/pittv3-gui/src/stores.rs
+++ b/pittv3-gui/src/stores.rs
@@ -20,6 +20,25 @@ use std::path::{Path, PathBuf};
 
 use certval_stores_core::{serialize_environment, TrustStoreProvider};
 use pittv3_gui_lib::settings_store::app_home;
+use pittv3_lib::std_utils::cbor_store_to_ders;
+
+/// Where a selectable store's material comes from.
+///
+/// Two kinds, because webpki-roots is an anchor set certval builds for itself rather than material
+/// a provider carries. Making it an entry here instead of a checkbox is not tidying: the selector
+/// is single-select, and *combining* anchor sets is the thing to prevent. `--webpki-tas` adds its
+/// own `TaSource` and `load_trust_anchors` adds a second one, which is the
+/// arrangement that function merges its own two inputs to avoid — two sources sharing an anchor
+/// poison its key identifier. webpki-roots being Mozilla's TLS set makes the overlap with the
+/// Mozilla entries near total, so that was reachable in one click.
+pub(crate) enum StoreSource {
+    /// Material linked in from a `certval_stores_*` provider. A function pointer because
+    /// `provider()` is not a const fn.
+    Provider(fn() -> &'static dyn TrustStoreProvider),
+    /// The webpki-roots anchors, reached through the `webpki_tas` argument rather than through a
+    /// written store: `TaSource` has no serializer, so there is no CBOR to put on disk.
+    Webpki,
+}
 
 /// A trust anchor and CA certificate store pair offered by the store selector, named by the
 /// provider environment it comes from.
@@ -28,8 +47,16 @@ pub(crate) struct BuiltInStore {
     pub label: &'static str,
     /// Provider environment, e.g. `NIPR`. Also names the cache folder the store is written to.
     pub env: &'static str,
-    /// The provider serving `env`. A function pointer because `provider()` is not a const fn.
-    pub provider: fn() -> &'static dyn TrustStoreProvider,
+    /// Where the material comes from
+    pub source: StoreSource,
+    /// The PKI this store's material comes from, as a noun phrase completing "Trust anchors [and
+    /// intermediate CAs] from ___." Only the phrase, because whether the store carries
+    /// intermediates is asked of the provider at render time by [`has_ca_store`] — writing it into
+    /// the sentence here would let the two disagree.
+    pub pki: &'static str,
+    /// Anything a user has to know before picking this one, or empty. For a property of the store
+    /// that changes what a run does, not for description — the sentence above is the description.
+    pub note: &'static str,
 }
 
 /// Value of the store selector meaning "none of the below": the TA and CA inputs are used as
@@ -43,7 +70,9 @@ pub(crate) const STORES: &[BuiltInStore] = &[
     BuiltInStore {
         label: "U.S. DoD (NIPR production)",
         env: "NIPR",
-        provider: certval_stores_nipr::provider,
+        source: StoreSource::Provider(certval_stores_nipr::provider),
+        pki: "the DoD production PKI on NIPRNet",
+        note: "",
     },
     // MOZILLA_ALL rather than MOZILLA_TLS: the intermediate store hangs off the combined
     // environment only, because a large share of the CCADB intermediates chain solely to
@@ -51,30 +80,52 @@ pub(crate) const STORES: &[BuiltInStore] = &[
     BuiltInStore {
         label: "Web PKI (Mozilla roots, TLS + S/MIME, + CCADB intermediates)",
         env: "MOZILLA_ALL",
-        provider: certval_stores_mozilla::provider,
+        source: StoreSource::Provider(certval_stores_mozilla::provider),
+        pki: "the Mozilla CA program, covering all purposes it supports",
+        note: "",
     },
-    // The trust-bit-scoped subsets. These carry no CA store, so paths through an intermediate
-    // need one supplied — but they are also the two that cannot be assembled by hand at all,
-    // since which trust bits a root carries is CCADB policy the DER does not record.
+    // The trust-bit-scoped subsets. These carry no CA store, so paths through an intermediate need
+    // one supplied. Which roots belong to each is CCADB policy rather than anything the
+    // certificates record, so the split has to come from the provider — it cannot be recovered
+    // from the DER of the roots themselves.
     BuiltInStore {
         label: "Web PKI (Mozilla roots, TLS only)",
         env: "MOZILLA_TLS",
-        provider: certval_stores_mozilla::provider,
+        source: StoreSource::Provider(certval_stores_mozilla::provider),
+        pki: "the Mozilla CA program, the roots trusted for websites",
+        note: "See the CCADB for further details.",
     },
     BuiltInStore {
         label: "Web PKI (Mozilla roots, S/MIME only)",
         env: "MOZILLA_EMAIL",
-        provider: certval_stores_mozilla::provider,
+        source: StoreSource::Provider(certval_stores_mozilla::provider),
+        pki: "the Mozilla CA program, the roots trusted for email",
+        note: "See the CCADB for further details.",
+    },
+    // certval's own webpki-roots anchors rather than a provider's material. Kept alongside
+    // MOZILLA_TLS deliberately: the two are the same idea from different hands — rustls' snapshot
+    // of the Mozilla program against CCADB read directly — and which one a run used is worth being
+    // able to say. The blurb is where the difference is stated, since the labels cannot carry it.
+    BuiltInStore {
+        label: "Web PKI (webpki-roots crate, TLS only)",
+        env: "WEBPKI",
+        source: StoreSource::Webpki,
+        pki: "the webpki-roots crate, rustls' snapshot of the Mozilla program",
+        note: "These anchors assert no validity, so anchor validity checking is off for the run.",
     },
     BuiltInStore {
         label: "U.S. Federal PKI (Common Policy CA G2)",
         env: "FPKI",
-        provider: certval_stores_fpki::provider,
+        source: StoreSource::Provider(certval_stores_fpki::provider),
+        pki: "the U.S. Federal PKI",
+        note: "Its bridge-era roots are nodes within the PKI, reached by cross-certificate.",
     },
     BuiltInStore {
         label: "U.S. DoD (Purebred development)",
         env: "DEV",
-        provider: certval_stores_pbdev::provider,
+        source: StoreSource::Provider(certval_stores_pbdev::provider),
+        pki: "the Purebred development environment",
+        note: "Test material: not for judging production certificates.",
     },
 ];
 
@@ -99,12 +150,18 @@ pub(crate) fn materialize(index: usize) -> Result<(Option<String>, Option<String
         .get(index - 1)
         .ok_or_else(|| format!("no built-in store at index {index}"))?;
 
+    // Nothing to write for webpki: the run builds those anchors itself from the argument, so there
+    // are no paths to hand back. See [`is_webpki`], which is what sets it.
+    let StoreSource::Provider(provider) = store.source else {
+        return Ok((None, None));
+    };
+
     let dir = store_home()
         .ok_or_else(|| "no home directory to cache built-in stores in".to_string())?
         .join(store.env);
     fs::create_dir_all(&dir).map_err(|e| format!("cannot create {}: {e}", dir.display()))?;
 
-    let serialized = serialize_environment(&[(store.provider)()], store.env)
+    let serialized = serialize_environment(&[provider()], store.env)
         .map_err(|e| format!("failed to serialize the {} store: {e:?}", store.env))?;
 
     let ta_path = dir.join("ta.cbor");
@@ -130,6 +187,145 @@ pub(crate) fn materialize(index: usize) -> Result<(Option<String>, Option<String
     Ok((Some(path_string(&ta_path)?), ca_path))
 }
 
+/// What an [`export`] wrote, for the message shown when it finishes.
+pub(crate) struct Exported {
+    /// Folder the material was written to, `<destination>/<env>`
+    pub folder: String,
+    /// Number of trust anchor DER files written
+    pub anchors: usize,
+    /// Number of intermediate CA DER files written, unpacked from the CA store
+    pub intermediates: usize,
+    /// Whether a CA store accompanied the anchors
+    pub ca_store: bool,
+}
+
+/// A file name for a certificate taken out of a CBOR store, derived from the name the store
+/// recorded for it.
+///
+/// Stores generated from a folder carry the original file names, which are the most useful thing
+/// to write back out — but they are a store's data, not this app's, so they are treated as
+/// untrusted: only the last component is used, anything outside a conservative set of characters
+/// becomes `_`, and a name that survives all that as empty falls back to the index. `seen` keeps
+/// two certificates recorded under one name from overwriting each other.
+fn der_file_name(stored: &str, index: usize, seen: &mut Vec<String>) -> String {
+    let base = stored.rsplit(['/', '\\']).next().unwrap_or("");
+    let cleaned: String = base
+        .chars()
+        .map(|c| {
+            if c.is_ascii_alphanumeric() || c == '.' || c == '-' || c == '_' {
+                c
+            } else {
+                '_'
+            }
+        })
+        .collect();
+    let cleaned = cleaned.trim_matches(['.', '_']).to_string();
+
+    let mut name = if cleaned.is_empty() {
+        format!("cert_{index}.der")
+    } else if [".der", ".cer", ".crt"]
+        .iter()
+        .any(|ext| cleaned.to_ascii_lowercase().ends_with(ext))
+    {
+        cleaned
+    } else {
+        format!("{cleaned}.der")
+    };
+
+    if seen.contains(&name) {
+        name = format!("{index}_{name}");
+    }
+    seen.push(name.clone());
+    name
+}
+
+/// Writes the material behind the built-in store at `index` into `dest`, so the certificates a run
+/// validated against can be inspected, archived or handed to another tool.
+///
+/// The material is linked into the binary and otherwise reachable only through a run, which is the
+/// reason this exists: there is no file to open. Everything lands under `<dest>/<env>` rather than
+/// in `dest` itself, so exporting two stores to the same place cannot interleave them.
+///
+/// Anchors are written as DER, one file per root, named for the label
+/// [`serialize_environment`] gives that anchor — so a certificate named in a report or a log is
+/// the file of the same name here. The two stores are written as the CBOR a run consumes.
+/// Intermediates are not exploded into DER: that would mean decoding the CA store, and this crate
+/// deliberately reaches certval only through `pittv3_lib`. The Diagnostics view already dumps
+/// buffers from a CBOR store, and it will happily take the `ca.cbor` written here.
+pub(crate) fn export(index: usize, dest: &Path) -> Result<Exported, String> {
+    if index == CUSTOM {
+        return Err("no built-in store is selected".to_string());
+    }
+    let store = STORES
+        .get(index - 1)
+        .ok_or_else(|| format!("no built-in store at index {index}"))?;
+
+    // No export for webpki: its anchors live in the run rather than in material this app holds, so
+    // there is nothing here to copy out. The button is hidden for it rather than failing here.
+    let StoreSource::Provider(provider) = store.source else {
+        return Err(format!("{} has no material to export", store.label));
+    };
+
+    let dir = dest.join(store.env);
+    let tas = dir.join("tas");
+    fs::create_dir_all(&tas).map_err(|e| format!("cannot create {}: {e}", tas.display()))?;
+
+    let serialized = serialize_environment(&[provider()], store.env)
+        .map_err(|e| format!("failed to serialize the {} store: {e:?}", store.env))?;
+    fs::write(dir.join("ta.cbor"), &serialized.ta_cbor)
+        .map_err(|e| format!("cannot write ta.cbor: {e}"))?;
+    if let Some(bytes) = &serialized.ca_cbor {
+        fs::write(dir.join("ca.cbor"), bytes).map_err(|e| format!("cannot write ca.cbor: {e}"))?;
+    }
+
+    // The provider hands over the roots as DER already, so nothing here parses a certificate.
+    // Duplicates are dropped for the same reason serialize_environment drops them: a root serving
+    // two environments is one anchor, and writing it twice would misreport the count.
+    let mut anchors = 0;
+    let mut seen: Vec<&[u8]> = Vec::new();
+    for entry in provider().entries() {
+        if entry.env != store.env {
+            continue;
+        }
+        for (i, der) in entry.roots.iter().enumerate() {
+            if seen.contains(der) {
+                continue;
+            }
+            seen.push(der);
+            let name = format!("{}_root_{i}.der", store.env);
+            fs::write(tas.join(&name), der).map_err(|e| format!("cannot write {name}: {e}"))?;
+            anchors += 1;
+        }
+    }
+
+    // The CA store unpacked into loose certificates. The CBOR beside it is what a run consumes, but
+    // it is opaque: this is the half a user can read, hand to another tool, or point a CA Folder at
+    // — which is the only way to add this material to a run that has already selected a store,
+    // since the CBOR arguments hold one path each and the selection occupies them.
+    let mut intermediates = 0;
+    if let Some(bytes) = &serialized.ca_cbor {
+        let certs = cbor_store_to_ders(bytes)?;
+        if !certs.is_empty() {
+            let cas = dir.join("cas");
+            fs::create_dir_all(&cas)
+                .map_err(|e| format!("cannot create {}: {e}", cas.display()))?;
+            let mut names = Vec::with_capacity(certs.len());
+            for (i, (stored, der)) in certs.iter().enumerate() {
+                let name = der_file_name(stored, i, &mut names);
+                fs::write(cas.join(&name), der).map_err(|e| format!("cannot write {name}: {e}"))?;
+                intermediates += 1;
+            }
+        }
+    }
+
+    Ok(Exported {
+        folder: path_string(&dir)?,
+        anchors,
+        intermediates,
+        ca_store: serialized.ca_cbor.is_some(),
+    })
+}
+
 /// Whether the store at `index` carries intermediate CA certificates as well as trust anchors.
 /// False for [`CUSTOM`] and for an anchors-only environment.
 ///
@@ -139,12 +335,31 @@ pub(crate) fn has_ca_store(index: usize) -> bool {
     if index == CUSTOM {
         return false;
     }
-    STORES.get(index - 1).is_some_and(|store| {
-        (store.provider)()
-            .entries()
-            .iter()
-            .any(|e| e.env == store.env && e.cert_store_cbor.is_some())
-    })
+    STORES
+        .get(index - 1)
+        .is_some_and(|store| match store.source {
+            StoreSource::Provider(provider) => provider()
+                .entries()
+                .iter()
+                .any(|e| e.env == store.env && e.cert_store_cbor.is_some()),
+            // webpki-roots is anchors and nothing else
+            StoreSource::Webpki => false,
+        })
+}
+
+/// Whether the store at `index` is the webpki-roots anchor set, which a run reaches through the
+/// `webpki_tas` argument rather than through a path. False for [`CUSTOM`].
+///
+/// This is the whole of what selecting it does, and it is why the argument no longer has a checkbox
+/// of its own: as a selection it cannot be combined with another anchor set, which is what the
+/// checkbox allowed.
+pub(crate) fn is_webpki(index: usize) -> bool {
+    if index == CUSTOM {
+        return false;
+    }
+    STORES
+        .get(index - 1)
+        .is_some_and(|store| matches!(store.source, StoreSource::Webpki))
 }
 
 /// Recovers the store selection from a saved trust anchor CBOR path, so a run restores the store
@@ -152,7 +367,16 @@ pub(crate) fn has_ca_store(index: usize) -> bool {
 ///
 /// This is a path comparison only — it does not read or write the cache — so it answers the same
 /// way whether or not the material has been written out yet.
-pub(crate) fn selection_for(ta_cbor: &Option<String>) -> usize {
+pub(crate) fn selection_for(ta_cbor: &Option<String>, webpki_tas: bool) -> usize {
+    // The webpki entry writes no path, so the saved argument is the only trace of it.
+    if webpki_tas {
+        if let Some(i) = STORES
+            .iter()
+            .position(|s| matches!(s.source, StoreSource::Webpki))
+        {
+            return i + 1;
+        }
+    }
     let Some(ta_cbor) = ta_cbor else {
         return CUSTOM;
     };
@@ -191,7 +415,10 @@ mod tests {
     #[test]
     fn every_catalogue_entry_resolves_against_its_provider() {
         for store in STORES {
-            let entries = (store.provider)().entries();
+            let StoreSource::Provider(provider) = store.source else {
+                continue; // webpki carries no provider to resolve against
+            };
+            let entries = provider().entries();
             assert!(
                 entries.iter().any(|e| e.env == store.env),
                 "{} names environment {}, which its provider does not serve; it serves {:?}",
@@ -220,7 +447,15 @@ mod tests {
     fn every_store_serializes_into_loadable_material() {
         for (i, store) in STORES.iter().enumerate() {
             let selection = i + 1;
-            let serialized = serialize_environment(&[(store.provider)()], store.env)
+            let StoreSource::Provider(provider) = store.source else {
+                // The webpki entry is the run's own anchor set: nothing is written, nothing is
+                // claimed, and the argument is the whole of what selecting it does.
+                assert!(is_webpki(selection));
+                assert!(!has_ca_store(selection));
+                assert_eq!(materialize(selection).unwrap(), (None, None));
+                continue;
+            };
+            let serialized = serialize_environment(&[provider()], store.env)
                 .unwrap_or_else(|e| panic!("{} failed to serialize: {e:?}", store.label));
 
             let ta = TaSource::new_from_cbor(&serialized.ta_cbor)
@@ -250,11 +485,110 @@ mod tests {
     fn custom_selects_nothing() {
         assert!(!has_ca_store(CUSTOM));
         assert_eq!(materialize(CUSTOM).unwrap(), (None, None));
-        assert_eq!(selection_for(&None), CUSTOM);
+        assert_eq!(selection_for(&None, false), CUSTOM);
         assert_eq!(
-            selection_for(&Some("/some/where/ta.cbor".to_string())),
+            selection_for(&Some("/some/where/ta.cbor".to_string()), false),
             CUSTOM
         );
+    }
+
+    /// An export is only worth offering if what it writes can be used elsewhere: the CBOR has to
+    /// load as a store, and each anchor has to be a certificate another tool can parse. FPKI
+    /// because it is the smallest environment — the mechanism is the same for all of them, and
+    /// MOZILLA_ALL would have the test writing a great many files to prove the same point.
+    #[test]
+    fn export_writes_usable_material() {
+        let dir = tempfile::tempdir().unwrap();
+        let selection = STORES.iter().position(|s| s.env == "FPKI").unwrap() + 1;
+
+        let exported = export(selection, dir.path()).unwrap();
+        let out = dir.path().join("FPKI");
+
+        let ta = TaSource::new_from_cbor(&fs::read(out.join("ta.cbor")).unwrap())
+            .expect("the exported TA store does not load");
+        assert!(!ta.is_empty());
+        assert_eq!(
+            out.join("ca.cbor").is_file(),
+            exported.ca_store,
+            "the reported CA store and the file on disk disagree"
+        );
+
+        let ders: Vec<PathBuf> = fs::read_dir(out.join("tas"))
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .collect();
+        assert!(exported.anchors > 0, "exported no anchors");
+        assert_eq!(exported.anchors, ders.len(), "reported more than it wrote");
+        for der in &ders {
+            let bytes = fs::read(der).unwrap();
+            certval::parse_cert(&bytes, der.to_str().unwrap())
+                .unwrap_or_else(|e| panic!("{} is not a certificate: {e:?}", der.display()));
+        }
+    }
+
+    /// An environment that carries intermediates unpacks them too, which is the half a user can
+    /// point another run at: the CBOR beside them holds the same certificates but nothing except
+    /// this app can read it, and the CBOR arguments hold one path each.
+    #[test]
+    fn export_unpacks_the_ca_store_into_certificates() {
+        let dir = tempfile::tempdir().unwrap();
+        let selection = STORES.iter().position(|s| s.env == "NIPR").unwrap() + 1;
+
+        let exported = export(selection, dir.path()).unwrap();
+        let out = dir.path().join("NIPR");
+
+        assert!(exported.ca_store, "NIPR is expected to carry intermediates");
+        assert!(exported.intermediates > 0);
+
+        let ders: Vec<PathBuf> = fs::read_dir(out.join("cas"))
+            .unwrap()
+            .map(|e| e.unwrap().path())
+            .collect();
+        assert_eq!(exported.intermediates, ders.len());
+
+        // What was unpacked has to be the store's own contents, certificate for certificate
+        let cbor = fs::read(out.join("ca.cbor")).unwrap();
+        let ca = CertSource::new_from_cbor(&cbor).unwrap();
+        assert_eq!(ca.get_buffers().len(), ders.len());
+        for der in &ders {
+            let bytes = fs::read(der).unwrap();
+            certval::parse_cert(&bytes, der.to_str().unwrap())
+                .unwrap_or_else(|e| panic!("{} is not a certificate: {e:?}", der.display()));
+        }
+    }
+
+    /// Exporting is offered for built-in stores alone, so asking for a custom one is a caller
+    /// error rather than an empty folder that looks like a successful export. Same for webpki,
+    /// whose anchors this app never holds — the button is hidden, and the call refuses.
+    #[test]
+    fn export_refuses_what_it_cannot_write() {
+        let dir = tempfile::tempdir().unwrap();
+        assert!(export(CUSTOM, dir.path()).is_err());
+        assert!(export(STORES.len() + 1, dir.path()).is_err());
+
+        let webpki = STORES.iter().position(is_webpki_source).unwrap() + 1;
+        assert!(export(webpki, dir.path()).is_err());
+    }
+
+    /// Selecting webpki has to survive a restart, and it is the one selection with no path to
+    /// recover from: the saved `webpki_tas` argument is its only trace. The pairing also has to be
+    /// exclusive — recovering it must not depend on a TA CBOR path being absent, since a stale one
+    /// could still be saved alongside.
+    #[test]
+    fn webpki_recovers_from_the_saved_argument() {
+        let webpki = STORES.iter().position(is_webpki_source).unwrap() + 1;
+
+        assert_eq!(selection_for(&None, true), webpki);
+        assert_eq!(
+            selection_for(&Some("/some/where/ta.cbor".to_string()), true),
+            webpki
+        );
+        assert!(is_webpki(webpki));
+        assert!(!is_webpki(CUSTOM));
+    }
+
+    fn is_webpki_source(store: &BuiltInStore) -> bool {
+        matches!(store.source, StoreSource::Webpki)
     }
 
     /// A selection has to survive the round trip through the saved arguments, which carry the path
@@ -265,10 +599,13 @@ mod tests {
             return; // no home directory on this host; nothing to recover a path against
         };
         for (i, store) in STORES.iter().enumerate() {
+            if is_webpki_source(store) {
+                continue; // never written, so there is no path to recover it from
+            }
             let path = home.join(store.env).join("ta.cbor");
             let saved = Some(path.to_str().unwrap().to_string());
             assert_eq!(
-                selection_for(&saved),
+                selection_for(&saved, false),
                 i + 1,
                 "{} did not round trip",
                 store.label

--- a/pittv3-lib/src/args.rs
+++ b/pittv3-lib/src/args.rs
@@ -118,10 +118,13 @@ pub struct Pittv3Args {
     #[cfg(feature = "std")]
     pub settings: Option<String>,
 
-    /// Full path of folder containing binary, DER-encoded intermediate CA certificates. Required
-    /// when generate action is performed. This is not used when path validation is performed other
-    /// than as a place to store downloaded files when dynamic building is used and download_folder
-    /// is not specified.
+    /// Full path of a folder containing DER- or PEM-encoded CRLs, traversed recursively and indexed
+    /// before path validation begins. Only files with a .crl extension are processed. The indexed
+    /// CRLs are the local revocation source, consulted before any remote retrieval, and the folder
+    /// also receives CRLs fetched remotely along with the last-modified map that makes those
+    /// fetches conditional. Note that the folder is written as well as read: indexing deletes any
+    /// CRL that is not valid at the time of interest, i.e. one whose thisUpdate is in the future or
+    /// whose nextUpdate has passed.
     #[cfg(feature = "std")]
     pub crl_folder: Option<String>,
 

--- a/pittv3-lib/src/args.rs
+++ b/pittv3-lib/src/args.rs
@@ -47,8 +47,9 @@ pub struct Pittv3Args {
     pub error_folder: Option<String>,
 
     /// Full path and filename of folder to receive downloaded binary DER-encoded certificates, if
-    /// absent at generate time, the ca_folder is used. Additionally, this is used to designate where
-    /// exported buffers are written by dump_cert_at_index or list_buffers.
+    /// absent at generate time, the ca_folder is used, which requires it to name a folder rather
+    /// than a single file. Additionally, this is used to designate where exported buffers are
+    /// written by dump_cert_at_index or list_buffers.
     #[cfg(feature = "std")]
     pub download_folder: Option<String>,
 
@@ -73,7 +74,8 @@ pub struct Pittv3Args {
     pub chase_aia_and_sia: bool,
 
     /// Flag that indicates generated CBOR file will contain only trust anchors  (so no need for
-    /// partial paths and no need to exclude self-signed certificates).
+    /// partial paths and no need to exclude self-signed certificates). The anchors are read from
+    /// the ca_folder input, which may name a single file, and the result is the form ta_cbor takes.
     #[cfg(feature = "std")]
     pub cbor_ta_store: bool,
 

--- a/pittv3-lib/src/graph_cache.rs
+++ b/pittv3-lib/src/graph_cache.rs
@@ -1,0 +1,214 @@
+//! Caches the graph a run builds when it augments a CBOR store with other material.
+//!
+//! A validation run that is given intermediates as well as a store folds them together and searches
+//! the combined material for partial paths. That search is the expensive part of preparing a run —
+//! milliseconds against a small community PKI, but the better part of half a second against the
+//! Web PKI's CCADB set — and it produces the same graph every time the inputs are the same. This
+//! module keeps the result so that only the first of a series of runs pays for it.
+//!
+//! **What makes a hit.** The key is a fingerprint of everything the graph depends on: the paths
+//! that contributed material, each one's size and modification time, the time of interest, whether
+//! webpki anchors were in play, and the settings as serialized. Anything else changing is not a
+//! reason to rebuild, and anything in that list changing means the cached graph describes inputs
+//! that no longer exist. Size and modification time rather than content: reading every input to
+//! decide whether to avoid reading every input would spend most of what the cache saves. The
+//! failure mode that leaves is a file replaced within the filesystem's timestamp granularity and at
+//! exactly its old length, which is worth the trade here — this is a path-building index, and a run
+//! that wants no part of it can delete the folder or set `PITTV3_GRAPH_CACHE` to `off`.
+//!
+//! **Only augmented graphs are cached.** A run that uses a store alone already has the store's own
+//! partial paths and searches nothing, so there is nothing to save; a generate run writes its graph
+//! where it was asked to. Both are left alone.
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use log::{debug, info};
+use sha2::{Digest, Sha256};
+use walkdir::WalkDir;
+
+use certval::{CertSource, CertVector, CertificationPathBuilderFormats, CertificationPathSettings};
+
+use crate::args::Pittv3Args;
+
+/// Environment variable that relocates the cache, or disables it entirely when set to `off`.
+const CACHE_ENV: &str = "PITTV3_GRAPH_CACHE";
+
+/// Folder the cached graphs live in, `~/.pittv3/graphs` unless [`CACHE_ENV`] says otherwise.
+/// `None` when caching is off or there is no home directory to put it in.
+fn cache_dir() -> Option<PathBuf> {
+    match std::env::var(CACHE_ENV) {
+        Ok(v) if v.eq_ignore_ascii_case("off") => None,
+        Ok(v) if !v.is_empty() => Some(PathBuf::from(v)),
+        _ => {
+            let home = std::env::var("HOME")
+                .or_else(|_| std::env::var("USERPROFILE"))
+                .ok()?;
+            Some(Path::new(&home).join(".pittv3").join("graphs"))
+        }
+    }
+}
+
+/// Folds one input path into `hasher`: the path itself, and the size and modification time of every
+/// file it names or contains. A path that cannot be read contributes its name alone, which still
+/// distinguishes it from a run that did not name it.
+fn hash_path(hasher: &mut Sha256, label: &str, path: &str) {
+    hasher.update(label.as_bytes());
+    hasher.update(path.as_bytes());
+    for entry in WalkDir::new(path).sort_by_file_name() {
+        let Ok(entry) = entry else { continue };
+        let Ok(meta) = entry.metadata() else { continue };
+        if meta.is_dir() {
+            continue;
+        }
+        hasher.update(entry.path().to_string_lossy().as_bytes());
+        hasher.update(meta.len().to_le_bytes());
+        if let Ok(modified) = meta.modified() {
+            if let Ok(since) = modified.duration_since(std::time::UNIX_EPOCH) {
+                hasher.update(since.as_nanos().to_le_bytes());
+            }
+        }
+    }
+}
+
+/// The identity of the graph a run would build, or `None` when the run builds no augmented graph
+/// and so has nothing worth caching.
+///
+/// Deliberately conservative about the settings: the whole serialized blob goes into the key rather
+/// than the handful of values known to reach path building, so a setting that starts mattering
+/// cannot silently reuse a graph built without it. The cost is a missed cache when an unrelated
+/// setting changes, which costs exactly what there was before this existed.
+pub fn fingerprint(args: &Pittv3Args, cps: &CertificationPathSettings) -> Option<String> {
+    if args.generate || args.ca_folder.is_none() {
+        return None;
+    }
+    #[cfg(feature = "remote")]
+    if args.dynamic_build {
+        // The graph grows as URIs are chased, so what pass 0 built is not what the run ends with.
+        return None;
+    }
+
+    let mut hasher = Sha256::new();
+    hasher.update(b"pittv3 graph v1");
+    if let Some(ca_folder) = &args.ca_folder {
+        hash_path(&mut hasher, "ca", ca_folder);
+    }
+    if let Some(cbor) = &args.cbor {
+        hash_path(&mut hasher, "cbor", cbor);
+    }
+    if let Some(ta_folder) = &args.ta_folder {
+        hash_path(&mut hasher, "ta", ta_folder);
+    }
+    if let Some(ta_cbor) = &args.ta_cbor {
+        hash_path(&mut hasher, "ta_cbor", ta_cbor);
+    }
+    #[cfg(feature = "webpki")]
+    hasher.update([u8::from(args.webpki_tas)]);
+    hasher.update(args.time_of_interest.to_le_bytes());
+    if let Ok(settings) = serde_json::to_string(cps) {
+        hasher.update(settings.as_bytes());
+    }
+
+    let digest = hasher.finalize();
+    Some(digest.iter().map(|b| format!("{b:02x}")).collect())
+}
+
+/// The fingerprint a run driven by `args` would use, reading the settings that run would read.
+///
+/// For callers outside a run — the desktop's graph export asks which graph the form in front of it
+/// keys to, and computing that a second way would answer a different question.
+pub fn fingerprint_for_args(args: &Pittv3Args) -> Option<String> {
+    let mut cps = certval::read_settings(&args.settings).ok()?;
+    if !cps.0.contains_key(certval::PS_TIME_OF_INTEREST) {
+        cps.set_time_of_interest(
+            certval::TimeOfInterest::from_unix_secs(args.time_of_interest).ok()?,
+        );
+    }
+    fingerprint(args, &cps)
+}
+
+/// The cached graph for `fingerprint`, or `None` when there is not one. Says nothing: a caller that
+/// wants the fact recorded should say what it is doing with it.
+pub fn cached(fingerprint: &str) -> Option<Vec<u8>> {
+    let path = cache_dir()?.join(format!("{fingerprint}.cbor"));
+    let bytes = fs::read(&path).ok()?;
+    // A truncated or corrupt cache file must not take the run down with it: fall through to
+    // building the graph, which is what a miss does anyway.
+    if CertSource::new_from_cbor(&bytes).is_err() {
+        debug!("Discarding unreadable cached graph at {}", path.display());
+        let _ = fs::remove_file(&path);
+        return None;
+    }
+    Some(bytes)
+}
+
+/// The cached graph for `fingerprint`, noting in the log that a run reused it.
+pub fn load(fingerprint: &str) -> Option<Vec<u8>> {
+    let bytes = cached(fingerprint)?;
+    info!("Reusing the cached graph for this trust material");
+    Some(bytes)
+}
+
+/// The cached trust anchors that go with the graph for `fingerprint`, or `None` when there are not
+/// any. In the same shape a trust anchor CBOR store takes, so a consumer reads it with
+/// `TaSource::new_from_cbor`.
+pub fn cached_anchors(fingerprint: &str) -> Option<Vec<u8>> {
+    let path = cache_dir()?.join(format!("{fingerprint}.ta.cbor"));
+    fs::read(&path).ok()
+}
+
+/// Saves the anchors a run assembled alongside its graph.
+///
+/// The graph is only half of an environment: partial paths terminate at anchors, and the anchors
+/// live in a [`TaSource`](certval::TaSource) that never enters the [`CertSource`] — so a graph
+/// exported on its own describes paths to certificates it does not carry. Caching both means what
+/// is handed out is the whole of what the run validated against, and the two are written under one
+/// key, so they cannot be paired with each other's material.
+pub fn store_anchors(fingerprint: &str, anchors: Vec<certval::CertFile>) {
+    let Some(dir) = cache_dir() else { return };
+    if fs::create_dir_all(&dir).is_err() {
+        return;
+    }
+    // A trust anchor store on disk is a serialized CertSource holding the anchors, which is what
+    // `serialize_environment` writes and `TaSource::new_from_cbor` reads.
+    let mut as_source = CertSource::new();
+    for cf in anchors {
+        as_source.push(cf);
+    }
+    let bytes = match as_source.serialize(CertificationPathBuilderFormats::Cbor) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            debug!("Cannot serialize the trust anchors for caching: {e:?}");
+            return;
+        }
+    };
+    let path = dir.join(format!("{fingerprint}.ta.cbor"));
+    if let Err(e) = fs::write(&path, &bytes) {
+        debug!("Cannot write the cached anchors {}: {e}", path.display());
+    }
+}
+
+/// Saves `cert_source`'s graph under `fingerprint`. Failure is logged and otherwise ignored: a
+/// cache that cannot be written costs time, not correctness.
+pub fn store(fingerprint: &str, cert_source: &CertSource) {
+    let Some(dir) = cache_dir() else { return };
+    if let Err(e) = fs::create_dir_all(&dir) {
+        debug!(
+            "Cannot create the graph cache folder {}: {e}",
+            dir.display()
+        );
+        return;
+    }
+    let bytes = match cert_source.serialize(CertificationPathBuilderFormats::Cbor) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            debug!("Cannot serialize the graph for caching: {e:?}");
+            return;
+        }
+    };
+    let path = dir.join(format!("{fingerprint}.cbor"));
+    match fs::write(&path, &bytes) {
+        Ok(()) => info!("Cached the graph at {}", path.display()),
+        Err(e) => debug!("Cannot write the cached graph {}: {e}", path.display()),
+    }
+}

--- a/pittv3-lib/src/help.rs
+++ b/pittv3-lib/src/help.rs
@@ -91,10 +91,13 @@ pub fn arg_help(name: &str) -> &'static str {
         ),
         "settings" => "Full path and filename of JSON-formatted certification path validation settings.",
         "crl-folder" => concat!(
-            "Full path of folder containing binary, DER-encoded intermediate CA certificates. Required ",
-            "when generate action is performed. This is not used when path validation is performed other ",
-            "than as a place to store downloaded files when dynamic building is used and download_folder ",
-            "is not specified.",
+            "Full path of a folder containing DER- or PEM-encoded CRLs, traversed recursively and indexed ",
+            "before path validation begins. Only files with a .crl extension are processed. The indexed ",
+            "CRLs are the local revocation source, consulted before any remote retrieval, and the folder ",
+            "also receives CRLs fetched remotely along with the last-modified map that makes those fetches ",
+            "conditional. Note that the folder is written as well as read: indexing deletes any CRL that is ",
+            "not valid at the time of interest, i.e. one whose thisUpdate is in the future or whose ",
+            "nextUpdate has passed.",
         ),
         "keep-crl-entries-in-memory" => concat!(
             "When set together with crl_folder, retain the revoked serial numbers of each verified ",
@@ -180,6 +183,16 @@ mod tests {
         assert!(arg_help("ta-folder").contains("trust anchors"));
         assert!(arg_help("ca-folder").contains("intermediate CA certificates"));
         assert_eq!(arg_help("not-an-argument"), "");
+    }
+
+    /// The CRL folder holds CRLs, not certificates. Asserting the absence as well as the presence
+    /// is what distinguishes this entry from the CA folder's, which describes a different artifact
+    /// in otherwise similar words.
+    #[test]
+    fn crl_folder_describes_crls_not_ca_certificates() {
+        let help = arg_help("crl-folder");
+        assert!(help.contains("CRLs"));
+        assert!(!help.contains("intermediate CA certificates"));
     }
 
     /// `validate_all` is declared twice in `Pittv3Args` behind opposing `std_app` gates. The help

--- a/pittv3-lib/src/help.rs
+++ b/pittv3-lib/src/help.rs
@@ -45,8 +45,9 @@ pub fn arg_help(name: &str) -> &'static str {
         ),
         "download-folder" => concat!(
             "Full path and filename of folder to receive downloaded binary DER-encoded certificates, if ",
-            "absent at generate time, the ca_folder is used. Additionally, this is used to designate ",
-            "where exported buffers are written by dump_cert_at_index or list_buffers.",
+            "absent at generate time, the ca_folder is used, which requires it to name a folder rather ",
+            "than a single file. Additionally, this is used to designate where exported buffers are ",
+            "written by dump_cert_at_index or list_buffers.",
         ),
         "ca-folder" => concat!(
             "Full path of a folder containing binary, DER-encoded intermediate CA certificates, or of a ",
@@ -67,7 +68,9 @@ pub fn arg_help(name: &str) -> &'static str {
         ),
         "cbor-ta-store" => concat!(
             "Flag that indicates generated CBOR file will contain only trust anchors (so no need for ",
-            "partial paths and no need to exclude self-signed certificates).",
+            "partial paths and no need to exclude self-signed certificates). The anchors are read ",
+            "from the CA input, which may name a single file, and the result is the form --ta-cbor ",
+            "takes.",
         ),
         "validate-all" => "Flag that indicates all available certification paths should be validated for each target.",
         "validate-self-signed" => "Check if certificate passed as end_entity_file is self-signed.",

--- a/pittv3-lib/src/lib.rs
+++ b/pittv3-lib/src/lib.rs
@@ -6,6 +6,8 @@
 extern crate alloc;
 
 pub mod args;
+#[cfg(feature = "std")]
+pub mod graph_cache;
 pub mod help;
 pub mod no_std_utils;
 pub mod options_no_std;

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -183,6 +183,7 @@ use std::time::Instant;
 use log::{debug, error, info};
 
 use crate::args::Pittv3Args;
+use crate::graph_cache;
 use crate::report::{ReportTotals, TargetReport, ValidationReport};
 use crate::stats::{PVStats, PathValidationStats, PathValidationStatsGroup};
 use crate::std_utils::*;
@@ -761,6 +762,12 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         cps.set_time_of_interest(TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap());
     }
 
+    // Keyed here, on the settings as read, because what follows adjusts them for the run — turning
+    // off AIA/SIA retrieval, and anchor validity for webpki anchors — and a caller outside a run
+    // has no way to reproduce those adjustments. Both are covered by the key anyway: chasing runs
+    // are not cached at all, and webpki_tas is hashed in its own right.
+    let graph_fingerprint = graph_cache::fingerprint(args, &cps);
+
     #[cfg(feature = "remote")]
     if !args.dynamic_build {
         cps.set_retrieve_from_aia_sia_http(false);
@@ -803,6 +810,11 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
                 if let Some(ta_folder) = &args.ta_folder {
                     error!("No trust anchors were loaded from {ta_folder}. {TA_FOLDER_EMPTY}");
                 }
+            }
+            // Cached beside the graph and under the same key: the graph's partial paths end at
+            // these anchors, and nothing in the graph carries them.
+            if let Some(fingerprint) = &graph_fingerprint {
+                graph_cache::store_anchors(fingerprint, ta_store.get_tas());
             }
             pe.add_trust_anchor_source(Box::new(ta_store));
             ta_store_added = true;
@@ -857,6 +869,10 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
     // Number of certificates the CA folder contributed to the graph, used after the loop to tell a
     // folder that yielded nothing from no folder at all.
     let mut ca_folder_certs = 0;
+
+    // Whether the graph came off the cache rather than being built. Its identity was settled
+    // before the settings were adjusted for the run — see `graph_fingerprint` above.
+    let mut graph_from_cache = false;
 
     // Start the clock for entire set of validation actions
     let start = Instant::now();
@@ -930,13 +946,28 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
             }
         };
 
+        // The same augmented graph as last time, when nothing it was built from has changed. What
+        // is skipped is the folder walk and the partial-path search, which is the expensive half of
+        // preparing a run; the certificates are still parsed, since they have to be.
+        if 0 == pass && !graph_from_cache {
+            if let Some(cached) = graph_fingerprint.as_deref().and_then(graph_cache::load) {
+                match CertSource::new_from_cbor(cached.as_slice()) {
+                    Ok(from_cache) => {
+                        cert_source = from_cache;
+                        graph_from_cache = true;
+                    }
+                    Err(e) => debug!("Ignoring an unusable cached graph: {e:?}"),
+                }
+            }
+        }
+
         // A CA folder is the intermediates the user already has, and it fed generation only: at
         // validation time the graph came from the CBOR store alone, so -t tas -c cas -e ee.der
         // found no paths at all and the folder had to be compiled into a store first. Fold it into
         // the graph here so it is a validation input in its own right; a store supplied alongside
         // it is augmented rather than displaced, since both are just certificates to build from. A
         // generate run is exempt because the CBOR read above was built from this same folder.
-        if 0 == pass && !args.generate {
+        if 0 == pass && !args.generate && !graph_from_cache {
             if let Some(ca_folder) = &args.ca_folder {
                 let before = cert_source.len();
                 // Either a folder of intermediates or a single file naming one, matching the trust
@@ -950,8 +981,26 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
                 if let Err(e) = r {
                     error!("Failed to read certificates from {ca_folder}: {e:?}");
                 }
+                // As on the trust anchor side: a file that yielded nothing may be a CBOR
+                // certificate store, which is what this app's store export writes. Merge its
+                // certificates into the same source, so a run can draw on a selected store and an
+                // exported one at once — the `cbor` argument holds only one path.
+                let from_cbor_store = cert_source.len() == before && Path::new(ca_folder).is_file();
+                if from_cbor_store {
+                    if let Some(certs) = cbor_cert_store_certs(ca_folder) {
+                        for cf in certs {
+                            cert_source.push(cf);
+                        }
+                    }
+                }
                 ca_folder_certs = cert_source.len() - before;
-                info!("Read {ca_folder_certs} certificate(s) from {ca_folder}");
+                if from_cbor_store {
+                    info!(
+                        "Read {ca_folder_certs} certificate(s) from the CBOR store at {ca_folder}"
+                    );
+                } else {
+                    info!("Read {ca_folder_certs} certificate(s) from {ca_folder}");
+                }
             }
         }
 
@@ -1052,9 +1101,13 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
 
         // Certificates read from the CA folder arrive with no partial paths, and a path that spans
         // the folder and the store exists only once the two are searched together, so build the
-        // graph here rather than take the store's serialized paths as complete.
-        if 0 == pass && 0 < ca_folder_certs {
+        // graph here rather than take the store's serialized paths as complete. A graph off the
+        // cache already carries the result of this search, which is the point of caching it.
+        if 0 == pass && 0 < ca_folder_certs && !graph_from_cache {
             cert_source.find_all_partial_paths(&pe, &cps);
+            if let Some(fingerprint) = &graph_fingerprint {
+                graph_cache::store(fingerprint, &cert_source);
+            }
         }
 
         // If this is not the first pass, find all partial paths present in buffers_and_paths. If
@@ -1189,7 +1242,10 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
     // The one cause a zero-path run cannot read off its own environment: the folder was read and
     // filtered down to nothing, which leaves the graph as empty as no folder at all while the user
     // has every reason to believe they provided the intermediates.
-    let ca_folder_empty = args.ca_folder.is_some() && !args.generate && 0 == ca_folder_certs;
+    // A graph off the cache did not read the folder this run, and a graph is only cached once the
+    // folder has contributed to it, so a zero count here says nothing about the folder.
+    let ca_folder_empty =
+        args.ca_folder.is_some() && !args.generate && 0 == ca_folder_certs && !graph_from_cache;
     // Distinguishes "no folder was given" from "the folder was given and nothing survived reading
     // it", which the shared diagnosis cannot tell apart because both leave the environment empty
     let ta_folder_empty = args.ta_folder.is_some() && pe.get_trust_anchors().is_empty();

--- a/pittv3-lib/src/report.rs
+++ b/pittv3-lib/src/report.rs
@@ -15,10 +15,11 @@ use alloc::vec::Vec;
 use serde::{Deserialize, Serialize};
 
 use certval::{
-    get_certificate_from_trust_anchor, name_constraints_set_to_name_constraints_settings,
-    name_to_string, source::ta_source::buffer_to_hex, valid_at_time, CertificationPath,
-    CertificationPathResults, Error, NameConstraintsSet, NameConstraintsSettings, PDVCertificate,
-    PDVTrustAnchorChoice, PathValidationStatus, PkiEnvironment, TimeOfInterest,
+    get_certificate_from_trust_anchor, is_self_signed,
+    name_constraints_set_to_name_constraints_settings, name_to_string,
+    source::ta_source::buffer_to_hex, valid_at_time, CertificationPath, CertificationPathResults,
+    Error, NameConstraintsSet, NameConstraintsSettings, PDVCertificate, PDVTrustAnchorChoice,
+    PathValidationStatus, PkiEnvironment, TimeOfInterest,
 };
 
 /// Summary details for one certificate (or trust anchor) in a certification path.
@@ -299,6 +300,10 @@ pub struct NoPathsContext {
     /// Why the target is outside its validity period at the time of interest, when it is. Path
     /// building excludes such certificates, so this alone explains a zero-path outcome.
     pub target_invalid_at_toi: Option<String>,
+    /// Whether the target signed itself, in which case its issuer is itself and the only thing that
+    /// can anchor it is the trust store. Worth separating because the generic advice — find the
+    /// issuer certificate, fetch it if need be — is advice that cannot possibly work here.
+    pub target_self_signed: bool,
     /// Whether the frontend can chase AIA and SIA URIs to fetch missing issuers: `None` when it
     /// cannot (so suggesting it would be noise), `Some(false)` when it can but the run did not, and
     /// `Some(true)` when the run already did.
@@ -326,6 +331,7 @@ impl NoPathsContext {
             target_invalid_at_toi: valid_at_time(target.decoded().tbs_certificate(), toi, true)
                 .err()
                 .map(|e| format!("{e:?}")),
+            target_self_signed: is_self_signed(pe, target),
             dynamic_build,
         }
     }
@@ -357,7 +363,18 @@ impl NoPathsContext {
 
         // A missing issuer and a present-but-unusable issuer are different problems with different
         // remedies, and reporting a bare zero conflates them.
+        // A self-signed target is its own issuer, so the whole issuer-hunting line of explanation
+        // below is beside the point: there is no certificate to go and find, and no URI to find it
+        // at. Either it is an anchor of this run or it cannot be validated at all.
         let material_missing = if 0 == self.trust_anchors {
+            false
+        } else if self.target_self_signed && !self.issuer_is_trust_anchor {
+            hints.push(
+                "The target is self-signed, so it is its own issuer: nothing can vouch for it but \
+                 a trust anchor, and no loaded anchor matches it. Validate it by adding it to the \
+                 trust store, or select a store that carries it."
+                    .to_string(),
+            );
             false
         } else if self.issuer_is_trust_anchor {
             hints.push(format!(
@@ -862,6 +879,7 @@ mod tests {
             issuer_is_trust_anchor: false,
             issuer_certs: 0,
             target_invalid_at_toi: None,
+            target_self_signed: false,
             dynamic_build: Some(false),
         }
     }
@@ -924,6 +942,35 @@ mod tests {
         .hints();
         assert!(hints[0].contains("not valid at the time of interest"));
         assert!(hints[0].contains("InvalidNotAfterDate"));
+    }
+
+    /// A root validated as a target has itself for an issuer, so the issuer-hunting explanation is
+    /// advice that cannot work: there is no certificate to find and no URI to find it at. Real
+    /// case — `DoDRootCA4.der` against a store that does not carry it was told that none of the 37
+    /// loaded intermediates had its subject, and to switch on AIA chasing.
+    #[test]
+    fn a_self_signed_target_is_told_it_needs_an_anchor_not_an_issuer() {
+        let hints = NoPathsContext {
+            target_self_signed: true,
+            ..ctx()
+        }
+        .hints();
+
+        assert_eq!(hints.len(), 1, "{hints:?}");
+        assert!(hints[0].contains("self-signed"));
+        assert!(hints[0].contains("trust store"));
+        // the two things that would be wrong to say here
+        assert!(!hints[0].contains("intermediate CA certificates"));
+        assert!(hints.iter().all(|h| !h.contains("Chasing AIA and SIA")));
+
+        // an anchor that matches it is a different outcome, and keeps the existing explanation
+        let hints = NoPathsContext {
+            target_self_signed: true,
+            issuer_is_trust_anchor: true,
+            ..ctx()
+        }
+        .hints();
+        assert!(hints[0].contains("A trust anchor matches the target's issuer name"));
     }
 
     #[test]

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -29,6 +29,57 @@ use crate::{
 #[cfg(feature = "revocation")]
 use certval::check_revocation;
 
+/// Decodes a CBOR certificate store into the certificates it carries, as `(name, DER)` pairs.
+///
+/// The store is the serialized form of a [`CertSource`], so what comes back is what a run would
+/// build paths from — one entry per buffer, in store order, carrying whatever name the store
+/// recorded (often the file the certificate was generated from). Nothing here parses or validates:
+/// a caller wanting to write the certificates out should not have to reason about the material.
+///
+/// Lives here rather than in a frontend so every frontend can offer it. `pittv3-gui`'s store export
+/// is the first caller; the browser will want the same thing, and the CLI already exposes it as
+/// `--list-buffers` with a download folder.
+#[cfg(feature = "std")]
+pub fn cbor_store_to_ders(cbor: &[u8]) -> core::result::Result<Vec<(String, Vec<u8>)>, String> {
+    let cert_source = CertSource::new_from_cbor(cbor)
+        .map_err(|e| format!("failed to parse the CBOR certificate store: {e:?}"))?;
+    Ok(cert_source
+        .get_buffers()
+        .into_iter()
+        .map(|cf| (cf.filename, cf.bytes))
+        .collect())
+}
+
+/// Reads `path` as a CBOR trust anchor store and returns its anchors, or `None` when it is not one.
+///
+/// The trust anchor and CA inputs take certificates, and a store is not one — but the two are easy
+/// to confuse, and this app invites the confusion by exporting a store as `ta.cbor` and `ca.cbor`.
+/// Rather than refuse a file the tool itself wrote, the input reads it: anchors from a store named
+/// here are merged into the same [`TaSource`] as the rest, exactly as `ta_cbor` is, so nominating
+/// one is additive and a run can draw on a built-in store and an exported one at once. Called only
+/// once a file has failed to yield certificates, so nothing about the ordinary path changes.
+#[cfg(feature = "std")]
+pub fn cbor_ta_store_anchors(path: &str) -> Option<Vec<CertFile>> {
+    let bytes = get_file_as_byte_vec_pem(Path::new(path)).ok()?;
+    TaSource::new_from_cbor(&bytes)
+        .ok()
+        .map(|from_cbor| from_cbor.get_tas())
+}
+
+/// Reads `path` as a CBOR certificate store and returns the certificates it carries, or `None` when
+/// it is not one. The CA-side counterpart of [`cbor_ta_store_anchors`].
+///
+/// Only the certificates are taken, not the partial paths recorded alongside them: they are being
+/// merged into a graph that is about to be built over the combined material, and paths computed
+/// against the store alone would not describe it.
+#[cfg(feature = "std")]
+pub fn cbor_cert_store_certs(path: &str) -> Option<Vec<CertFile>> {
+    let bytes = get_file_as_byte_vec_pem(Path::new(path)).ok()?;
+    CertSource::new_from_cbor(&bytes)
+        .ok()
+        .map(|from_cbor| from_cbor.get_buffers())
+}
+
 /// Builds the trust anchor store named by the `ta_cbor` and `ta_folder` arguments, or `None` when
 /// neither was given.
 ///
@@ -83,7 +134,9 @@ pub fn load_trust_anchors(
         // Naming a file is not a lesser case: an anchor store assembled from several sources is
         // reached by naming them, and the alternative is asking the user to build a directory
         // around one certificate.
-        let r = if Path::new(ta_folder).is_file() {
+        let named_file = Path::new(ta_folder).is_file();
+        let before = ta_store.len();
+        let r = if named_file {
             ta_file_to_vec(pe, ta_folder, &mut ta_store, time_of_interest)
         } else {
             ta_folder_to_vec(pe, ta_folder, &mut ta_store, time_of_interest)
@@ -92,6 +145,21 @@ pub fn load_trust_anchors(
             return Err(format!(
                 "failed to load trust anchors from {ta_folder} with error {e:?}"
             ));
+        }
+
+        // A file that yielded no anchor may be a CBOR trust anchor store rather than certificate
+        // material — the shape this app's own store export writes. Read it as one and merge it in,
+        // which is what `ta_cbor` does with the same bytes.
+        if named_file && ta_store.len() == before {
+            if let Some(anchors) = cbor_ta_store_anchors(ta_folder) {
+                for cf in anchors {
+                    ta_store.push(cf);
+                }
+                info!(
+                    "Read {} trust anchor(s) from the CBOR store at {ta_folder}",
+                    ta_store.len() - before
+                );
+            }
         }
     }
 
@@ -603,15 +671,17 @@ pub async fn generate(
 
     let no_anchors = args.ta_cbor.is_none() && args.ta_folder.is_none();
 
+    // Reported through the log rather than stdout: a GUI captures the log and never sees a
+    // println, so a run that stopped here looked to a user like a run that did nothing at all.
     #[cfg(feature = "webpki")]
     if args.cbor.is_none() || (no_anchors && !args.webpki_tas) || args.ca_folder.is_none() {
-        println!("ERROR: The cbor and ca-folder options are required when generate is specified plus one of ta-cbor, ta-folder or webpki-tas");
+        error!("The cbor and ca-folder options are required when generate is specified plus one of ta-cbor, ta-folder or webpki-tas");
         return;
     }
 
     #[cfg(not(feature = "webpki"))]
     if args.cbor.is_none() || no_anchors || args.ca_folder.is_none() {
-        println!("ERROR: The cbor and ca-folder options are required when generate is specified plus either ta-cbor or ta-folder");
+        error!("The cbor and ca-folder options are required when generate is specified plus either ta-cbor or ta-folder");
         return;
     }
 
@@ -627,14 +697,21 @@ pub async fn generate(
     cps.set_cbor_ta_store(args.cbor_ta_store);
 
     let graph = build_graph(pe, cps).await;
-    if let Ok(graph) = graph {
-        if let Some(cbor) = args.cbor.as_ref() {
-            fs::write(cbor, graph.as_slice()).expect("Unable to write generated CBOR file");
+    match graph {
+        Ok(graph) => {
+            if let Some(cbor) = args.cbor.as_ref() {
+                // Not expect(): an unwritable path is a typo, not a bug, and panicking here took
+                // the run's worker thread with it. Naming the file it wrote also answers "where
+                // did the store go", which the argument alone does not.
+                match fs::write(cbor, graph.as_slice()) {
+                    Ok(()) => info!("Wrote the generated store to {cbor}"),
+                    Err(e) => error!("Failed to write the generated store to {cbor}: {e}"),
+                }
+            }
         }
-    } else {
-        println!("Failed: {graph:?}");
+        Err(e) => error!("Failed to generate the store: {e:?}"),
     }
-    println!("Generation took {:?}", Instant::now() - start);
+    info!("Generation took {:?}", Instant::now() - start);
 }
 
 /// `cleanup_certs` attempts to remove files that cannot be used from the indicated `certs_folder`

--- a/pittv3-lib/tests/generate_inputs.rs
+++ b/pittv3-lib/tests/generate_inputs.rs
@@ -1,0 +1,193 @@
+//! Integration tests for the inputs a generate run accepts.
+//!
+//! Validation learned to take a single file wherever it takes a folder, but generation did not:
+//! `build_graph` handed the CA input straight to the folder-walking functions, which return
+//! `NotFound` for anything that is not a directory. So a store could be validated against with a
+//! file for its CA input but not built from one, and the argument's own help text promised
+//! otherwise. These tests pin both halves of the fix — a CA store and a trust anchor store, each
+//! built from a named file — and then use what was built, since a store that cannot be validated
+//! against has not really been generated.
+#![cfg(feature = "std")]
+
+use std::fs;
+use std::path::Path;
+
+use certval::*;
+use pittv3_lib::args::Pittv3Args;
+use pittv3_lib::options_std::options_std;
+use pittv3_lib::report::{TargetStatus, ValidationReport};
+
+/// A time at which the PKITS fixtures are valid
+const TOI: u64 = 1648039783;
+
+const FLAVOR: &str = "../certval/tests/examples/PKITS_data_p256/certs";
+
+fn example(name: &str) -> String {
+    Path::new(FLAVOR).join(name).to_str().unwrap().to_string()
+}
+
+/// Writes the settings file a run reads, holding the time of interest and turning revocation
+/// checking off: these tests are about which certificates reach the graph, and the PKITS fixtures
+/// carry no revocation material to answer with.
+fn settings_file(dir: &Path) -> String {
+    let mut cps = CertificationPathSettings::new();
+    cps.set_time_of_interest(TimeOfInterest::from_unix_secs(TOI).unwrap());
+    cps.set_check_revocation_status(false);
+    let path = dir.join("settings.json");
+    fs::write(&path, serde_json::to_string(&cps).unwrap()).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+fn run(args: Pittv3Args) -> ValidationReport {
+    tokio_test::block_on(options_std(&args))
+}
+
+/// Generates a store at `cbor` from `ca_input`, which may name a file or a folder. `ta_store` picks
+/// which kind: a trust anchor store or the usual store of intermediates and partial paths.
+fn generate(dir: &Path, ca_input: &str, cbor: &Path, ta_store: bool) {
+    run(Pittv3Args {
+        ta_folder: Some(example("TrustAnchorRootCertificate.crt")),
+        ca_folder: Some(ca_input.to_string()),
+        cbor: Some(cbor.to_str().unwrap().to_string()),
+        generate: true,
+        cbor_ta_store: ta_store,
+        settings: Some(settings_file(dir)),
+        time_of_interest: TOI,
+        ..Default::default()
+    });
+}
+
+/// Validates the PKITS test 1 end entity certificate with whatever trust anchor and CA material the
+/// caller supplies, so a generated store can be exercised the way a user would use it.
+fn validate(
+    dir: &Path,
+    ta_folder: Option<String>,
+    ta_cbor: Option<String>,
+    ca_folder: Option<String>,
+    cbor: Option<String>,
+) -> ValidationReport {
+    run(Pittv3Args {
+        ta_folder,
+        ta_cbor,
+        ca_folder,
+        cbor,
+        end_entity_file: Some(example("ValidCertificatePathTest1EE.crt")),
+        settings: Some(settings_file(dir)),
+        time_of_interest: TOI,
+        ..Default::default()
+    })
+}
+
+/// A CA store built from one named certificate, then validated against. The generate step used to
+/// fail here for want of a directory, leaving an empty CBOR file behind and no path to be found.
+#[test]
+fn generates_a_ca_store_from_a_single_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let cbor = dir.path().join("ca.cbor");
+
+    generate(dir.path(), &example("GoodCACert.crt"), &cbor, false);
+
+    assert!(cbor.is_file());
+    let report = validate(
+        dir.path(),
+        Some(example("TrustAnchorRootCertificate.crt")),
+        None,
+        None,
+        Some(cbor.to_str().unwrap().to_string()),
+    );
+
+    assert_eq!(None, report.error);
+    assert_eq!(1, report.totals.valid_paths);
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+    // The path is trust anchor, intermediate, target
+    assert_eq!(3, report.targets[0].paths[0].certs.len());
+}
+
+/// A trust anchor store built from one named anchor, then used as the anchors for a run. Note the
+/// anchors come from the CA input rather than the trust anchor input when `cbor_ta_store` is set —
+/// that is the flag's contract, and it is the reason this file is worth having.
+#[test]
+fn generates_a_ta_store_from_a_single_file() {
+    let dir = tempfile::tempdir().unwrap();
+    let cbor = dir.path().join("ta.cbor");
+
+    generate(
+        dir.path(),
+        &example("TrustAnchorRootCertificate.crt"),
+        &cbor,
+        true,
+    );
+
+    assert!(cbor.is_file());
+    let report = validate(
+        dir.path(),
+        None,
+        Some(cbor.to_str().unwrap().to_string()),
+        Some(example("GoodCACert.crt")),
+        None,
+    );
+
+    assert_eq!(None, report.error);
+    assert_eq!(1, report.totals.valid_paths);
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+}
+
+/// A CBOR store named in the trust anchor or CA input is read as one rather than skipped.
+///
+/// The app exports a store as `ta.cbor` and `ca.cbor`, and the obvious place to then put them is
+/// the TA and CA inputs — which read certificates, so both files were silently ignored and the run
+/// found nothing with no explanation. Both rows now merge a store's contents into the same source
+/// the rest of the material goes into, which is also the only way to add a second store to a run:
+/// the `ta_cbor` and `cbor` arguments hold one path each.
+#[test]
+fn ta_and_ca_inputs_accept_a_cbor_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let ta_cbor = dir.path().join("ta.cbor");
+    let ca_cbor = dir.path().join("ca.cbor");
+
+    generate(
+        dir.path(),
+        &example("TrustAnchorRootCertificate.crt"),
+        &ta_cbor,
+        true,
+    );
+    generate(dir.path(), &example("GoodCACert.crt"), &ca_cbor, false);
+
+    // Both stores handed to the certificate inputs, not to the CBOR arguments
+    let report = validate(
+        dir.path(),
+        Some(ta_cbor.to_str().unwrap().to_string()),
+        None,
+        Some(ca_cbor.to_str().unwrap().to_string()),
+        None,
+    );
+
+    assert_eq!(None, report.error);
+    assert_eq!(1, report.totals.valid_paths);
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+    assert_eq!(3, report.targets[0].paths[0].certs.len());
+}
+
+/// A folder is still read as a folder, so the dispatch has not traded one input shape for the
+/// other.
+#[test]
+fn generates_a_ca_store_from_a_folder() {
+    let dir = tempfile::tempdir().unwrap();
+    let ca_folder = dir.path().join("ca");
+    fs::create_dir_all(&ca_folder).unwrap();
+    fs::copy(example("GoodCACert.crt"), ca_folder.join("GoodCACert.crt")).unwrap();
+    let cbor = dir.path().join("ca.cbor");
+
+    generate(dir.path(), ca_folder.to_str().unwrap(), &cbor, false);
+
+    assert!(cbor.is_file());
+    let report = validate(
+        dir.path(),
+        Some(example("TrustAnchorRootCertificate.crt")),
+        None,
+        None,
+        Some(cbor.to_str().unwrap().to_string()),
+    );
+
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+}

--- a/pittv3-lib/tests/graph_cache.rs
+++ b/pittv3-lib/tests/graph_cache.rs
@@ -1,0 +1,186 @@
+//! Integration tests for the cached partial-path graph.
+//!
+//! A run that augments its trust material searches the combined set for partial paths, which is the
+//! expensive half of preparing a run. The result is cached and reused when nothing it was built
+//! from has changed. What has to hold is that reuse is invisible in the answer.
+//!
+//! **Its own test binary on purpose.** The cache folder is chosen by an environment variable, and
+//! environment variables belong to the process rather than to a test, so a test that sets one while
+//! sibling tests run in parallel is measuring their writes as well as its own. That is exactly what
+//! happened when this lived alongside the CA-folder tests: four graphs in a folder that should have
+//! held one.
+#![cfg(feature = "std")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use certval::*;
+use pittv3_lib::args::Pittv3Args;
+use pittv3_lib::graph_cache;
+use pittv3_lib::options_std::options_std;
+use pittv3_lib::report::{TargetStatus, ValidationReport};
+
+/// Serializes the tests in this file. They each point the cache at their own folder, but they do it
+/// through an environment variable, and those belong to the process: two tests running at once
+/// would share whichever folder was set last. Held for the whole of a test body, poison ignored so
+/// one failure reports itself rather than being masked by the other test failing to acquire.
+static CACHE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// A time at which the PKITS fixtures are valid
+const TOI: u64 = 1648039783;
+
+const FLAVOR: &str = "../certval/tests/examples/PKITS_data_p256/certs";
+
+fn example(name: &str) -> PathBuf {
+    Path::new(FLAVOR).join(name)
+}
+
+fn folder_with(dir: &Path, names: &[&str]) -> String {
+    fs::create_dir_all(dir).unwrap();
+    for name in names {
+        fs::copy(example(name), dir.join(name)).unwrap();
+    }
+    dir.to_str().unwrap().to_string()
+}
+
+fn settings_file(dir: &Path) -> String {
+    let mut cps = CertificationPathSettings::new();
+    cps.set_time_of_interest(TimeOfInterest::from_unix_secs(TOI).unwrap());
+    cps.set_check_revocation_status(false);
+    let path = dir.join("settings.json");
+    fs::write(&path, serde_json::to_string(&cps).unwrap()).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+fn validate(dir: &Path, ta_folder: Option<String>, ca_folder: Option<String>) -> ValidationReport {
+    let args = args_for(dir, ta_folder, ca_folder);
+    tokio_test::block_on(options_std(&args))
+}
+
+/// The arguments a run uses, so a test can ask what a caller outside the run would compute for them.
+fn args_for(dir: &Path, ta_folder: Option<String>, ca_folder: Option<String>) -> Pittv3Args {
+    Pittv3Args {
+        ta_folder,
+        ca_folder,
+        end_entity_file: Some(
+            example("ValidCertificatePathTest1EE.crt")
+                .to_str()
+                .unwrap()
+                .to_string(),
+        ),
+        settings: Some(settings_file(dir)),
+        time_of_interest: TOI,
+        ..Default::default()
+    }
+}
+
+/// The cached graphs, not counting the anchor file written beside each one.
+fn cached_graphs(cache: &Path) -> Vec<PathBuf> {
+    fs::read_dir(cache)
+        .map(|entries| {
+            entries
+                .map(|e| e.unwrap().path())
+                .filter(|p| !p.to_string_lossy().ends_with(".ta.cbor"))
+                .collect()
+        })
+        .unwrap_or_default()
+}
+
+/// A caller outside a run has to arrive at the same key the run filed the graph under, or it can
+/// never find it. The desktop's Export Graph is that caller, and it found nothing every time:
+/// `options_std` adjusts the settings for the run — AIA/SIA retrieval off, anchor validity off for
+/// webpki anchors — and the whole settings blob goes into the key, so a key taken after those
+/// adjustments cannot be reproduced from the arguments alone. The run now keys off the settings as
+/// read, before it touches them.
+#[test]
+fn a_caller_outside_the_run_computes_the_same_key() {
+    let _guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    // SAFETY: this test binary is single-threaded by construction; see the module comment.
+    unsafe { std::env::set_var("PITTV3_GRAPH_CACHE", &cache) };
+
+    let ta_folder = folder_with(&dir.path().join("ta"), &["TrustAnchorRootCertificate.crt"]);
+    let ca_folder = folder_with(&dir.path().join("ca"), &["GoodCACert.crt"]);
+    let args = args_for(dir.path(), Some(ta_folder), Some(ca_folder));
+
+    let report = tokio_test::block_on(options_std(&args));
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+
+    let fingerprint =
+        graph_cache::fingerprint_for_args(&args).expect("these inputs do build a graph");
+    assert!(
+        graph_cache::cached(&fingerprint).is_some(),
+        "the run's graph is not filed under the key an outside caller computes"
+    );
+
+    // The anchors are cached beside the graph, because they are not in it: partial paths end at
+    // them, but they live in a TaSource the CertSource never sees. An export of the graph alone
+    // would describe paths to certificates it does not carry.
+    let anchors = graph_cache::cached_anchors(&fingerprint).expect("the anchors were not cached");
+    let ta = TaSource::new_from_cbor(&anchors).expect("the cached anchors do not load");
+    assert!(!ta.is_empty(), "the cached anchor store is empty");
+
+    // And the graph really does lack them, which is the reason both halves are written
+    let graph = CertSource::new_from_cbor(&graph_cache::cached(&fingerprint).unwrap()).unwrap();
+    assert!(
+        !graph
+            .get_buffers()
+            .iter()
+            .any(|cf| ta.get_tas().iter().any(|anchor| anchor.bytes == cf.bytes)),
+        "an anchor turned up in the graph; the two halves are supposed to be disjoint"
+    );
+
+    unsafe { std::env::remove_var("PITTV3_GRAPH_CACHE") };
+}
+
+#[test]
+fn the_augmented_graph_is_cached_reused_and_rekeyed() {
+    let _guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    // SAFETY: the lock above serializes the tests that touch this variable; see CACHE_ENV_LOCK.
+    unsafe { std::env::set_var("PITTV3_GRAPH_CACHE", &cache) };
+
+    let ta_folder = folder_with(&dir.path().join("ta"), &["TrustAnchorRootCertificate.crt"]);
+    let ca_folder = folder_with(&dir.path().join("ca"), &["GoodCACert.crt"]);
+
+    let first = validate(dir.path(), Some(ta_folder.clone()), Some(ca_folder.clone()));
+    assert_eq!(TargetStatus::Valid, first.targets[0].status);
+    assert_eq!(
+        1,
+        cached_graphs(&cache).len(),
+        "the run's graph should have been cached"
+    );
+
+    // Same inputs: served from the cache, and the answer is the one built the long way
+    let second = validate(dir.path(), Some(ta_folder.clone()), Some(ca_folder));
+    assert_eq!(first.targets[0].status, second.targets[0].status);
+    assert_eq!(first.totals.paths_found, second.totals.paths_found);
+    assert_eq!(first.totals.valid_paths, second.totals.valid_paths);
+    assert_eq!(
+        first.targets[0].paths[0].certs.len(),
+        second.targets[0].paths[0].certs.len()
+    );
+    assert_eq!(
+        1,
+        cached_graphs(&cache).len(),
+        "a hit should not write a second copy"
+    );
+
+    // Different CA material is a different graph, and must not be answered with the first one
+    let bigger = folder_with(
+        &dir.path().join("ca2"),
+        &["GoodCACert.crt", "BasicSelfIssuedNewKeyCACert.crt"],
+    );
+    let third = validate(dir.path(), Some(ta_folder), Some(bigger));
+    assert_eq!(TargetStatus::Valid, third.targets[0].status);
+    assert_eq!(
+        2,
+        cached_graphs(&cache).len(),
+        "a changed input set has to key differently"
+    );
+
+    unsafe { std::env::remove_var("PITTV3_GRAPH_CACHE") };
+}

--- a/pittv3/src/cliargs.rs
+++ b/pittv3/src/cliargs.rs
@@ -138,10 +138,13 @@ pub struct Pittv3CliArgs {
     #[clap(long, short, help_heading = "VALIDATION")]
     pub settings: Option<String>,
 
-    /// Full path of folder containing binary, DER-encoded intermediate CA certificates. Required
-    /// when generate action is performed. This is not used when path validation is performed other
-    /// than as a place to store downloaded files when dynamic building is used and download_folder
-    /// is not specified.
+    /// Full path of a folder containing DER- or PEM-encoded CRLs, traversed recursively and indexed
+    /// before path validation begins. Only files with a .crl extension are processed. The indexed
+    /// CRLs are the local revocation source, consulted before any remote retrieval, and the folder
+    /// also receives CRLs fetched remotely along with the last-modified map that makes those
+    /// fetches conditional. Note that the folder is written as well as read: indexing deletes any
+    /// CRL that is not valid at the time of interest, i.e. one whose thisUpdate is in the future or
+    /// whose nextUpdate has passed.
     #[cfg(feature = "std")]
     #[clap(long, help_heading = "VALIDATION")]
     pub crl_folder: Option<String>,

--- a/pittv3/src/cliargs.rs
+++ b/pittv3/src/cliargs.rs
@@ -54,8 +54,9 @@ pub struct Pittv3CliArgs {
     pub error_folder: Option<String>,
 
     /// Full path and filename of folder to receive downloaded binary DER-encoded certificates, if
-    /// absent at generate time, the ca_folder is used. Additionally, this is used to designate where
-    /// exported buffers are written by dump_cert_at_index or list_buffers.
+    /// absent at generate time, the ca_folder is used, which requires it to name a folder rather
+    /// than a single file. Additionally, this is used to designate where exported buffers are
+    /// written by dump_cert_at_index or list_buffers.
     #[cfg(feature = "std")]
     #[clap(long, short, help_heading = "COMMON OPTIONS")]
     pub download_folder: Option<String>,
@@ -84,7 +85,8 @@ pub struct Pittv3CliArgs {
     pub chase_aia_and_sia: bool,
 
     /// Flag that indicates generated CBOR file will contain only trust anchors  (so no need for
-    /// partial paths and no need to exclude self-signed certificates).
+    /// partial paths and no need to exclude self-signed certificates). The anchors are read from
+    /// the ca_folder input, which may name a single file, and the result is the form ta_cbor takes.
     #[cfg(feature = "std")]
     #[clap(long, help_heading = "GENERATION")]
     pub cbor_ta_store: bool,


### PR DESCRIPTION
- fix copy and paste error re: CRL folder docs
- accept TAs and CAs as referenced to folders or single files
- Improve blurb shown under selected Trust Store and add an export button to allow serialization of the selected store
- Add an Export PKI Environment button to allow saving an augmented graph to a pair of ta.cbor and ca.cbor files for sharing or later use
- Reorg the form and menu
- Refactor WebPKI TAs checkbox into an item in the drop list
- Cache augmented graphs to the .pittv3 folder