### PR TITLE
preparatory work for adding revocation support to pittv3-wasm

### DIFF
--- a/certval/src/revocation.rs
+++ b/certval/src/revocation.rs
@@ -77,5 +77,10 @@ pub use crate::revocation::subject_name_and_key::*;
 #[cfg(feature = "revocation")]
 pub use crate::crl::*;
 
-#[cfg(feature = "remote")]
+// Gated on `revocation`, which is what gates the module itself, rather than on `remote`. The
+// OCSP code divides into processing a response and going to fetch one, and only the second needs
+// `remote` — `send_ocsp_request` carries that gate itself. Re-exporting the whole module behind
+// `remote` hid the first from every build that cannot fetch, which is exactly the build that has to
+// be handed a response by its caller.
+#[cfg(feature = "revocation")]
 pub use crate::ocsp_client::*;

--- a/certval/src/revocation/crl.rs
+++ b/certval/src/revocation/crl.rs
@@ -44,11 +44,12 @@ use crate::{
 
 use core::time::Duration;
 
+// The collector itself is ungated, but the only caller here is the remote CRL fetcher.
 #[cfg(feature = "remote")]
-use log::debug;
+use crate::collect_crl_dp_uris;
 
 #[cfg(feature = "remote")]
-use der::asn1::Ia5String;
+use log::debug;
 
 #[cfg(feature = "remote")]
 use alloc::vec;
@@ -369,28 +370,6 @@ pub struct CrlInfo {
 //7)	For each CRL, review revocation notifications
 //		a.	Check certificate status
 //			i.	If certificate is found on a CRL, process any CRL entry extensions
-
-/// get_crl_dps returns a list of URIs read from the CRL DP extension, if any.
-#[cfg(feature = "remote")]
-fn get_crl_dps(target_cert: &PDVCertificate) -> Vec<&Ia5String> {
-    let mut retval = vec![];
-    if let Ok(Some(PDVExtension::CrlDistributionPoints(crl_dps))) =
-        target_cert.get_extension(&ID_CE_CRL_DISTRIBUTION_POINTS)
-    {
-        for crl_dp in &crl_dps.0 {
-            if let Some(DistributionPointName::FullName(gns)) = &crl_dp.distribution_point {
-                for gn in gns {
-                    if let GeneralName::UniformResourceIdentifier(uri) = &gn {
-                        if !retval.contains(&uri) {
-                            retval.push(uri);
-                        }
-                    }
-                }
-            }
-        }
-    }
-    retval
-}
 
 /// fetch_crl takes a string that notionally contains a URI that may be used to retrieve a CRL.
 #[cfg(feature = "remote")]
@@ -1295,7 +1274,8 @@ pub(crate) async fn check_revocation_crl_remote(
 ) -> PathValidationStatus {
     let mut target_status = PathValidationStatus::RevocationStatusNotDetermined;
     let cur_cert_subject = name_to_string(target_cert.decoded().tbs_certificate().subject());
-    let crl_dps = get_crl_dps(target_cert);
+    let mut crl_dps = vec![];
+    collect_crl_dp_uris(target_cert, &mut crl_dps);
     if crl_dps.is_empty() {
         info!(
             "No CRL DPs found for {}",

--- a/certval/src/revocation/ocsp_client.rs
+++ b/certval/src/revocation/ocsp_client.rs
@@ -21,10 +21,8 @@ use crate::{
     PathValidationStatus, PkiEnvironment, Result,
 };
 
-#[cfg(feature = "remote")]
 use alloc::vec;
 
-#[cfg(feature = "remote")]
 use der::asn1::OctetString;
 
 #[cfg(feature = "remote")]
@@ -43,20 +41,17 @@ use const_oid::db::rfc5912::{ID_CE_EXT_KEY_USAGE, ID_KP_OCSP_SIGNING};
 #[cfg(feature = "revocation")]
 use const_oid::db::rfc6960::{ID_PKIX_OCSP_BASIC, ID_PKIX_OCSP_NOCHECK, ID_PKIX_OCSP_NONCE};
 
-#[cfg(feature = "remote")]
 use spki::AlgorithmIdentifier;
 use x509_cert::serial_number::SerialNumber;
 
-#[cfg(feature = "remote")]
 use x509_ocsp::Version::V1;
 
+use crate::PKIXALG_SHA1;
 #[cfg(feature = "remote")]
-use crate::{collect_ocsp_uris, name_to_string, PKIXALG_SHA1};
+use crate::{collect_ocsp_uris, name_to_string};
 
-#[cfg(feature = "remote")]
 use x509_cert::ext::Extension;
 
-#[cfg(feature = "remote")]
 use x509_ocsp::ext::Nonce;
 
 fn get_key_hash(issuer: &dyn SubjectNameAndKey) -> Result<Vec<u8>> {
@@ -233,7 +228,35 @@ async fn post_ocsp(uri_to_check: &str, enc_ocsp_req: &[u8], max_bytes: u64) -> R
     crate::builder::uri_utils::read_capped_body(body, max_bytes, uri_to_check).await
 }
 
-#[cfg(feature = "remote")]
+/// Builds the DER-encoded OCSP request that asks `issuer`'s responder about `target_cert`.
+///
+/// This is the request half of OCSP with the retrieval left out, for a caller that has its own way
+/// to reach a responder — a browser going through a relay, say, or anything else built without
+/// `remote`, where certval cannot open a socket of its own. Send the result to a responder as
+/// `application/ocsp-request` and hand what comes back to
+/// [`process_ocsp_response`], or put it in the path's `ocsp_responses` slot for
+/// `check_revocation` to find.
+///
+/// `issuer` is the subject that issued `target_cert` — the preceding certificate in the path, or
+/// the trust anchor for the first certificate. It is not merely a formality: an OCSP `CertID`
+/// identifies a certificate by the hash of its *issuer's* name and public key together with its
+/// serial number, so a request built against the wrong issuer asks about a different certificate
+/// and a responder will answer `unknown` at best.
+///
+/// A `nonce` is carried as a non-critical `id-pkix-ocsp-nonce` request extension when supplied.
+/// Note that [`process_ocsp_response`] does not check a nonce on a response handed to it, since
+/// such a response was not solicited by this library; a caller that solicited one and wants the
+/// guarantee has to compare it itself.
+pub fn build_ocsp_request(
+    target_cert: &CertificateInner<Raw>,
+    issuer: &dyn SubjectNameAndKey,
+    nonce: Option<&[u8]>,
+) -> Result<Vec<u8>> {
+    let name_hash = get_subject_name_hash(issuer)?;
+    let key_hash = get_key_hash(issuer)?;
+    prepare_ocsp_request(target_cert, &name_hash, &key_hash, nonce)
+}
+
 fn prepare_ocsp_request(
     target_cert: &CertificateInner<Raw>,
     name_hash: &[u8],

--- a/certval/src/revocation/ocsp_client.rs
+++ b/certval/src/revocation/ocsp_client.rs
@@ -25,7 +25,7 @@ use crate::{
 use alloc::vec;
 
 #[cfg(feature = "remote")]
-use der::asn1::{Ia5String, OctetString};
+use der::asn1::OctetString;
 
 #[cfg(feature = "remote")]
 use reqwest::header::CONTENT_TYPE;
@@ -33,18 +33,12 @@ use reqwest::header::CONTENT_TYPE;
 #[cfg(feature = "remote")]
 use core::time::Duration;
 
-#[cfg(feature = "remote")]
-use x509_cert::ext::pkix::name::GeneralName;
 #[cfg(feature = "revocation")]
 use x509_cert::ext::pkix::ExtendedKeyUsage;
 
 // Needed by the (stapling-capable) responder EKU check, so gated on `revocation`, not `remote`.
 #[cfg(feature = "revocation")]
 use const_oid::db::rfc5912::{ID_CE_EXT_KEY_USAGE, ID_KP_OCSP_SIGNING};
-
-// Used only when fetching an OCSP responder URL from AIA (network), so `remote`-only.
-#[cfg(feature = "remote")]
-use const_oid::db::rfc5912::{ID_AD_OCSP, ID_PE_AUTHORITY_INFO_ACCESS};
 
 #[cfg(feature = "revocation")]
 use const_oid::db::rfc6960::{ID_PKIX_OCSP_BASIC, ID_PKIX_OCSP_NOCHECK, ID_PKIX_OCSP_NONCE};
@@ -57,7 +51,7 @@ use x509_cert::serial_number::SerialNumber;
 use x509_ocsp::Version::V1;
 
 #[cfg(feature = "remote")]
-use crate::{name_to_string, pdv_extension::ExtensionProcessing, PDVExtension, PKIXALG_SHA1};
+use crate::{collect_ocsp_uris, name_to_string, PKIXALG_SHA1};
 
 #[cfg(feature = "remote")]
 use x509_cert::ext::Extension;
@@ -861,25 +855,6 @@ fn process_ocsp_response_internal(
 }
 
 #[cfg(feature = "remote")]
-fn get_ocsp_aias(target_cert: &PDVCertificate) -> Vec<&Ia5String> {
-    let mut retval = vec![];
-    if let Ok(Some(PDVExtension::AuthorityInfoAccessSyntax(aias))) =
-        target_cert.get_extension(&ID_PE_AUTHORITY_INFO_ACCESS)
-    {
-        for aia in &aias.0 {
-            if aia.access_method == ID_AD_OCSP {
-                if let GeneralName::UniformResourceIdentifier(aia) = &aia.access_location {
-                    if !retval.contains(&aia) {
-                        retval.push(aia);
-                    }
-                }
-            }
-        }
-    }
-    retval
-}
-
-#[cfg(feature = "remote")]
 pub(crate) async fn check_revocation_ocsp(
     pe: &PkiEnvironment,
     cps: &CertificationPathSettings,
@@ -889,7 +864,8 @@ pub(crate) async fn check_revocation_ocsp(
     pos: usize,
 ) -> PathValidationStatus {
     let mut target_status = PathValidationStatus::RevocationStatusNotDetermined;
-    let ocsp_aias = get_ocsp_aias(target_cert);
+    let mut ocsp_aias = vec![];
+    collect_ocsp_uris(target_cert, &mut ocsp_aias);
     if ocsp_aias.is_empty() {
         info!(
             "No OCSP AIAs found for {}",
@@ -1108,6 +1084,13 @@ pub(crate) async fn check_revocation_ocsp(
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    // The offline replay tests below parse a target's extensions before checking its status. The
+    // non-test code no longer needs this trait -- reading OCSP URIs out of AIA moved to
+    // `collect_ocsp_uris` in pdv_utilities -- so it is imported here rather than at module scope,
+    // where it would be unused in every build that is not running these tests.
+    #[cfg(all(feature = "std", feature = "rsa"))]
+    use crate::ExtensionProcessing;
 
     // ------------------------------------------------------------------------------------------
     // Nonce policy (nonce_acceptable) - fully deterministic, no network.

--- a/certval/src/util/pdv_utilities.rs
+++ b/certval/src/util/pdv_utilities.rs
@@ -20,7 +20,7 @@ use x509_cert::ext::pkix::{
         name::{GeneralSubtree, GeneralSubtrees},
         BasicConstraints, PolicyConstraints,
     },
-    name::GeneralName,
+    name::{DistributionPointName, GeneralName},
     InhibitAnyPolicy,
 };
 use x509_cert::name::Name;
@@ -99,6 +99,64 @@ pub fn collect_uris_from_aia_and_sia(cert: &PDVCertificate, uris: &mut Vec<Strin
                     let s = uri.to_string();
                     if !uris.contains(&s) && s.starts_with("http") {
                         uris.push(uri.to_string());
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `collect_crl_dp_uris` collects unique URIs from the full names of the CRL distribution points
+/// extension of the presented certificate and returns them via the `uris` parameter.
+///
+/// Unlike [`collect_uris_from_aia_and_sia`], no scheme filtering is applied. CRL DPs routinely name
+/// `ldap://` locations, and what a caller can reach is the caller's business: a client with an LDAP
+/// implementation, or a relay fetching on a browser's behalf, can use one where a direct HTTP
+/// fetcher cannot. certval's own CRL retrieval filters for itself, rejecting anything but HTTP with
+/// [`Error::InvalidUriScheme`], which also keeps the URIs it declined visible in the log rather
+/// than silently absent.
+///
+/// This is deliberately available in every build, revocation feature or not, for the same reason
+/// [`collect_uris_from_aia_and_sia`] is: reading a URI out of an extension is parsing, not
+/// fetching, and the callers that need it most are the ones that cannot fetch for themselves.
+pub fn collect_crl_dp_uris(cert: &PDVCertificate, uris: &mut Vec<String>) {
+    if let Ok(Some(PDVExtension::CrlDistributionPoints(crl_dps))) =
+        cert.get_extension(&ID_CE_CRL_DISTRIBUTION_POINTS)
+    {
+        for crl_dp in &crl_dps.0 {
+            if let Some(DistributionPointName::FullName(gns)) = &crl_dp.distribution_point {
+                for gn in gns {
+                    if let GeneralName::UniformResourceIdentifier(uri) = gn {
+                        let s = uri.to_string();
+                        if !uris.contains(&s) {
+                            uris.push(s);
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+/// `collect_ocsp_uris` collects unique URIs from the `id-ad-ocsp` access descriptions of the
+/// presented certificate's authority information access extension and returns them via the `uris`
+/// parameter.
+///
+/// Scheme filtering and build availability are as described for [`collect_crl_dp_uris`].
+///
+/// Note that an OCSP URI alone is not enough to retrieve a response: unlike a CRL, which is a plain
+/// GET, an OCSP request must be constructed for the specific certificate and posted. A caller
+/// driving its own retrieval needs both this and a means of building that request.
+pub fn collect_ocsp_uris(cert: &PDVCertificate, uris: &mut Vec<String>) {
+    if let Ok(Some(PDVExtension::AuthorityInfoAccessSyntax(aias))) =
+        cert.get_extension(&ID_PE_AUTHORITY_INFO_ACCESS)
+    {
+        for aia in &aias.0 {
+            if ID_AD_OCSP == aia.access_method {
+                if let GeneralName::UniformResourceIdentifier(uri) = &aia.access_location {
+                    let s = uri.to_string();
+                    if !uris.contains(&s) {
+                        uris.push(s);
                     }
                 }
             }
@@ -1399,4 +1457,43 @@ fn ta_validity_distinguishes_absent_from_failed() {
     let no_validity = TrustAnchorChoice::<Raw>::from_der(&bytes).unwrap();
     assert_eq!(Ok(None), ta_valid_at_time(&no_validity, toi, true));
     assert_eq!(Ok(None), ta_valid_at_time(&no_validity, expired, true));
+}
+
+/// The revocation URI collectors read the two extensions a caller needs to retrieve revocation data
+/// for itself. Both accumulate into a caller-supplied vector and skip duplicates, so a caller can
+/// sweep a whole certification path into one list without post-processing.
+#[test]
+fn revocation_uris_collected() {
+    let der = include_bytes!("../../tests/examples/ocsp_dod/47.der");
+    let cert = parse_cert(der, "47.der").unwrap();
+
+    let mut crl_dps = alloc::vec![];
+    collect_crl_dp_uris(&cert, &mut crl_dps);
+    assert_eq!(
+        crl_dps,
+        alloc::vec![String::from("http://crl.disa.mil/crl/DODEMAILCA_63.crl")]
+    );
+
+    let mut ocsp = alloc::vec![];
+    collect_ocsp_uris(&cert, &mut ocsp);
+    assert_eq!(ocsp, alloc::vec![String::from("http://ocsp.disa.mil")]);
+
+    // Accumulating the same certificate again adds nothing: sweeping a path whose certificates
+    // share a responder must not queue the same fetch repeatedly.
+    collect_crl_dp_uris(&cert, &mut crl_dps);
+    collect_ocsp_uris(&cert, &mut ocsp);
+    assert_eq!(1, crl_dps.len());
+    assert_eq!(1, ocsp.len());
+}
+
+/// A certificate carrying neither extension contributes nothing rather than failing, so a caller
+/// can run the collectors across every position in a path without checking first.
+#[test]
+fn revocation_uris_absent_is_not_an_error() {
+    let der = include_bytes!("../../tests/examples/PKITS_data_2048/certs/GoodCACert.crt");
+    let cert = parse_cert(der, "GoodCACert.crt").unwrap();
+
+    let mut ocsp = alloc::vec![];
+    collect_ocsp_uris(&cert, &mut ocsp);
+    assert!(ocsp.is_empty());
 }

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -64,10 +64,17 @@ impl Capabilities {
         }
     }
 
-    /// A browser with no relay: no filesystem, no outbound requests, and certval built without
-    /// revocation support. Same as [`Default`], named for the call sites that mean it explicitly.
+    /// A browser with no relay: no filesystem and no outbound requests, but certval *is* built
+    /// with revocation support, so revocation data supplied alongside the certificates is
+    /// processed and only the fetching is missing. That is why this is no longer [`Default`] —
+    /// `revocation` is the one bit a browser has without a relay, and reporting it accurately is
+    /// what makes the form show "cannot reach a responder" rather than "built without support".
     pub fn browser_local() -> Self {
-        Self::default()
+        Self {
+            filesystem: false,
+            network: false,
+            revocation: true,
+        }
     }
 }
 

--- a/pittv3-wasm/Cargo.toml
+++ b/pittv3-wasm/Cargo.toml
@@ -20,10 +20,17 @@ rust-version = "1.88"
 # The browser frontend builds certval with no-default-features (no filesystem, network or thread
 # support) plus pqc. Trust anchor and CA stores are baked in as CBOR at build time or supplied by
 # the user via file upload.
+#
+# `revocation` is the CRL and OCSP *processing* code, and is independent of `remote`, which is the
+# fetching. It costs nothing here beyond code size and gets certval's no-std `check_revocation`
+# (a synchronous fn, unlike the async one std builds) compiled in, so revocation data supplied
+# alongside the certificates can be honored. Nothing fetches it yet, so runs leave the check off by
+# default -- see `run_settings` in main.rs. Listed on all three crates rather than relying on
+# pittv3_gui_lib's feature to fan out, so each line states what that crate is built with.
 [dependencies]
-certval = { path = "../certval", default-features = false, features = ["eddsa", "pqc", "rsa"] }
-pittv3_lib = { path = "../pittv3-lib", default-features = false, features = ["eddsa", "pqc", "rsa"] }
-pittv3_gui_lib = { path = "../pittv3-gui-lib", default-features = false, features = ["pqc"] }
+certval = { path = "../certval", default-features = false, features = ["eddsa", "pqc", "revocation", "rsa"] }
+pittv3_lib = { path = "../pittv3-lib", default-features = false, features = ["eddsa", "pqc", "revocation", "rsa"] }
+pittv3_gui_lib = { path = "../pittv3-gui-lib", default-features = false, features = ["pqc", "revocation"] }
 
 dioxus = { version = "0.7.9", features = ["web"] }
 log = "0.4.33"

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -125,6 +125,21 @@ fn load_validate_all() -> bool {
 /// the very same settings file checked against the current time on the desktop. Filling it in at
 /// run time keeps the two frontends in agreement and still leaves the stored file portable, since
 /// the value is not written back to the model.
+///
+/// Revocation status checking is materialized the same way and for the same class of reason:
+/// certval's default for an absent `PS_CHECK_REVOCATION_STATUS` is *true*, and nothing in the
+/// browser can fetch a CRL or an OCSP response until a relay exists, so an unstated preference
+/// means off here.
+///
+/// This is anticipatory rather than load-bearing today. The validation path this frontend uses
+/// (`pittv3_gui_lib::validate`) has no `check_revocation` call site at all -- the one that reads
+/// this setting lives in `pittv3_lib::no_std_utils`, which it does not go through -- so the
+/// setting currently decides nothing. Certval is built with `revocation` so the processing code is
+/// present for stapled data; wiring the call site is what makes this line matter, and the default
+/// should already be right when that happens rather than flipping every existing user's results to
+/// `RevocationStatusNotDetermined` on the day it lands. A user who sets it explicitly still gets
+/// what they asked for -- the settings form says outright that these settings apply only where the
+/// tool can fetch.
 fn run_settings(model: &SettingsModel) -> CertificationPathSettings {
     let mut cps = CertificationPathSettings::default();
     model.apply(&mut cps);
@@ -132,6 +147,9 @@ fn run_settings(model: &SettingsModel) -> CertificationPathSettings {
         if let Ok(toi) = TimeOfInterest::from_unix_secs(now_as_unix_epoch()) {
             cps.set_time_of_interest(toi);
         }
+    }
+    if model.check_revocation_status.is_none() {
+        cps.set_check_revocation_status(false);
     }
     cps
 }
@@ -897,5 +915,34 @@ fn App() -> Element {
                 }
             }
         }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::run_settings;
+    use pittv3_gui_lib::gui_settings_model::SettingsModel;
+
+    /// certval's default for an absent `PS_CHECK_REVOCATION_STATUS` is true, so the browser would
+    /// otherwise carry a preference for a check it has no way to satisfy. The frontend's current
+    /// validation path reads the setting nowhere, so this guards the intent rather than an active
+    /// behavior: it is what keeps the day a `check_revocation` call site is wired from silently
+    /// turning every existing user's results into `RevocationStatusNotDetermined`.
+    #[test]
+    fn revocation_checking_is_off_unless_asked_for() {
+        let cps = run_settings(&SettingsModel::default());
+        assert!(!cps.get_check_revocation_status());
+    }
+
+    /// An explicit preference is still honored -- the settings form states that these settings
+    /// apply only where the tool can fetch, so a user who sets it gets what they asked for rather
+    /// than a silently discarded setting.
+    #[test]
+    fn explicit_revocation_preference_is_honored() {
+        let model = SettingsModel {
+            check_revocation_status: Some(true),
+            ..SettingsModel::default()
+        };
+        assert!(run_settings(&model).get_check_revocation_status());
     }
 }


### PR DESCRIPTION
- enable revocation feature in pittv3-wasm and add code to turn off revocation checking (until such time as retrieval is in place)
- Make collect_crl_dp_uris and collect_ocsp_uris public and ungated