### PR TITLE
Export the artifacts used to validate a certification path

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5199,6 +5199,7 @@ dependencies = [
  "tokio-test",
  "walkdir",
  "x509-cert",
+ "x509-ocsp",
 ]
 
 [[package]]

--- a/pittv3-gui-lib/assets/pittv3.css
+++ b/pittv3-gui-lib/assets/pittv3.css
@@ -135,6 +135,13 @@ button[type="submit"] {
   margin: 0.25rem 0 0.5rem 0;
 }
 
+/* Name for an export, sized to the name rather than to the row: it sits among buttons, and the
+   full-width rule for text inputs would push them off the line. */
+.export-name {
+  width: 12rem;
+  margin-left: 0.25rem;
+}
+
 /* A badge is a pill, so it must never wrap: a rounded box two lines tall renders as an ellipse with
    its own corners cutting into the text. Scoped here rather than on any container, because the
    containers deliberately break long content -- .cert-table cells set overflow-wrap: anywhere so a

--- a/pittv3-gui-lib/src/export.rs
+++ b/pittv3-gui-lib/src/export.rs
@@ -1,0 +1,232 @@
+//! Taking the artifacts behind a validation away with you.
+//!
+//! A results view can say a path was valid; it cannot hand over what made it so. This assembles, for
+//! each certification path a run produced, the material that path was built and judged from — every
+//! certificate, the revocation data consulted, the responder certificates that make an OCSP response
+//! checkable, and the manifest describing all of it — either as a zip or as the manifests alone.
+//!
+//! Everything here is derived, not retained. The certificates come off the path, the OCSP artifacts
+//! out of the results, the CRLs from whichever source in the environment still holds them, and the
+//! manifest is rendered on demand by the same `pittv3_lib::pitt_log` code that writes one into a
+//! results folder. So a run pays nothing for an export nobody asks for, and the archive a browser
+//! downloads is the same document a CLI run writes to disk.
+
+use std::io::{Cursor, Write};
+
+use certval::{
+    CertificationPath, CertificationPathResults, CertificationPathSettings, PkiEnvironment,
+};
+use pittv3_lib::pitt_log::{cpr_artifact_entries, render_path_manifest};
+use zip::write::SimpleFileOptions;
+use zip::{CompressionMethod, ZipWriter};
+
+/// One file in an export: the name it takes inside a path's folder, and its contents.
+pub type ExportEntry = (String, Vec<u8>);
+
+/// Name the manifest takes inside a path's folder. Also the entry [`paths_text`] pulls back out, so
+/// the concatenated log and the archived manifests are necessarily the same text.
+pub const MANIFEST_NAME: &str = "manifest.txt";
+
+/// The files describing one certification path.
+///
+/// Certificates are numbered by hop with the trust anchor at zero, matching what a results-folder
+/// run writes, so the same layout is recognizable however it was produced. Position is the one thing
+/// a reader cannot recover from names alone, which is why it leads each one.
+pub fn path_entries(
+    pe: &PkiEnvironment,
+    path: &CertificationPath,
+    cps: Option<&CertificationPathSettings>,
+    cpr: &CertificationPathResults,
+) -> Vec<ExportEntry> {
+    let mut out = vec![];
+
+    let mut manifest = Vec::new();
+    render_path_manifest(pe, &mut manifest, path, cpr, cps);
+    out.push((MANIFEST_NAME.to_string(), manifest));
+
+    out.push(("0-ta.der".to_string(), path.trust_anchor.encoded_ta.clone()));
+    for (i, ca) in path.intermediates.iter().enumerate() {
+        out.push((format!("{}.der", i + 1), ca.as_bytes().to_vec()));
+    }
+    out.push((
+        format!("{}-target.der", path.intermediates.len() + 1),
+        path.target.as_bytes().to_vec(),
+    ));
+
+    out.extend(cpr_artifact_entries(cpr));
+    out.extend(crl_entries(pe, path, cpr));
+    out
+}
+
+/// The CRLs that settled a status on this path, recovered from the environment.
+///
+/// The results retain only `CrlInfo`, deliberately — keeping every CRL body per position per path is
+/// what made a 9.5 MB distribution point cost megabytes a run. The bytes are still held by whichever
+/// `CrlSource` supplied them, so this asks the environment for the candidates covering each
+/// certificate and keeps the ones the results say were actually used.
+///
+/// Matched on issuer and thisUpdate rather than taken wholesale: `get_crls` answers with candidates
+/// by issuer name alone, on purpose, since `process_crl` re-checks scope, validity and signature on
+/// everything handed back. Shipping the superset would put CRLs in the bundle that had no bearing on
+/// the result. A CRL that has since been pruned from its source simply does not appear, and the
+/// manifest's revocation section still records what it was and where it came from.
+#[cfg(feature = "revocation")]
+fn crl_entries(
+    pe: &PkiEnvironment,
+    path: &CertificationPath,
+    cpr: &CertificationPathResults,
+) -> Vec<ExportEntry> {
+    use der::{Decode, Encode};
+    use x509_cert::certificate::Raw;
+    use x509_cert::crl::CertificateList;
+
+    let Some(per_hop) = cpr.get_crl() else {
+        return vec![];
+    };
+    let chain: Vec<&certval::PDVCertificate> = path
+        .intermediates
+        .iter()
+        .chain(core::iter::once(&path.target))
+        .collect();
+
+    let mut out = vec![];
+    for (hop, infos) in per_hop.iter().enumerate() {
+        if infos.is_empty() {
+            continue;
+        }
+        let Some(cert) = chain.get(hop) else {
+            continue;
+        };
+        let Ok(candidates) = pe.get_crls(cert) else {
+            continue;
+        };
+        let suffix = infos.len() > 1;
+        for (j, info) in infos.iter().enumerate() {
+            let found = candidates.iter().find(|bytes| {
+                CertificateList::<Raw>::from_der(bytes)
+                    .ok()
+                    .map(|crl| {
+                        crl.tbs_cert_list.this_update.to_unix_duration().as_secs()
+                            == info.this_update
+                            && crl
+                                .tbs_cert_list
+                                .issuer
+                                .to_der()
+                                .map(|der| der == info.issuer_name_blob)
+                                .unwrap_or(false)
+                    })
+                    .unwrap_or(false)
+            });
+            if let Some(bytes) = found {
+                let name = if suffix {
+                    format!("{}-crl-{}.crl", hop + 1, j)
+                } else {
+                    format!("{}-crl.crl", hop + 1)
+                };
+                out.push((name, bytes.clone()));
+            }
+        }
+    }
+    out
+}
+
+#[cfg(not(feature = "revocation"))]
+fn crl_entries(
+    _pe: &PkiEnvironment,
+    _path: &CertificationPath,
+    _cpr: &CertificationPathResults,
+) -> Vec<ExportEntry> {
+    vec![]
+}
+
+/// Packages one or more paths' entries as a zip, each path under `<name>/<n>/` numbered from one.
+///
+/// `name` is the caller's, and it names both the archive and the folder inside it, so extracting
+/// leaves one directory rather than scattering numbered folders into wherever it landed.
+pub fn zip_paths(name: &str, paths: &[Vec<ExportEntry>]) -> Result<Vec<u8>, String> {
+    let mut buf = Cursor::new(Vec::new());
+    {
+        let mut zw = ZipWriter::new(&mut buf);
+        let options = SimpleFileOptions::default().compression_method(CompressionMethod::Deflated);
+        for (i, entries) in paths.iter().enumerate() {
+            for (file, bytes) in entries {
+                zw.start_file(format!("{name}/{}/{file}", i + 1), options)
+                    .map_err(|e| format!("Failed to add {file} to the archive: {e}"))?;
+                zw.write_all(bytes)
+                    .map_err(|e| format!("Failed to write {file} into the archive: {e}"))?;
+            }
+        }
+        zw.finish()
+            .map_err(|e| format!("Failed to finish the archive: {e}"))?;
+    }
+    Ok(buf.into_inner())
+}
+
+/// The manifests alone, one after another, for a caller wanting the account of every path without
+/// the material behind it.
+///
+/// Taken back out of the same entries the archive carries rather than rendered a second time, so the
+/// two exports cannot disagree about what the run found.
+pub fn paths_text(paths: &[Vec<ExportEntry>]) -> String {
+    let mut out = String::new();
+    for entries in paths {
+        let Some((_, bytes)) = entries.iter().find(|(name, _)| name == MANIFEST_NAME) else {
+            continue;
+        };
+        out.push_str(&String::from_utf8_lossy(bytes));
+        out.push('\n');
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The archive puts every path under the caller's name, numbered from one, so extracting it
+    /// leaves a single directory rather than loose numbered folders.
+    #[test]
+    fn paths_are_numbered_from_one_under_the_given_name() {
+        let paths = vec![
+            vec![("manifest.txt".to_string(), b"first".to_vec())],
+            vec![("manifest.txt".to_string(), b"second".to_vec())],
+        ];
+        let zipped = zip_paths("MyExport", &paths).unwrap();
+        let mut archive = zip::ZipArchive::new(Cursor::new(zipped)).unwrap();
+        let mut names: Vec<String> = (0..archive.len())
+            .map(|i| archive.by_index(i).unwrap().name().to_string())
+            .collect();
+        names.sort();
+        assert_eq!(
+            names,
+            vec![
+                "MyExport/1/manifest.txt".to_string(),
+                "MyExport/2/manifest.txt".to_string()
+            ]
+        );
+    }
+
+    /// The text export is the archive's manifests, so the two cannot describe different runs.
+    #[test]
+    fn text_export_is_the_manifests_the_archive_carries() {
+        let paths = vec![
+            vec![
+                ("manifest.txt".to_string(), b"path one".to_vec()),
+                ("0-ta.der".to_string(), vec![0x30]),
+            ],
+            vec![("manifest.txt".to_string(), b"path two".to_vec())],
+        ];
+        let text = paths_text(&paths);
+        assert!(text.contains("path one"));
+        assert!(text.contains("path two"));
+        // the DER rode along in the archive and must not appear in the log
+        assert!(!text.contains('\u{30}'.to_string().as_str()) || !text.contains("0-ta"));
+    }
+
+    /// A path contributing no manifest is skipped rather than emitting a blank section.
+    #[test]
+    fn a_path_without_a_manifest_contributes_nothing_to_the_text() {
+        let paths = vec![vec![("0-ta.der".to_string(), vec![0x30])]];
+        assert!(paths_text(&paths).is_empty());
+    }
+}

--- a/pittv3-gui-lib/src/lib.rs
+++ b/pittv3-gui-lib/src/lib.rs
@@ -4,6 +4,7 @@
 // unused_qualifications is not included below because the rsx macro expansion trips it
 #![warn(missing_docs, rust_2018_idioms)]
 
+pub mod export;
 pub mod gui_help;
 pub mod gui_results;
 pub mod gui_rows;

--- a/pittv3-gui-lib/src/validate.rs
+++ b/pittv3-gui-lib/src/validate.rs
@@ -103,13 +103,15 @@ impl PreparedValidation {
 /// certificates changes which paths exist rather than whether a certificate was revoked. A caller
 /// that shares one owes it a `clear()` when the time of interest moves backward or the revocation
 /// policy tightens; one that would rather not think about it can pass a fresh cache each time and get
-/// the previous behavior.
+/// the previous behavior. Passing `None` registers no cache at all, so every path determines every
+/// status for itself -- slower, and what a caller wants when each path has to stand on its own
+/// evidence rather than on an answer reached while validating another one.
 pub fn prepare_validation(
     store: Option<(&str, &[u8], &[u8])>,
     tas: &[(String, Vec<u8>)],
     cas: &[(String, Vec<u8>)],
     cps: &CertificationPathSettings,
-    #[cfg(feature = "revocation")] rev_cache: &Arc<RevocationCache>,
+    #[cfg(feature = "revocation")] rev_cache: Option<&Arc<RevocationCache>>,
     // certval's glob import shadows the 1-arg `Result` alias, so name the 2-arg form explicitly
 ) -> core::result::Result<(PreparedValidation, Vec<ResultLine>), Vec<ResultLine>> {
     let mut out = vec![];
@@ -217,7 +219,15 @@ pub fn prepare_validation(
     // is discarded with it, which is what keeps it honest when the time of interest changes: that
     // is a settings change, and a settings change rebuilds the environment.
     #[cfg(feature = "revocation")]
-    pe.add_revocation_cache(Box::new(rev_cache.clone()));
+    // `None` declines the cache outright, which is not the same as passing an empty one: with no
+    // cache registered every path derives every certificate's status from revocation data of its
+    // own, so each path accounts for itself. That matters for an export -- a path whose certificates
+    // were answered from cache carries a status and no evidence, because the evidence was obtained
+    // while validating a different path -- and it is the only way to make a run reach a responder
+    // twice on purpose.
+    if let Some(rev_cache) = rev_cache {
+        pe.add_revocation_cache(Box::new(rev_cache.clone()));
+    }
     // Nothing to register for OCSP -- certval has no source for it -- so this is simply carried
     // and consulted when a path is built. See validate_target.
     let ocsp = OcspResponses::new();
@@ -242,17 +252,65 @@ pub fn validate_prepared(
     ees: &[(String, Vec<u8>)],
     validate_all: bool,
 ) -> (Vec<TargetReport>, Vec<ResultLine>) {
+    let (reports, out, _) = validate_prepared_retaining(prepared, cps, ees, validate_all, false);
+    (reports, out)
+}
+
+/// One validated path, kept so the artifacts behind it can be exported afterwards.
+///
+/// The path and the results are what an export is assembled from; the settings are the ones that
+/// path was validated under, which is not the run's settings — RFC 5937 trust anchor constraints are
+/// folded in per path — so a manifest reporting the run's would describe inputs the path was not
+/// judged against.
+///
+/// Nothing is computed to produce these. The path and results exist for the duration of the
+/// validation regardless; retaining them is declining to drop them, which is why this is a caller's
+/// choice at the call site rather than a setting a user has to know to turn on before a run they
+/// have not seen the outcome of yet.
+pub struct RetainedPath {
+    /// Name of the target this path was built for, as the caller supplied it
+    pub target_name: String,
+    /// The path as validated
+    pub path: CertificationPath,
+    /// The settings this path was validated under
+    pub cps: CertificationPathSettings,
+    /// The results recorded while validating it
+    pub cpr: CertificationPathResults,
+}
+
+/// As [`validate_prepared`], additionally returning each validated path when `retain` is set, so a
+/// frontend can export the artifacts behind a result without validating a second time.
+///
+/// Validating again to produce an export would describe a *different* run: revocation data moves,
+/// and a responder asked twice can answer twice. An export is worth having precisely because it
+/// accounts for the result on screen, so the material has to come from that run or not at all.
+pub fn validate_prepared_retaining(
+    prepared: &PreparedValidation,
+    cps: &CertificationPathSettings,
+    ees: &[(String, Vec<u8>)],
+    validate_all: bool,
+    retain: bool,
+) -> (Vec<TargetReport>, Vec<ResultLine>, Vec<RetainedPath>) {
     let mut out = vec![];
     let mut reports = vec![];
+    let mut retained = vec![];
     for (name, bytes) in ees {
-        let (report, lines) =
-            validate_target(&prepared.pe, cps, name, bytes, validate_all, &prepared.ocsp);
+        let sink = retain.then_some(&mut retained);
+        let (report, lines) = validate_target(
+            &prepared.pe,
+            cps,
+            name,
+            bytes,
+            validate_all,
+            &prepared.ocsp,
+            sink,
+        );
         out.extend(lines);
         if let Some(r) = report {
             reports.push(r);
         }
     }
-    (reports, out)
+    (reports, out, retained)
 }
 
 /// Reports a target for which the builder produced no candidate path, carrying the diagnosis of
@@ -328,6 +386,7 @@ fn validate_target(
     ee: &[u8],
     validate_all: bool,
     ocsp: &OcspResponses,
+    mut retain: Option<&mut Vec<RetainedPath>>,
 ) -> (Option<TargetReport>, Vec<ResultLine>) {
     let mut out = vec![];
     let toi = cps.get_time_of_interest();
@@ -465,6 +524,19 @@ fn validate_target(
             r.as_ref().err(),
             path_start.elapsed().as_millis() as u64,
         ));
+        // Kept for a later export, with the settings this path was actually judged under rather than
+        // the run's -- `path_cps` carries the RFC 5937 trust anchor constraints folded in above, and
+        // a manifest reporting the run's settings would name inputs the path was not validated
+        // against. Paths that failed are kept too: a failure is the case someone most wants the
+        // material for.
+        if let Some(retained) = retain.as_deref_mut() {
+            retained.push(RetainedPath {
+                target_name: ee_name.to_string(),
+                path: path.clone(),
+                cps: path_cps.clone(),
+                cpr: cpr.clone(),
+            });
+        }
         let cert_count = path.intermediates.len() + 2;
         match r {
             Ok(_) => {
@@ -648,8 +720,15 @@ pub fn validate_hackathon_zip(
         out.extend(validate_self_signed(&pe, name, der));
     }
     for (name, der) in &ees {
-        let (report, lines) =
-            validate_target(&pe, cps, name, der, validate_all, &OcspResponses::new());
+        let (report, lines) = validate_target(
+            &pe,
+            cps,
+            name,
+            der,
+            validate_all,
+            &OcspResponses::new(),
+            None,
+        );
         out.extend(lines);
         if let Some(report) = report {
             reports.push(report);

--- a/pittv3-lib/Cargo.toml
+++ b/pittv3-lib/Cargo.toml
@@ -20,6 +20,10 @@ rust-version = "1.85"
 
 [dependencies]
 x509-cert = { version = "0.3.0", default-features = false, features = ["pem"] }
+# To take the responder's certificates out of an OCSP response when exporting the artifacts behind a
+# path. They ride inside the response (BasicOcspResponse.certs), so this decodes what the run already
+# holds rather than retaining anything further. Same version certval pins.
+x509-ocsp = { version = "0.3.0-pre", default-features = false }
 const-oid = { version = "0.10.2", default-features = false, features = ["db"] }
 der = { version="0.8.1", features = ["alloc", "derive", "flagset", "oid"] }
 spki = { version = "0.8.0", default-features = false, features = ["alloc"] }

--- a/pittv3-lib/src/no_std_utils.rs
+++ b/pittv3-lib/src/no_std_utils.rs
@@ -88,10 +88,8 @@ pub(crate) fn validate_cert(
         let mut r = pe.validate_path(pe, &path_cps, path, &mut cpr);
 
         #[cfg(feature = "revocation")]
-        if r.is_ok() {
-            if path_cps.get_check_revocation_status() {
-                r = check_revocation_local(pe, &path_cps, path, &mut cpr);
-            }
+        if r.is_ok() && path_cps.get_check_revocation_status() {
+            r = check_revocation_local(pe, &path_cps, path, &mut cpr);
         }
 
         #[cfg(feature = "std_app")]

--- a/pittv3-lib/src/pitt_log.rs
+++ b/pittv3-lib/src/pitt_log.rs
@@ -498,7 +498,8 @@ pub fn log_cpr(_pe: &PkiEnvironment, f: &mut dyn Write, np: &Path, cpr: &Certifi
 
 /// Renders the certification path validation outputs -- the status and the valid policy graph.
 ///
-/// Separate from [`write_cpr_artifacts`] because the two halves go to different places and only one
+/// Separate from the filesystem half (`write_cpr_artifacts`, private) because the two halves go to
+/// different places and only one
 /// of them needs a filesystem: a frontend assembling an archive in memory renders this and collects
 /// the artifacts as bytes, while a run writing to a results folder does both to disk. Keeping the
 /// rendering here means every frontend's manifest is the same manifest rather than a second one that
@@ -1068,6 +1069,10 @@ pub fn render_path_manifest(
     }
 }
 
+// The test writes the rendered settings to a file, so it needs the half of this module that has a
+// filesystem. It was covered by the module-wide gate before that gate was narrowed to the functions
+// that actually need it.
+#[cfg(feature = "std_app")]
 #[test]
 fn test_cps_log() {
     extern crate alloc;
@@ -1078,7 +1083,6 @@ fn test_cps_log() {
 
     use certval::validator::path_settings::*;
 
-    #[cfg(feature = "std_app")]
     let mut cps = CertificationPathSettings::new();
     cps.set_initial_explicit_policy_indicator(true);
     cps.set_initial_policy_mapping_inhibit_indicator(true);

--- a/pittv3-lib/src/pitt_log.rs
+++ b/pittv3-lib/src/pitt_log.rs
@@ -1,20 +1,29 @@
 //! Supports generation of manifest files that describe certification path validation results
-#![cfg(feature = "std_app")]
 
 extern crate alloc;
 use alloc::collections::BTreeMap;
+#[cfg(feature = "std_app")]
 use log::error;
 use std::io::Write;
-use std::{fs, fs::File, path::Path};
+use std::path::Path;
+// The filesystem half of this module exists only where there is a filesystem to write to.
+#[cfg(feature = "std_app")]
+use std::{fs, fs::File};
 
 use const_oid::db::rfc5912::{
     ID_CE_AUTHORITY_KEY_IDENTIFIER, ID_CE_BASIC_CONSTRAINTS, ID_CE_CERTIFICATE_POLICIES,
     ID_CE_EXT_KEY_USAGE, ID_CE_INHIBIT_ANY_POLICY, ID_CE_NAME_CONSTRAINTS,
     ID_CE_POLICY_CONSTRAINTS, ID_CE_POLICY_MAPPINGS, ID_CE_SUBJECT_KEY_IDENTIFIER,
 };
+#[cfg(feature = "revocation")]
+use der::asn1::GeneralizedTime;
+use der::{Decode, Encode};
+#[cfg(feature = "std_app")]
 use sha2::Digest;
+#[cfg(feature = "std_app")]
 use sha2::Sha256;
 use x509_cert::ext::pkix::name::GeneralName;
+use x509_ocsp::{BasicOcspResponse, CertStatus, OcspResponse, ResponderId, SingleResponse};
 
 use certval::source::ta_source::{buffer_to_hex, get_filename_from_ta_metadata};
 use certval::util::pdv_utilities::*;
@@ -40,7 +49,7 @@ pub fn get_file_stem_or_empty(filename: &str) -> String {
 
 /// `log_cps` contributes to the manifest file related to
 /// [`CertificationPathSettings`](../certval/path_settings/type.CertificationPathSettings.html) contents.
-pub fn log_cps(f: &mut File, cps: &CertificationPathSettings) {
+pub fn log_cps(f: &mut dyn Write, cps: &CertificationPathSettings) {
     f.write_all(
         format!(
             "Initial explicit policy: {}\n",
@@ -165,7 +174,7 @@ pub fn log_cps(f: &mut File, cps: &CertificationPathSettings) {
 
 /// `log_ta_details` contributes to the manifest file related to
 /// [`PDVTrustAnchor`](../certval/pdv_certificate/struct.PDVTrustAnchor.html) contents.
-pub fn log_ta_details(_pe: &PkiEnvironment, f: &mut File, ta: &PDVTrustAnchorChoice) {
+pub fn log_ta_details(_pe: &PkiEnvironment, f: &mut dyn Write, ta: &PDVTrustAnchorChoice) {
     // TODO - implement me
     f.write_all(format!("\t\t* Source: {}\n", get_filename_from_ta_metadata(ta)).as_bytes())
         .expect("Unable to write manifest file");
@@ -173,7 +182,7 @@ pub fn log_ta_details(_pe: &PkiEnvironment, f: &mut File, ta: &PDVTrustAnchorCho
 
 /// `log_cert_details` contributes to the manifest file related to
 /// [`PDVCertificate`](../certval/pdv_certificate/struct.PDVCertificate.html) contents.
-pub fn log_cert_details(pe: &PkiEnvironment, f: &mut File, cert: &PDVCertificate) {
+pub fn log_cert_details(pe: &PkiEnvironment, f: &mut dyn Write, cert: &PDVCertificate) {
     f.write_all(
         format!(
             "\t\t* Issuer Name: {}\n",
@@ -481,7 +490,20 @@ pub fn log_cert_details(pe: &PkiEnvironment, f: &mut File, cert: &PDVCertificate
 
 /// `log_cpr` contributes to the manifest file related to
 /// [`CertificationPathResults`](../certval/path_settings/type.CertificationPathResults.html) contents.
-pub fn log_cpr(_pe: &PkiEnvironment, f: &mut File, np: &Path, cpr: &CertificationPathResults) {
+#[cfg(feature = "std_app")]
+pub fn log_cpr(_pe: &PkiEnvironment, f: &mut dyn Write, np: &Path, cpr: &CertificationPathResults) {
+    render_cpr(f, cpr);
+    write_cpr_artifacts(np, cpr);
+}
+
+/// Renders the certification path validation outputs -- the status and the valid policy graph.
+///
+/// Separate from [`write_cpr_artifacts`] because the two halves go to different places and only one
+/// of them needs a filesystem: a frontend assembling an archive in memory renders this and collects
+/// the artifacts as bytes, while a run writing to a results folder does both to disk. Keeping the
+/// rendering here means every frontend's manifest is the same manifest rather than a second one that
+/// drifts.
+pub fn render_cpr(f: &mut dyn Write, cpr: &CertificationPathResults) {
     let status = cpr.get_validation_status();
     if let Some(status) = status {
         f.write_all(format!("Status: {status:?}\n\n").as_bytes())
@@ -501,63 +523,21 @@ pub fn log_cpr(_pe: &PkiEnvironment, f: &mut File, np: &Path, cpr: &Certificatio
             }
         }
     }
+}
 
-    // TODO add CRL and OCSP details to manifest (probably best to wait until CrlInfo is in CPR)
-
-    // i + i in the below loops because TAs are not considered here (and the indexes for artifcacts uses
-    // TAs in slot 0).
-    if let Some(ocsp_reqs) = cpr.get_ocsp_requests() {
-        for (i, or) in ocsp_reqs.iter().enumerate() {
-            let suffix = or.len() > 1;
-            for (j, ir) in or.iter().enumerate() {
-                let p = if suffix {
-                    np.join(format!("{}-ocsp-{}.ocspReq", i + 1, j).as_str())
-                } else {
-                    np.join(format!("{}-ocsp.ocspReq", i + 1).as_str())
-                };
-                fs::write(p, ir).expect("Unable to write OCSP request");
-            }
+/// Writes the revocation artifacts a run consulted into `np`: OCSP requests and responses, the
+/// responder certificates carried inside those responses, and CRLs where their bytes are still held.
+#[cfg(feature = "std_app")]
+fn write_cpr_artifacts(np: &Path, cpr: &CertificationPathResults) {
+    for (name, bytes) in cpr_artifact_entries(cpr) {
+        let p = np.join(&name);
+        if let Err(e) = fs::write(&p, &bytes) {
+            error!("Unable to write {}: {e}", p.display());
         }
     }
-    if let Some(ocsp_resp) = cpr.get_ocsp_responses() {
-        for (i, or) in ocsp_resp.iter().enumerate() {
-            let suffix = or.len() > 1;
-            for (j, ir) in or.iter().enumerate() {
-                let p = if suffix {
-                    np.join(format!("{}-ocsp-{}.ocspResp", i + 1, j).as_str())
-                } else {
-                    np.join(format!("{}-ocsp.ocspResp", i + 1).as_str())
-                };
-                fs::write(p, ir).expect("Unable to write OCSP response");
-            }
-        }
-    }
-    if let Some(ocsp_reqs) = cpr.get_failed_ocsp_requests() {
-        for (i, or) in ocsp_reqs.iter().enumerate() {
-            let suffix = or.len() > 1;
-            for (j, ir) in or.iter().enumerate() {
-                let p = if suffix {
-                    np.join(format!("{}-ocsp-{}.failed.ocspReq", i + 1, j).as_str())
-                } else {
-                    np.join(format!("{}-ocsp.failed.ocspReq", i + 1).as_str())
-                };
-                fs::write(p, ir).expect("Unable to write OCSP request");
-            }
-        }
-    }
-    if let Some(ocsp_resp) = cpr.get_failed_ocsp_responses() {
-        for (i, or) in ocsp_resp.iter().enumerate() {
-            let suffix = or.len() > 1;
-            for (j, ir) in or.iter().enumerate() {
-                let p = if suffix {
-                    np.join(format!("{}-ocsp-{}.failed.ocspResp", i + 1, j).as_str())
-                } else {
-                    np.join(format!("{}-ocsp.failed.ocspResp", i + 1).as_str())
-                };
-                fs::write(p, ir).expect("Unable to write OCSP response");
-            }
-        }
-    }
+    // CRLs are not among those entries because the results retain only `CrlInfo`, not the CRL. Here
+    // the bytes can sometimes be recovered from the file the source cached, so the note-or-CRL
+    // decision lives with the filesystem half.
     if let Some(crls) = cpr.get_crl() {
         for (i, or) in crls.iter().enumerate() {
             let suffix = or.len() > 1;
@@ -586,11 +566,333 @@ pub fn log_cpr(_pe: &PkiEnvironment, f: &mut File, np: &Path, cpr: &Certificatio
     }
 }
 
+/// The revocation artifacts a run consulted, as (file name, bytes) pairs: OCSP requests and
+/// responses, the failed variants, and the responder certificates carried inside each response.
+///
+/// Named here rather than at each destination so a file in a results folder and an entry in an
+/// archive are the same artifact under the same name. Nothing here touches a filesystem, which is
+/// what lets a browser assemble the identical set in memory.
+///
+/// CRLs are absent: the results retain only the compact `CrlInfo`, so their bytes have to come from
+/// whichever source still holds them, which is a decision for the caller rather than for this.
+pub fn cpr_artifact_entries(cpr: &CertificationPathResults) -> Vec<(String, Vec<u8>)> {
+    // i + 1 throughout because trust anchors are not considered here, while artifact indexes put the
+    // trust anchor in slot 0.
+    let mut out = vec![];
+    let mut push_all = |items: Option<Vec<Vec<Vec<u8>>>>, ext: &str| {
+        let Some(items) = items else {
+            return;
+        };
+        for (i, per_hop) in items.iter().enumerate() {
+            let suffix = per_hop.len() > 1;
+            for (j, bytes) in per_hop.iter().enumerate() {
+                let name = if suffix {
+                    format!("{}-ocsp-{}.{ext}", i + 1, j)
+                } else {
+                    format!("{}-ocsp.{ext}", i + 1)
+                };
+                out.push((name, bytes.clone()));
+            }
+        }
+    };
+    push_all(cpr.get_ocsp_requests(), "ocspReq");
+    push_all(cpr.get_ocsp_responses(), "ocspResp");
+    push_all(cpr.get_failed_ocsp_requests(), "failed.ocspReq");
+    push_all(cpr.get_failed_ocsp_responses(), "failed.ocspResp");
+
+    if let Some(responses) = cpr.get_ocsp_responses() {
+        for (i, per_hop) in responses.iter().enumerate() {
+            for (j, response) in per_hop.iter().enumerate() {
+                out.extend(ocsp_responder_cert_entries(i + 1, j, response));
+            }
+        }
+    }
+    out
+}
+
+/// The responder's certificates carried inside one OCSP response, as (file name, bytes).
+///
+/// Without these a saved response cannot be checked: it is a signed statement, and verifying it
+/// needs the responder's certificate. PITTv1 and v2 both wrote them out for that reason. Nothing is
+/// retained to produce them -- a `BasicOCSPResponse` carries them in its `certs` field, so this
+/// decodes bytes the results already hold. A response identifying its signer by name and key hash
+/// alone may carry none, in which case there is nothing to write and the responder certificate is
+/// expected to be the CA's own, already on the path.
+pub fn ocsp_responder_cert_entries(
+    hop: usize,
+    resp: usize,
+    response: &[u8],
+) -> Vec<(String, Vec<u8>)> {
+    let Some(basic) = OcspResponse::from_der(response)
+        .ok()
+        .and_then(|r| r.response_bytes)
+        .and_then(|b| BasicOcspResponse::from_der(b.response.as_bytes()).ok())
+    else {
+        return vec![];
+    };
+    let Some(certs) = basic.certs.as_ref() else {
+        return vec![];
+    };
+    certs
+        .iter()
+        .enumerate()
+        .filter_map(|(k, cert)| {
+            let der = cert.to_der().ok()?;
+            Some((format!("{hop}-ocsp-{resp}-cert-{k}.der"), der))
+        })
+        .collect()
+}
+
+/// Renders the "Revocation status determination details" section: what settled the revocation
+/// status of each certificate on the path, and what the evidence said.
+///
+/// A section of its own, after the algorithm outputs, following PITTv2 -- revocation is not an RFC
+/// 5280 path-validation output and reads oddly among them, and a reader asking "why does it say
+/// revoked?" is looking for one place rather than a line inside each certificate's block.
+///
+/// Positions are hops: certificate #1 is the one the trust anchor issued. A trust anchor has no
+/// revocation status, so it has no entry, and a hop nothing was determined for is named as such
+/// rather than omitted -- silence there is indistinguishable from a hop that was checked and found
+/// good, which is the distinction the section exists to make.
+pub fn render_revocation_details(
+    f: &mut dyn Write,
+    path: &CertificationPath,
+    cpr: &CertificationPathResults,
+) {
+    // What settled each hop comes from `revocation_outcomes_from_cpr`, the same function the results
+    // views render their badges from, so the manifest and the screen cannot disagree.
+    //
+    // Reading the artifacts instead would be wrong, and was: a determination served from the
+    // revocation status cache examines no CRL and no response and leaves nothing behind, so a hop
+    // answered from cache has a status and no evidence. Driving the section off the evidence reported
+    // "no revocation status was determined" for certificates the run had in fact found to be not
+    // revoked. The artifacts are the detail beneath the answer, never the answer.
+    let num_certs = path.intermediates.len() + 1;
+    let outcomes = crate::report::revocation_outcomes_from_cpr(cpr, num_certs);
+    if outcomes.is_empty() {
+        return;
+    }
+
+    let chain: Vec<&PDVCertificate> = path
+        .intermediates
+        .iter()
+        .chain(core::iter::once(&path.target))
+        .collect();
+
+    let ocsp = cpr.get_ocsp_responses();
+    #[cfg(feature = "revocation")]
+    let crls = cpr.get_crl();
+
+    let mut out = String::new();
+    for outcome in &outcomes {
+        let pos = outcome.cert_index - 1;
+        out.push_str(&format!("\t+ Certificate #{}\n", outcome.cert_index));
+        out.push_str(&format!(
+            "\t\t+ Status: {}\n",
+            revocation_status_text(outcome.status)
+        ));
+        out.push_str(&format!(
+            "\t\t+ Determined by: {}\n",
+            revocation_method_text(outcome.method)
+        ));
+
+        if let Some(responses) = ocsp.as_ref().and_then(|v| v.get(pos)) {
+            for (i, response) in responses.iter().enumerate() {
+                out.push_str(&format!("\t\t+ OCSP response #{}\n", i + 1));
+                let serial = chain
+                    .get(pos)
+                    .map(|c| c.decoded().tbs_certificate().serial_number().as_bytes());
+                out.push_str(&render_ocsp_details(response, serial));
+            }
+        }
+        #[cfg(feature = "revocation")]
+        if let Some(hop_crls) = crls.as_ref().and_then(|v| v.get(pos)) {
+            for (i, info) in hop_crls.iter().enumerate() {
+                out.push_str(&format!("\t\t+ CRL #{}\n", i + 1));
+                out.push_str(&render_crl_details(info));
+            }
+        }
+    }
+
+    f.write_all(
+        "\n********************************************************************************\n"
+            .as_bytes(),
+    )
+    .expect("Unable to write manifest file");
+    f.write_all("Revocation status determination details\n".as_bytes())
+        .expect("Unable to write manifest file");
+    f.write_all(
+        "********************************************************************************\n"
+            .as_bytes(),
+    )
+    .expect("Unable to write manifest file");
+    f.write_all(out.as_bytes())
+        .expect("Unable to write manifest file");
+}
+
+/// The revocation status of one certificate, worded for a manifest.
+fn revocation_status_text(status: crate::report::RevocationStatus) -> &'static str {
+    use crate::report::RevocationStatus::*;
+    match status {
+        NotRevoked => "not revoked",
+        Revoked => "revoked",
+        Undetermined => "could not be determined",
+        NotChecked => "not checked",
+    }
+}
+
+/// What settled a certificate's revocation status, worded for a manifest.
+///
+/// Says where the answer came from and not merely what kind of answer it was: a response the run was
+/// handed and one it fetched are both OCSP but say different things about what the run did, and a
+/// cached determination examined nothing at all this time -- which is exactly the case that has no
+/// artifact in the bundle beside it.
+fn revocation_method_text(method: crate::report::RevocationMethod) -> &'static str {
+    use crate::report::RevocationMethod::*;
+    match method {
+        OcspNoCheck => "the OCSP no-check extension",
+        Crl => "a CRL",
+        Ocsp => "an OCSP response",
+        Blocklist => "a configured blocklist",
+        Allowlist => "a configured allowlist",
+        Cache => "a cached determination, not revocation data examined for this path",
+        StapledOcsp => "an OCSP response supplied to the run",
+        StapledCrl => "a CRL supplied to the run",
+        LocalCrl => "a CRL already held",
+        OcspFromAia => "an OCSP response from an authority information access URI",
+        RemoteCrlDp => "a CRL from a distribution point",
+        None => "nothing",
+    }
+}
+
+/// Renders one OCSP response's details, read out of the response itself rather than from anything
+/// recorded alongside it, so the manifest describes the artifact the bundle carries.
+fn render_ocsp_details(response: &[u8], serial: Option<&[u8]>) -> String {
+    let mut out = String::new();
+    let basic = match OcspResponse::from_der(response)
+        .ok()
+        .and_then(|r| r.response_bytes)
+        .and_then(|b| BasicOcspResponse::from_der(b.response.as_bytes()).ok())
+    {
+        Some(basic) => basic,
+        None => {
+            out.push_str("\t\t\t+ Response could not be decoded\n");
+            return out;
+        }
+    };
+
+    let data = &basic.tbs_response_data;
+    match &data.responder_id {
+        ResponderId::ByName(name) => out.push_str(&format!(
+            "\t\t\t+ OCSP responder name: {}\n",
+            name_to_string(name)
+        )),
+        ResponderId::ByKey(key) => out.push_str(&format!(
+            "\t\t\t+ OCSP responder key ID: {}\n",
+            buffer_to_hex(key.as_bytes())
+        )),
+    }
+    out.push_str(&format!(
+        "\t\t\t+ Signature algorithm: {}\n",
+        basic.signature_algorithm.oid
+    ));
+    out.push_str(&format!(
+        "\t\t\t+ Produced at: {}\n",
+        data.produced_at.0.to_date_time()
+    ));
+
+    // A responder may answer about many certificates in one response -- DoD's routinely returns a
+    // batch of several dozen -- and all but one of those say nothing about this hop. Rendering the
+    // batch would bury the single answer that matters among serial numbers from unrelated
+    // certificates, so only the entry naming this certificate is shown.
+    let singles: Vec<&SingleResponse> = match serial {
+        Some(serial) => data
+            .responses
+            .iter()
+            .filter(|s| s.cert_id.serial_number.as_bytes() == serial)
+            .collect(),
+        None => data.responses.iter().collect(),
+    };
+    if singles.is_empty() {
+        out.push_str("\t\t\t+ The response carries no entry for this certificate\n");
+        return out;
+    }
+    for single in singles {
+        out.push_str(&format!(
+            "\t\t\t+ This update: {}\n",
+            single.this_update.0.to_date_time()
+        ));
+        if let Some(next) = &single.next_update {
+            out.push_str(&format!("\t\t\t+ Next update: {}\n", next.0.to_date_time()));
+        }
+        out.push_str(&format!(
+            "\t\t\t+ Certificate serial number: 0x{}\n",
+            buffer_to_hex(single.cert_id.serial_number.as_bytes())
+        ));
+        match &single.cert_status {
+            CertStatus::Good(_) => out.push_str("\t\t\t+ Certificate status: not revoked\n"),
+            CertStatus::Revoked(info) => {
+                out.push_str("\t\t\t+ Certificate status: revoked\n");
+                out.push_str(&format!(
+                    "\t\t\t+ Revocation time: {}\n",
+                    info.revocation_time.0.to_date_time()
+                ));
+                if let Some(reason) = info.revocation_reason {
+                    out.push_str(&format!("\t\t\t+ Revocation reason: {reason:?}\n"));
+                }
+            }
+            CertStatus::Unknown(_) => out.push_str("\t\t\t+ Certificate status: unknown\n"),
+        }
+    }
+    out
+}
+
+/// Renders a Unix epoch second count the way every other time in the manifest reads.
+///
+/// `CrlInfo` keeps its times as epoch seconds while a certificate's and an OCSP response's arrive as
+/// ASN.1 times, so without this the same manifest reports one CRL as `1787147411` and the response
+/// beside it as `2026-08-18T14:20:24Z`. Falls back to the raw number if the value is not a time this
+/// can represent, which beats printing nothing.
+#[cfg(feature = "revocation")]
+fn unix_secs_as_time(secs: u64) -> String {
+    match GeneralizedTime::from_unix_duration(core::time::Duration::from_secs(secs)) {
+        Ok(t) => t.to_date_time().to_string(),
+        Err(_) => secs.to_string(),
+    }
+}
+
+/// Renders one CRL's details from the compact [`CrlInfo`] the results retain.
+///
+/// The CRL body is not held there, so this reports where it came from as well as what it is: a
+/// bundle may carry the note rather than the CRL, and a reader has to be able to tell which.
+#[cfg(feature = "revocation")]
+fn render_crl_details(info: &CrlInfo) -> String {
+    let mut out = format!("\t\t\t+ CRL issuer: {}\n", info.issuer_name);
+    if let Some(idp) = &info.idp_name {
+        out.push_str(&format!("\t\t\t+ Issuing distribution point: {idp}\n"));
+    }
+    out.push_str(&format!(
+        "\t\t\t+ This update: {}\n",
+        unix_secs_as_time(info.this_update)
+    ));
+    if let Some(next) = info.next_update {
+        out.push_str(&format!(
+            "\t\t\t+ Next update: {}\n",
+            unix_secs_as_time(next)
+        ));
+    }
+    if let Some(uri) = &info.uri {
+        out.push_str(&format!("\t\t\t+ Retrieved from: {uri}\n"));
+    }
+    out
+}
+
 /// Writes a CRL artifact into the manifest folder from the compact [`CrlInfo`] now retained in the
 /// results (the results no longer carry the full CRL body). When the CRL was loaded from a folder
 /// its cached bytes are copied out as a `.crl`; when it is only known by URI (e.g., fetched remotely
 /// and not retained) a `.crl.txt` note is written recording where the full CRL can be re-obtained
 /// along with its validity window.
+#[cfg(feature = "std_app")]
 fn write_crl_artifact(np: &Path, stem: &str, info: &CrlInfo) {
     if let Some(filename) = &info.filename {
         let p = np.join(format!("{stem}.crl"));
@@ -620,6 +922,7 @@ fn write_crl_artifact(np: &Path, stem: &str, info: &CrlInfo) {
 /// `log_path` contributes to the manifest file related to
 /// [`CertificationPath`](../certval/path_settings/struct.CertificationPath.html) contents as well
 /// as output generated by [`log_cps`] and [`log_cpr`].
+#[cfg(feature = "std_app")]
 pub fn log_path(
     pe: &PkiEnvironment,
     f: &Option<String>,
@@ -681,6 +984,26 @@ pub fn log_path(
             error!("Failed to create manifest file");
             return;
         };
+        render_path_manifest(pe, &mut f, path, cpr, cps);
+        write_cpr_artifacts(&np, cpr);
+    }
+}
+
+/// Renders the manifest describing one certification path: the algorithm inputs, the path's
+/// certificates, the validation outputs and the revocation determination details.
+///
+/// This is the whole of the manifest and the only place it is composed, so the file a results-folder
+/// run writes and the entry an archive carries are the same document rather than two that agree
+/// until one is edited. Nothing here touches a filesystem -- a caller supplies a `File`, a `Vec<u8>`,
+/// or anything else that writes.
+pub fn render_path_manifest(
+    pe: &PkiEnvironment,
+    f: &mut dyn Write,
+    path: &CertificationPath,
+    cpr: &CertificationPathResults,
+    cps: Option<&CertificationPathSettings>,
+) {
+    {
         let s = get_filename_from_metadata(&path.target);
         f.write_all(format!("Certification path validation results for: {s}\n\n").as_bytes())
             .expect("Unable to write manifest file");
@@ -697,7 +1020,7 @@ pub fn log_path(
         )
         .expect("Unable to write manifest file");
         if let Some(cps) = cps {
-            log_cps(&mut f, cps);
+            log_cps(f, cps);
         } else {
             f.write_all("None".as_bytes())
                 .expect("Unable to write manifest file");
@@ -716,17 +1039,17 @@ pub fn log_path(
         .expect("Unable to write manifest file");
         f.write_all("\t+ Trust Anchor\n".as_bytes())
             .expect("Unable to write manifest file");
-        log_ta_details(pe, &mut f, &path.trust_anchor);
+        log_ta_details(pe, f, &path.trust_anchor);
 
         for (i, c) in path.intermediates.iter().enumerate() {
             f.write_all(format!("\t+ Certificate #{}\n", i + 1).as_bytes())
                 .expect("Unable to write manifest file");
-            log_cert_details(pe, &mut f, c);
+            log_cert_details(pe, f, c);
         }
 
         f.write_all("\t+ Target Certificate\n".as_bytes())
             .expect("Unable to write manifest file");
-        log_cert_details(pe, &mut f, &path.target);
+        log_cert_details(pe, f, &path.target);
 
         f.write_all(
             "\n********************************************************************************\n"
@@ -740,7 +1063,8 @@ pub fn log_path(
                 .as_bytes(),
         )
         .expect("Unable to write manifest file");
-        log_cpr(pe, &mut f, &np, cpr);
+        render_cpr(f, cpr);
+        render_revocation_details(f, path, cpr);
     }
 }
 

--- a/pittv3-lib/src/report.rs
+++ b/pittv3-lib/src/report.rs
@@ -12,7 +12,9 @@ use alloc::string::{String, ToString};
 use alloc::vec;
 use alloc::vec::Vec;
 
+use der::Encode;
 use serde::{Deserialize, Serialize};
+use sha2::{Digest, Sha256};
 
 use certval::{
     get_certificate_from_trust_anchor, is_self_signed,
@@ -37,6 +39,26 @@ pub struct CertSummary {
     pub not_before: Option<String>,
     /// notAfter rendered as a string, absent when unavailable
     pub not_after: Option<String>,
+    /// Uppercase ASCII hex SHA-256 of the DER-encoded certificate, absent for a trust anchor
+    /// expressed as name and public key without a wrapped certificate.
+    ///
+    /// The other fields describe a certificate; this one identifies it. Subject, issuer and serial
+    /// are rendered for reading and are not a key: two certificates can share all three (a reissue
+    /// under a rotated key, a cross-certificate), and none of them can get from a row of a report
+    /// back to the bytes the row describes. A caller holding the run's artifacts — to offer a
+    /// download, to name a file, to tell whether two reports describe the same certificate — needs
+    /// something derived from the encoding, and the digest is the same value whether the
+    /// certificate was seen as a trust anchor, an intermediate or a target.
+    ///
+    /// Taken over the certificate itself for a trust anchor that wraps one, rather than over the
+    /// `TrustAnchorChoice` around it, so that one certificate has one identity no matter which role
+    /// a path gave it.
+    pub sha256: Option<String>,
+}
+
+/// Uppercase ASCII hex SHA-256 of `der`, the identity [`CertSummary::sha256`] carries.
+pub fn sha256_hex(der: &[u8]) -> String {
+    buffer_to_hex(Sha256::digest(der).to_vec().as_slice())
 }
 
 impl CertSummary {
@@ -49,11 +71,12 @@ impl CertSummary {
             serial: Some(buffer_to_hex(tbs.serial_number().as_bytes())),
             not_before: Some(tbs.validity().not_before.to_string()),
             not_after: Some(tbs.validity().not_after.to_string()),
+            sha256: Some(sha256_hex(cert.as_bytes())),
         }
     }
 
-    /// Prepares a [`CertSummary`] from a parsed trust anchor. Serial number and validity are only
-    /// available when the trust anchor wraps a certificate.
+    /// Prepares a [`CertSummary`] from a parsed trust anchor. Serial number, validity and digest are
+    /// only available when the trust anchor wraps a certificate.
     pub fn from_trust_anchor(ta: &PDVTrustAnchorChoice) -> CertSummary {
         if let Some(cert) = get_certificate_from_trust_anchor(&ta.decoded_ta) {
             let tbs = cert.tbs_certificate();
@@ -63,6 +86,13 @@ impl CertSummary {
                 serial: Some(buffer_to_hex(tbs.serial_number().as_bytes())),
                 not_before: Some(tbs.validity().not_before.to_string()),
                 not_after: Some(tbs.validity().not_after.to_string()),
+                // Over the certificate rather than over `ta.encoded_ta`, which is the
+                // TrustAnchorChoice wrapping it: the same certificate reached as an intermediate on
+                // another path must produce the same digest, or the identity is a description of the
+                // role instead of the material. A certificate that will not re-encode leaves this
+                // absent rather than falling back to the wrapper's digest, since a wrong identity is
+                // worse than none.
+                sha256: cert.to_der().ok().map(|der| sha256_hex(&der)),
             };
         }
 
@@ -76,6 +106,7 @@ impl CertSummary {
             serial: None,
             not_before: None,
             not_after: None,
+            sha256: None,
         }
     }
 }
@@ -838,6 +869,7 @@ mod tests {
                     serial: Some("01FF".to_string()),
                     not_before: Some("2026-01-01T00:00:00Z".to_string()),
                     not_after: Some("2027-01-01T00:00:00Z".to_string()),
+                    sha256: Some("A1B2C3".to_string()),
                 }),
                 status: TargetStatus::Invalid,
                 paths: vec![PathReport {

--- a/pittv3-service/src/orchestrate.rs
+++ b/pittv3-service/src/orchestrate.rs
@@ -154,7 +154,7 @@ async fn run(
     // them. Scoping it here keeps a request's answers derived under that request's settings.
     let rev_cache = Arc::new(RevocationCache::new());
     let (prepared, mut lines) =
-        match prepare_validation(store, &input.trust_anchors, cas, settings, &rev_cache) {
+        match prepare_validation(store, &input.trust_anchors, cas, settings, Some(&rev_cache)) {
             Ok((prepared, lines)) => (
                 prepared,
                 lines

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -19,13 +19,14 @@ use pittv3_gui_lib::settings_store::SettingsStore;
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::report::{TargetReport, ValidationReport};
 
+use pittv3_gui_lib::export::{path_entries, paths_text, zip_paths};
 use pittv3_gui_lib::retrieval::harvest_revocation_work;
 
 use crate::relay::{chase_certificates, retrieve_crls, retrieve_ocsp, FetchBudget, Tier};
 use crate::validate::{
     merge_service_stores, prepare_validation, shipped_catalog, validate_hackathon_zip,
-    validate_prepared, PreparedValidation, ResultLine, StoreDescriptor, SAMPLE_INVALID,
-    SAMPLE_VALID,
+    validate_prepared, validate_prepared_retaining, PreparedValidation, ResultLine, RetainedPath,
+    StoreDescriptor, SAMPLE_INVALID, SAMPLE_VALID,
 };
 
 /// Store selection value indicating no baked-in store, i.e., uploaded trust anchors only
@@ -54,6 +55,13 @@ const SETTINGS_KEY: &str = "pittv3.settings";
 /// interchange format.
 #[cfg_attr(not(target_family = "wasm"), allow(dead_code))]
 const VALIDATE_ALL_KEY: &str = "pittv3.validate_all";
+
+/// localStorage key for whether the revocation status cache is used. A run option like
+/// [`VALIDATE_ALL_KEY`] and kept out of the settings for the same reason: it decides how a run goes
+/// about reaching an answer, not what a path has to satisfy, and certval has no such setting -- the
+/// cache is something a frontend registers on the environment or does not.
+#[cfg_attr(not(target_family = "wasm"), allow(dead_code))]
+const REV_CACHE_KEY: &str = "pittv3.use_rev_cache";
 
 /// Sidebar views in display order
 const VIEW_LABELS: &[&str] = &[
@@ -130,6 +138,13 @@ impl SettingsStore for LocalStorageSettingsStore {
 /// Reads the persisted validate-all choice, defaulting to true (explore every discovered path)
 fn load_validate_all() -> bool {
     storage_get(VALIDATE_ALL_KEY)
+        .map(|v| v == "true")
+        .unwrap_or(true)
+}
+
+/// Reads the persisted revocation-cache choice, defaulting to true (reuse determinations)
+fn load_use_rev_cache() -> bool {
+    storage_get(REV_CACHE_KEY)
         .map(|v| v == "true")
         .unwrap_or(true)
 }
@@ -266,6 +281,12 @@ fn App() -> Element {
     // remount and pick the new values up.
     let mut form_gen = use_signal(|| 0usize);
     let mut validate_all = use_signal(load_validate_all);
+    // Whether determinations reached for one path may answer for another. On, a certificate checked
+    // once is not checked again, which is much faster and is what a user validating certificates
+    // wants. Off, every path derives every status from revocation data of its own -- which is what a
+    // user *exporting* a path wants, since a hop answered from cache carries a status and no
+    // evidence to hand anyone.
+    let mut use_rev_cache = use_signal(load_use_rev_cache);
     // Transient status line for the settings-file load/save controls (cleared on next action)
     let mut settings_status = use_signal(String::new);
     let mut targets = use_signal(Vec::<TargetReport>::new);
@@ -314,6 +335,16 @@ fn App() -> Element {
     // alongside it would re-fetch revocation data a retrieval had already paid for. Settings changes
     // are the case that does invalidate them, and the effect that watches settings clears this.
     let rev_cache = use_signal(|| Arc::new(RevocationCache::new()));
+    // The paths this run validated, kept so their artifacts can be exported without validating
+    // again. Retaining costs nothing to compute -- the paths and results exist for the duration of
+    // the validation regardless -- and re-validating to produce an export would describe a
+    // different run, since revocation data moves between one click and the next.
+    let mut retained_paths = use_signal(Vec::<RetainedPath>::new);
+    // Name the export takes: the archive's file name and the single folder inside it. Offered rather
+    // than generated because a bundle is usually about to be handed to someone else, and "the DoD
+    // email cert Armen reported" survives that trip where a timestamp does not. PITTv2 prompts for
+    // the same thing.
+    let mut export_name = use_signal(|| "PITTv3Results".to_string());
 
     // What asking a service for its stores produced, in a sentence, for the Resources view. A
     // statically hosted copy finding no service is the ordinary case and not a failure, but "the
@@ -405,6 +436,18 @@ fn App() -> Element {
         );
     });
 
+    // Whether to use the cache is decided when the environment is prepared, because that is when the
+    // cache is registered on it -- so changing this has to make the environment stale, or the choice
+    // would not take effect until something else happened to force a rebuild. Clearing on the way is
+    // deliberate: turning the cache off and on again must not bring back determinations reached
+    // before it was turned off, which are exactly the ones the user was trying to stop reusing.
+    use_effect(move || {
+        let on = use_rev_cache();
+        let _ = storage_set(REV_CACHE_KEY, if on { "true" } else { "false" });
+        rev_cache().clear();
+        env_dirty.set(true);
+    });
+
     // The store selection and uploaded trust anchors / CA certificates also feed the prepared
     // environment; reading them here subscribes this effect so any change marks it stale.
     use_effect(move || {
@@ -485,6 +528,70 @@ fn App() -> Element {
         let js = format!(
             "const a = document.createElement('a'); a.href = \"{uri}\"; a.download = \"pittv3-results-{}.json\"; a.click();",
             now_as_unix_epoch()
+        );
+        let _ = dioxus::document::eval(&js);
+    };
+
+    // Builds the per-path export entries once for whichever export was asked for, so the archive and
+    // the log describe the same paths in the same order.
+    let build_entries = move || -> Vec<Vec<(String, Vec<u8>)>> {
+        let guard = prepared_env.read();
+        let Some((prepared, _)) = guard.as_ref() else {
+            return vec![];
+        };
+        retained_paths
+            .read()
+            .iter()
+            .map(|r| path_entries(prepared.environment(), &r.path, Some(&r.cps), &r.cpr))
+            .collect()
+    };
+
+    // downloads every validated path's artifacts as a zip: the certificates, the revocation data
+    // consulted, the responder certificates that make an OCSP response checkable, and a manifest per
+    // path. Paths are numbered from one under the export's name.
+    let save_artifacts = move |_| {
+        use base64::engine::general_purpose::STANDARD;
+        use base64::Engine as _;
+        let entries = build_entries();
+        if entries.is_empty() {
+            notes.write().push(ResultLine {
+                class: "err",
+                text: "No validated paths are held from this run to export".to_string(),
+            });
+            return;
+        }
+        let name = export_name();
+        match zip_paths(&name, &entries) {
+            Ok(zipped) => {
+                let js = format!(
+                    "const a = document.createElement('a'); a.href = \"data:application/zip;base64,{}\"; a.download = \"{name}.zip\"; a.click();",
+                    STANDARD.encode(&zipped)
+                );
+                let _ = dioxus::document::eval(&js);
+            }
+            Err(e) => notes.write().push(ResultLine {
+                class: "err",
+                text: format!("Failed to build the archive: {e}"),
+            }),
+        }
+    };
+
+    // downloads the manifests alone -- every path's account of itself, one after another, without the
+    // material behind them
+    let save_path_logs = move |_| {
+        let entries = build_entries();
+        let text = paths_text(&entries);
+        if text.is_empty() {
+            notes.write().push(ResultLine {
+                class: "err",
+                text: "No validated paths are held from this run to export".to_string(),
+            });
+            return;
+        }
+        let name = export_name();
+        let uri = format!("data:text/plain;charset=utf-8,{}", percent_encode(&text));
+        let js = format!(
+            "const a = document.createElement('a'); a.href = \"{uri}\"; a.download = \"{name}.txt\"; a.click();"
         );
         let _ = dioxus::document::eval(&js);
     };
@@ -581,7 +688,12 @@ fn App() -> Element {
         // than for path building.
         let mut cas = uploaded_cas();
         cas.extend(chased_cas());
-        match prepare_validation(store, &uploaded_tas(), &cas, &cps, &rev_cache()) {
+        let cache = if use_rev_cache() {
+            Some(rev_cache())
+        } else {
+            None
+        };
+        match prepare_validation(store, &uploaded_tas(), &cas, &cps, cache.as_ref()) {
             Ok(prepared) => {
                 prepared_env.set(Some(prepared));
                 env_dirty.set(false);
@@ -695,7 +807,9 @@ fn App() -> Element {
         let guard = prepared_env.read();
         let (prepared, prep_notes) = guard.as_ref().unwrap();
         notes.write().extend(prep_notes.iter().cloned());
-        let (reports, lines) = validate_prepared(prepared, &cps, &loaded_ees(), validate_all());
+        let (reports, lines, retained) =
+            validate_prepared_retaining(prepared, &cps, &loaded_ees(), validate_all(), true);
+        retained_paths.set(retained);
         drop(guard);
         notes.write().extend(lines);
         targets.write().extend(reports);
@@ -897,6 +1011,21 @@ fn App() -> Element {
                         }
 
                         div { class: "controls center-row",
+                            label { r#for: "use-rev-cache", "Reuse revocation determinations: " }
+                            input {
+                                id: "use-rev-cache",
+                                r#type: "checkbox",
+                                checked: use_rev_cache(),
+                                onchange: move |ev| use_rev_cache.set(ev.checked()),
+                            }
+                            span { class: "hint",
+                                "On, a certificate checked on one path is not checked again on another. "
+                                "Off, every path obtains its own revocation data — slower, but each path "
+                                "then carries the evidence for its own result, which an export needs."
+                            }
+                        }
+
+                        div { class: "controls center-row",
                             button {
                                 class: "validate-button",
                                 disabled: loaded_ees().is_empty() || validating(),
@@ -963,12 +1092,33 @@ fn App() -> Element {
                                     button {
                                         disabled: targets.read().is_empty(),
                                         onclick: save_results,
-                                        "Save"
+                                        title: "Download the structured report as JSON",
+                                        "Save report"
+                                    }
+                                    button {
+                                        disabled: retained_paths.read().is_empty(),
+                                        onclick: save_path_logs,
+                                        title: "Download every path's manifest as one text file",
+                                        "Save path logs"
+                                    }
+                                    button {
+                                        disabled: retained_paths.read().is_empty(),
+                                        onclick: save_artifacts,
+                                        title: "Download the certificates and revocation data behind every path, as a zip",
+                                        "Save artifacts"
+                                    }
+                                    input {
+                                        r#type: "text",
+                                        class: "export-name",
+                                        value: "{export_name}",
+                                        title: "Name for the export: the archive and the folder inside it",
+                                        oninput: move |e| export_name.set(e.value()),
                                     }
                                     button {
                                         onclick: move |_| {
                                             targets.write().clear();
                                             notes.write().clear();
+                                            retained_paths.write().clear();
                                         },
                                         "Clear"
                                     }

--- a/pittv3-wasm/src/validate.rs
+++ b/pittv3-wasm/src/validate.rs
@@ -258,7 +258,7 @@ mod tests {
         // nothing should carry over between them.
         let rev_cache = std::sync::Arc::new(RevocationCache::new());
         let (prepared, prep_notes) =
-            prepare_validation(Some(store), &[], &[], cps, &rev_cache).unwrap();
+            prepare_validation(Some(store), &[], &[], cps, Some(&rev_cache)).unwrap();
         notes.extend(prep_notes);
         let (reports, lines) = validate_prepared(&prepared, cps, ees, true);
         notes.extend(lines);


### PR DESCRIPTION
- add three buttons that imitate pittv2 to support exporting information from validated paths
- generated text manifest and zip file are similar to pittv2's output (the json format is new and may not stick)
- add a checkbox to govern the use of a revocation cache (off forces reliance on artifacts not past decisions)()