### PR TITLE
Various pittv3-wasm changes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5169,6 +5169,7 @@ dependencies = [
  "serde_json",
  "web-time",
  "x509-cert",
+ "x509-ocsp",
  "zip",
 ]
 

--- a/certval/src/builder/file_utils.rs
+++ b/certval/src/builder/file_utils.rs
@@ -11,7 +11,6 @@ use x509_cert::anchor::TrustAnchorChoice;
 use x509_cert::certificate::{CertificateInner, Raw};
 
 use crate::source::cert_source::CertFile;
-use crate::util::pdv_utilities::*;
 use crate::*;
 
 #[cfg(feature = "std")]

--- a/certval/src/builder/uri_utils.rs
+++ b/certval/src/builder/uri_utils.rs
@@ -6,7 +6,6 @@ use const_oid::db::rfc5912::{
 };
 use x509_cert::ext::pkix::name::GeneralName;
 
-use crate::util::pdv_utilities::*;
 use crate::*;
 
 #[cfg(feature = "remote")]

--- a/pittv3-gui-lib/Cargo.toml
+++ b/pittv3-gui-lib/Cargo.toml
@@ -26,6 +26,10 @@ x509-cert = { version = "0.3.0", default-features = false }
 # CRL is decoded once when it is stored. Both are already in the graph via certval, so naming them
 # here adds no crate to any frontend's build.
 cms = { version = "0.3.0-pre.2", default-features = false }
+# Only used to read an *uploaded* OCSP response well enough to work out which certificate it
+# answers about (see `retrieval::staple_uploaded_ocsp`). Judging the response remains certval's
+# job -- nothing here decides revocation status. Version tracks certval's so one x509-ocsp resolves.
+x509-ocsp = { version = "0.3.0-pre", default-features = false }
 der = { version = "0.8.1", default-features = false, features = ["alloc", "oid"] }
 
 # No renderer here -- each frontend names its own (web or desktop). devtools is left off because

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -182,12 +182,17 @@ fn lines_join(values: &[String]) -> String {
 }
 
 /// Table row with a labeled checkbox showing the effective value of a boolean setting; the hint
-/// marks fields carrying an override versus the default
+/// marks fields carrying an override versus the default.
+///
+/// `default_note` replaces the bare "default" hint for a field whose unset value does not resolve to
+/// certval's default in this frontend. Without it the row would say "default" beside a value certval
+/// would not have chosen, which is true of neither reading.
 #[component]
 fn BoolRow(
     label: &'static str,
     checked: bool,
     overridden: bool,
+    #[props(default)] default_note: Option<&'static str>,
     onchange: EventHandler<bool>,
 ) -> Element {
     rsx! {
@@ -205,7 +210,7 @@ fn BoolRow(
                     if overridden {
                         "override"
                     } else {
-                        "default"
+                        {default_note.unwrap_or("default")}
                     }
                 }
             }
@@ -551,6 +556,15 @@ const TABS: &[(SettingsTab, &str)] = &[
 pub fn EditSettings(
     initial: SettingsModel,
     #[props(default)] caps: Capabilities,
+    /// What an *unset* `check_revocation_status` resolves to for the run this frontend will make.
+    ///
+    /// certval's default is true, but a frontend may resolve an unset value differently: the browser
+    /// turns it on only when the run can obtain revocation data, by retrieving it or by being handed
+    /// it. Stating the outcome here keeps the form honest without gui-lib re-implementing the rule --
+    /// the frontend that owns the rule reports it, and this only displays it. `None` means certval's
+    /// default applies, which is the case for the desktop and the CLI.
+    #[props(default)]
+    revocation_default: Option<bool>,
     on_save: EventHandler<SettingsModel>,
     on_close: EventHandler<()>,
 ) -> Element {
@@ -769,8 +783,17 @@ pub fn EditSettings(
                             tbody {
                                 BoolRow {
                                     label: "Check revocation status (master)",
-                                    checked: m.check_revocation_status.unwrap_or(true),
+                                    checked: m.check_revocation_status
+                                        .unwrap_or(revocation_default.unwrap_or(true)),
                                     overridden: m.check_revocation_status.is_some(),
+                                    // Only when this frontend's unset value disagrees with certval's,
+                                    // so the ordinary case still reads plainly as "default".
+                                    default_note: match revocation_default {
+                                        Some(false) => {
+                                            Some("default — off for this run; tick to check anyway")
+                                        }
+                                        _ => None,
+                                    },
                                     onchange: move |v| model.write().check_revocation_status = Some(v),
                                 }
                                 BoolRow {

--- a/pittv3-gui-lib/src/retrieval.rs
+++ b/pittv3-gui-lib/src/retrieval.rs
@@ -42,7 +42,7 @@ use x509_cert::crl::CertificateList;
 #[cfg(feature = "revocation")]
 use x509_ocsp::{BasicOcspResponse, CertId, OcspRequest, OcspResponse, OcspResponseStatus};
 
-use crate::validate::PreparedValidation;
+use crate::validate::{maybe_pem, PreparedValidation};
 
 /// Extracts the certificates from a retrieved body, which by convention is either a single
 /// DER-encoded certificate or a certs-only SignedData message, i.e., a `.p7c`. The message form is
@@ -77,8 +77,15 @@ pub fn certificates_in(body: &[u8]) -> Vec<Vec<u8>> {
 /// run being made.
 pub fn harvest_chase_uris(certs: &[(String, Vec<u8>)]) -> Vec<String> {
     let mut uris = vec![];
-    for (name, der) in certs {
-        if let Ok(cert) = parse_cert(der, name) {
+    for (name, bytes) in certs {
+        // PEM or DER: a caller's certificate arrives in whichever form its file held, and
+        // `parse_cert` takes DER only. Decoding here rather than trusting the caller keeps this in
+        // step with `validate_target`, which has always accepted both -- the two disagreeing is
+        // what let a PEM target validate normally while silently contributing no URIs.
+        let Ok(der) = maybe_pem(bytes) else {
+            continue;
+        };
+        if let Ok(cert) = parse_cert(&der, name) {
             collect_uris_from_aia_and_sia(&cert, &mut uris);
         }
     }
@@ -244,8 +251,13 @@ pub fn harvest_revocation_work(
     #[cfg(feature = "revocation")]
     let mut asked: Vec<(OcspKey, String)> = vec![];
 
-    for (name, der) in ees {
-        let Ok(target) = parse_cert(der, name) else {
+    for (name, bytes) in ees {
+        // See the note in `harvest_chase_uris`: decode PEM before parsing, because `validate_target`
+        // does and a target that validates must also be one this can find work for.
+        let Ok(der) = maybe_pem(bytes) else {
+            continue;
+        };
+        let Ok(target) = parse_cert(&der, name) else {
             continue;
         };
         if pe.is_cert_a_trust_anchor(&target).is_ok() {
@@ -536,8 +548,13 @@ pub fn staple_uploaded_ocsp(
     let mut examined = 0usize;
     let mut unaskable = 0usize;
 
-    for (name, der) in ees {
-        let Ok(target) = parse_cert(der, name) else {
+    for (name, bytes) in ees {
+        // See the note in `harvest_chase_uris`: decode PEM before parsing, because `validate_target`
+        // does and a target that validates must also be one this can find work for.
+        let Ok(der) = maybe_pem(bytes) else {
+            continue;
+        };
+        let Ok(target) = parse_cert(&der, name) else {
             continue;
         };
         if pe.is_cert_a_trust_anchor(&target).is_ok() {
@@ -819,6 +836,54 @@ mod tests {
         assert!(
             note.contains("examined 1 certificate(s)"),
             "the note should say how many candidates were compared; got {note}"
+        );
+    }
+
+    /// PEM and DER of the *same* certificate must yield the same work.
+    ///
+    /// The regression: `validate_target` decoded PEM and the harvest did not, so a PEM target
+    /// validated normally while contributing nothing to retrieve. Revocation then came back
+    /// undetermined with no note explaining it, because an empty work list means the retrieval
+    /// loops never run. Cost an afternoon on 2026-08-20 against `www.amazon.com.pem`.
+    ///
+    /// Asserted as an equality between encodings rather than against a fixed list, so the test
+    /// stays true if the fixture is reissued, and with a non-empty check so it cannot pass by both
+    /// sides returning nothing -- which is exactly how the bug behaved.
+    #[test]
+    fn pem_and_der_of_the_same_certificate_harvest_alike() {
+        let der = include_bytes!("../../certval/tests/examples/amazon.com/2-target.der").to_vec();
+        let pem = include_bytes!("../../certval/tests/examples/amazon.com/2-target.pem").to_vec();
+        assert_ne!(der, pem, "fixtures must genuinely differ in encoding");
+
+        let from_der = harvest_chase_uris(&[("2-target.der".to_string(), der)]);
+        let from_pem = harvest_chase_uris(&[("2-target.pem".to_string(), pem)]);
+
+        assert!(
+            !from_der.is_empty(),
+            "the DER fixture should name at least one AIA/SIA URI, or this test proves nothing"
+        );
+        assert_eq!(
+            from_der, from_pem,
+            "a PEM certificate must harvest the same URIs as its DER form"
+        );
+    }
+
+    /// The same equality for the byte-level helper the fix rests on, so a regression in `maybe_pem`
+    /// is reported here rather than as an unexplained empty work list somewhere downstream.
+    #[test]
+    fn maybe_pem_yields_identical_der_for_both_encodings() {
+        use crate::validate::maybe_pem;
+        let der = include_bytes!("../../certval/tests/examples/amazon.com/2-target.der").to_vec();
+        let pem = include_bytes!("../../certval/tests/examples/amazon.com/2-target.pem").to_vec();
+        assert_eq!(
+            maybe_pem(&der).unwrap(),
+            der,
+            "DER must pass through unchanged"
+        );
+        assert_eq!(
+            maybe_pem(&pem).unwrap(),
+            der,
+            "PEM must decode to the same DER"
         );
     }
 

--- a/pittv3-gui-lib/src/retrieval.rs
+++ b/pittv3-gui-lib/src/retrieval.rs
@@ -35,7 +35,12 @@ use cms::content_info::ContentInfo;
 use cms::signed_data::SignedData;
 use der::{Decode, Encode};
 use x509_cert::certificate::Raw;
+// Only the CertID comparison is generic over the profile, and that exists only with `revocation`.
+#[cfg(feature = "revocation")]
+use x509_cert::certificate::Profile;
 use x509_cert::crl::CertificateList;
+#[cfg(feature = "revocation")]
+use x509_ocsp::{BasicOcspResponse, CertId, OcspRequest, OcspResponse, OcspResponseStatus};
 
 use crate::validate::PreparedValidation;
 
@@ -429,6 +434,240 @@ impl CrlSource for MemoryCrlSource {
     }
 }
 
+/// Adds a CRL the user supplied by hand, accepting either DER or PEM.
+///
+/// This is the no-network counterpart to retrieving one: the checker cannot tell the difference,
+/// because both end up in the same [`MemoryCrlSource`] and are judged the same way by certval's
+/// `process_crl`. Returns whether it was a CRL at all — a file that is not one is reported rather
+/// than stored, for the same reason [`MemoryCrlSource::add`] reports it.
+pub fn add_uploaded_crl(prepared: &PreparedValidation, bytes: &[u8]) -> bool {
+    if prepared.crl_source().add(bytes) {
+        return true;
+    }
+    // PEM is worth a second try rather than a separate button: a CRL saved out of another tool is
+    // as likely to be armored as not, and the user should not have to know which they have.
+    match pem_rfc7468::decode_vec(bytes) {
+        Ok((_label, der)) => prepared.crl_source().add(&der),
+        Err(_) => false,
+    }
+}
+
+/// What offering an uploaded OCSP response to a run came to.
+#[derive(Clone, Debug, Default)]
+pub struct OcspStapleOutcome {
+    /// How many (certificate, issuer) pairs on the paths this run builds the response answers for.
+    pub matched: usize,
+    /// What happened, in terms a user can act on.
+    pub notes: Vec<String>,
+}
+
+/// Reads the `CertID`s an OCSP response answers about, or says why it answers about none.
+///
+/// Split out from [`staple_uploaded_ocsp`] because it is the half that depends only on the bytes:
+/// everything it can reject, it rejects without a prepared environment or a path in sight.
+#[cfg(feature = "revocation")]
+fn answered_cert_ids(bytes: &[u8]) -> core::result::Result<Vec<CertId>, String> {
+    let response = OcspResponse::from_der(bytes).map_err(|_| "Not an OCSP response".to_string())?;
+    if response.response_status != OcspResponseStatus::Successful {
+        return Err(format!(
+            "OCSP response reports {:?} rather than an answer",
+            response.response_status
+        ));
+    }
+    let rb = response
+        .response_bytes
+        .as_ref()
+        .ok_or_else(|| "OCSP response carries no response bytes".to_string())?;
+    let basic = BasicOcspResponse::from_der(rb.response.as_bytes())
+        .map_err(|_| "OCSP response body could not be read".to_string())?;
+    let ids: Vec<CertId> = basic
+        .tbs_response_data
+        .responses
+        .iter()
+        .map(|single| single.cert_id.clone())
+        .collect();
+    match ids.is_empty() {
+        true => Err("OCSP response answers about no certificate".to_string()),
+        false => Ok(ids),
+    }
+}
+
+/// Files an OCSP response the user supplied by hand against whichever certificates it answers
+/// about, so a no-network run can determine revocation status from it.
+///
+/// **The response says what it is about, so the user does not have to.** An OCSP `CertID` names the
+/// hash of the issuer's name and public key together with the certificate's serial number, which is
+/// exactly the identity [`OcspKey`] is built on. So rather than asking which certificate a file
+/// concerns, this walks the (certificate, issuer) pairs on the paths the environment builds, asks
+/// certval to build the request it *would* have sent for each, and files the response against every
+/// pair whose `CertID` the response answers. One response can match more than one pair, and a
+/// response matching none is reported rather than stored.
+///
+/// Building the request rather than re-hashing the issuer here is deliberate: it makes the match
+/// certval's own notion of identity by construction, and the hash helpers are private to certval
+/// anyway. It also means the comparison inherits certval's SHA-1 `CertID`, so a response built with
+/// a different hash algorithm cannot be matched this way — which is reported, not swallowed.
+#[cfg(feature = "revocation")]
+pub fn staple_uploaded_ocsp(
+    prepared: &PreparedValidation,
+    cps: &CertificationPathSettings,
+    ees: &[(String, Vec<u8>)],
+    bytes: &[u8],
+) -> OcspStapleOutcome {
+    let mut out = OcspStapleOutcome::default();
+
+    let answered = match answered_cert_ids(bytes) {
+        Ok(ids) => ids,
+        Err(note) => {
+            out.notes.push(note);
+            return out;
+        }
+    };
+
+    let pe = prepared.environment();
+    let toi = cps.get_time_of_interest();
+    let sink = prepared.ocsp_responses();
+    // A certificate sits on more than one path, and under the same issuer each time; file once.
+    let mut filed: Vec<OcspKey> = vec![];
+    // Counted so a miss can say what was looked at. "Examined none" and "examined nine and none
+    // matched" are different problems -- the first is a path that did not build, the second a
+    // response about something else -- and a note that cannot tell them apart sends the reader to
+    // the wrong place.
+    let mut examined = 0usize;
+    let mut unaskable = 0usize;
+
+    for (name, der) in ees {
+        let Ok(target) = parse_cert(der, name) else {
+            continue;
+        };
+        if pe.is_cert_a_trust_anchor(&target).is_ok() {
+            continue;
+        }
+        let mut paths: Vec<CertificationPath> = vec![];
+        if pe
+            .get_paths_for_target(&target, &mut paths, 0, toi)
+            .is_err()
+        {
+            continue;
+        }
+        for path in &paths {
+            let chain: Vec<&PDVCertificate> = path
+                .intermediates
+                .iter()
+                .chain(core::iter::once(&path.target))
+                .collect();
+            for (pos, cert) in chain.iter().enumerate() {
+                let issuer: &dyn SubjectNameAndKey = match pos {
+                    0 => &path.trust_anchor.decoded_ta,
+                    _ => chain[pos - 1].as_ref(),
+                };
+                let Some(key) = OcspKey::new(cert, issuer) else {
+                    continue;
+                };
+                if filed.contains(&key) {
+                    continue;
+                }
+                // Decoded under the `Raw` profile because that is the profile certval encoded it
+                // with: `build_ocsp_request` takes the serial straight off a `CertificateInner<Raw>`,
+                // and `SerialNumber<Rfc5280>` enforces a length constraint `Raw` does not. Reading
+                // it back as Rfc5280 would therefore fail for a certificate whose serial is longer
+                // than the RFC permits -- and, because the failure was a `continue`, would drop that
+                // certificate from consideration without a word. Round-tripping under the profile it
+                // was written with cannot fail that way.
+                let Ok(request) = build_ocsp_request(cert.decoded(), issuer, None) else {
+                    unaskable += 1;
+                    continue;
+                };
+                let Ok(request) = OcspRequest::<Raw>::from_der(&request) else {
+                    unaskable += 1;
+                    continue;
+                };
+                let Some(asked) = request.tbs_request.request_list.first() else {
+                    unaskable += 1;
+                    continue;
+                };
+                examined += 1;
+                if !answered.iter().any(|id| same_cert_id(id, &asked.req_cert)) {
+                    continue;
+                }
+                sink.insert(key.clone(), bytes.to_vec());
+                filed.push(key);
+                out.matched += 1;
+            }
+        }
+    }
+
+    if out.matched == 0 {
+        // Say what the response is about and what was asked, so a mismatch identifies itself. The
+        // serial is the discriminating field -- two CertIDs over the same issuer differ only there
+        // -- and the hash OID is named because certval asks with SHA-1 and a response built with a
+        // different one cannot match however right it otherwise is.
+        let about = answered
+            .iter()
+            .map(|id| hex(id.serial_number.as_bytes()))
+            .collect::<Vec<String>>()
+            .join(", ");
+        let algs = answered
+            .iter()
+            .map(|id| id.hash_algorithm.oid.to_string())
+            .collect::<Vec<String>>();
+        let non_sha1 = algs.iter().any(|oid| oid != SHA1_OID);
+        let mut note = format!(
+            "OCSP response answers about serial(s) {about}; examined {examined} certificate(s) on \
+             the paths built for the loaded certificates and none is that certificate."
+        );
+        if examined == 0 {
+            note.push_str(
+                " No certificate was examined at all, so no path was built -- check the trust \
+                 anchor and intermediates before the response.",
+            );
+        }
+        if non_sha1 {
+            note.push_str(&format!(
+                " The response uses CertID hash {}, while the comparison is made with SHA-1 \
+                 ({SHA1_OID}), so it cannot be matched this way.",
+                algs.join(", ")
+            ));
+        }
+        if unaskable > 0 {
+            note.push_str(&format!(
+                " {unaskable} certificate(s) could not have a request built for them and were not \
+                 compared."
+            ));
+        }
+        out.notes.push(note);
+    }
+    out
+}
+
+/// The OID certval builds a `CertID` with, named so a miss can report a response that used another.
+#[cfg(feature = "revocation")]
+const SHA1_OID: &str = "1.3.14.3.2.26";
+
+/// Lowercase hex, for naming a serial in a note.
+#[cfg(feature = "revocation")]
+fn hex(bytes: &[u8]) -> String {
+    bytes.iter().map(|b| format!("{b:02X}")).collect()
+}
+
+/// Compares two `CertID`s on the four things that identify a certificate to a responder.
+///
+/// The hash algorithm is compared **by OID alone**, deliberately. An `AlgorithmIdentifier` carries
+/// optional parameters, and absent-versus-NULL is a split real implementations sit on both sides
+/// of; a derived equality would therefore reject a response that answers exactly the question that
+/// was asked. The three values that follow are what actually identify the certificate.
+///
+/// Generic over the two profiles because the two sides arrive under different ones: the response is
+/// read as `Rfc5280`, the request certval built is read back as `Raw`. The comparison is on the
+/// encoded values, which are profile-independent, so this is a widening rather than a loosening.
+#[cfg(feature = "revocation")]
+fn same_cert_id<A: Profile, B: Profile>(a: &CertId<A>, b: &CertId<B>) -> bool {
+    a.hash_algorithm.oid == b.hash_algorithm.oid
+        && a.issuer_name_hash.as_bytes() == b.issuer_name_hash.as_bytes()
+        && a.issuer_key_hash.as_bytes() == b.issuer_key_hash.as_bytes()
+        && a.serial_number.as_bytes() == b.serial_number.as_bytes()
+}
+
 #[cfg(test)]
 mod tests {
     use super::*;
@@ -456,6 +695,131 @@ mod tests {
         assert!(!source.add(b"this is not a CRL"));
         assert!(source.is_empty());
         assert!(source.get_all_crls().unwrap().is_empty());
+    }
+
+    #[test]
+    fn an_uploaded_file_that_is_not_a_crl_is_refused_in_either_encoding() {
+        // Exercises both arms of add_uploaded_crl's DER-then-PEM attempt without needing a
+        // prepared environment: neither encoding yields a CRL, so neither stores one.
+        let source = MemoryCrlSource::new();
+        assert!(!source.add(b"neither DER nor PEM"));
+        assert!(!source.add(b"-----BEGIN X509 CRL-----\nbm90IGEgY3Js\n-----END X509 CRL-----\n"));
+        assert!(source.is_empty());
+    }
+
+    #[cfg(feature = "revocation")]
+    #[test]
+    fn a_file_that_is_not_an_ocsp_response_is_named_as_such() {
+        assert_eq!(
+            answered_cert_ids(b"not an ocsp response"),
+            Err("Not an OCSP response".to_string())
+        );
+        assert_eq!(
+            answered_cert_ids(&[]),
+            Err("Not an OCSP response".to_string())
+        );
+    }
+
+    /// An unsuccessful response is a different thing from an unreadable one, and the difference is
+    /// what a user needs: the file is fine, the responder declined to answer.
+    #[cfg(feature = "revocation")]
+    #[test]
+    fn a_response_reporting_failure_is_distinguished_from_an_unreadable_one() {
+        // OCSPResponse ::= SEQUENCE { responseStatus OCSPResponseStatus } with status
+        // malformedRequest(1) and no responseBytes -- the shortest well-formed refusal.
+        let refusal = [0x30u8, 0x03, 0x0A, 0x01, 0x01];
+        let err = answered_cert_ids(&refusal).unwrap_err();
+        assert!(
+            err.contains("rather than an answer"),
+            "unexpected note: {err}"
+        );
+    }
+
+    /// The end-to-end claim: a real OCSP response, handed over as a file, is matched to the
+    /// certificate it answers about and filed where the validation path will find it.
+    ///
+    /// Uses certval's own amazon.com capture — the same fixtures its `stapled_ocsp` test uses, and
+    /// the same `<n>-ocsp.ocspResp` naming `pitt_log` writes when a run exports what it consulted,
+    /// so this is the export-then-reload round trip the upload buttons exist for.
+    ///
+    /// The **intermediate** is the target here, deliberately, and not for convenience:
+    /// `1-ocsp.ocspResp` is the response *about* the intermediate (its CertID serial is the
+    /// intermediate's), so this asks the question the fixture can answer. It also sidesteps a
+    /// separate finding — with uploads and no baked store, a path builds to an uploaded
+    /// intermediate but not to an end entity beneath it — which would otherwise make this test red
+    /// for a reason that has nothing to do with matching a response.
+    #[cfg(feature = "revocation")]
+    #[test]
+    fn a_real_ocsp_response_is_matched_to_the_certificate_it_answers_about() {
+        use crate::validate::prepare_validation;
+        use certval::TimeOfInterest;
+
+        let ta = include_bytes!("../../certval/tests/examples/amazon.com/0-ta.der").to_vec();
+        let ca = include_bytes!("../../certval/tests/examples/amazon.com/1.der").to_vec();
+        let ca_ocsp =
+            include_bytes!("../../certval/tests/examples/amazon.com/1-ocsp.ocspResp").to_vec();
+
+        let mut cps = CertificationPathSettings::default();
+        // Inside the captured chain's validity window; the capture is from 2021-2022.
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1640995200).unwrap());
+
+        let (prepared, _notes) =
+            prepare_validation(None, &[("0-ta.der".to_string(), ta)], &[], &cps, None)
+                .expect("the amazon.com trust anchor should prepare an environment");
+
+        let targets = vec![("1.der".to_string(), ca)];
+        let outcome = staple_uploaded_ocsp(&prepared, &cps, &targets, &ca_ocsp);
+
+        assert!(
+            outcome.matched > 0,
+            "the intermediate's own OCSP response matched nothing; notes: {:?}",
+            outcome.notes
+        );
+        assert!(
+            !prepared.ocsp_responses().is_empty(),
+            "matched but nothing was filed for the validation path to find"
+        );
+    }
+
+    /// A response that is genuinely about something else is refused rather than filed, which is the
+    /// property that makes matching worth doing at all — otherwise stapling everything everywhere
+    /// would do just as well.
+    #[cfg(feature = "revocation")]
+    #[test]
+    fn an_ocsp_response_about_a_different_pki_matches_nothing() {
+        use crate::validate::prepare_validation;
+        use certval::TimeOfInterest;
+
+        let ta = include_bytes!("../../certval/tests/examples/amazon.com/0-ta.der").to_vec();
+        let ca = include_bytes!("../../certval/tests/examples/amazon.com/1.der").to_vec();
+        // A response from an unrelated capture: right shape, wrong certificates.
+        let foreign =
+            include_bytes!("../../certval/tests/examples/harvard.edu/1-ocsp.ocspResp").to_vec();
+
+        let mut cps = CertificationPathSettings::default();
+        cps.set_time_of_interest(TimeOfInterest::from_unix_secs(1640995200).unwrap());
+
+        let (prepared, _notes) =
+            prepare_validation(None, &[("0-ta.der".to_string(), ta)], &[], &cps, None)
+                .expect("the amazon.com trust anchor should prepare an environment");
+
+        let targets = vec![("1.der".to_string(), ca)];
+        let outcome = staple_uploaded_ocsp(&prepared, &cps, &targets, &foreign);
+
+        assert_eq!(outcome.matched, 0);
+        assert!(prepared.ocsp_responses().is_empty());
+        // The note must identify the response rather than merely report failure: the serial it
+        // answers about is what tells the reader it is the wrong file, and the count tells them a
+        // path was built and searched rather than nothing having been looked at.
+        let note = outcome.notes.first().expect("a miss must be explained");
+        assert!(
+            note.contains("137D539CAA7C31A9A433701968847A8D"),
+            "the note should name the serial the response answers about; got {note}"
+        );
+        assert!(
+            note.contains("examined 1 certificate(s)"),
+            "the note should say how many candidates were compared; got {note}"
+        );
     }
 
     /// A clone shares the contents, which is what lets one be registered on the environment while

--- a/pittv3-gui-lib/src/validate.rs
+++ b/pittv3-gui-lib/src/validate.rs
@@ -36,7 +36,7 @@ fn err(text: String) -> ResultLine {
 /// Returns DER bytes given buffers that may be PEM or DER encoded. DER detection accepts
 /// SEQUENCE (certificates and the certificate variant of TrustAnchorChoice) plus the context
 /// tags that begin the tbsCert and taInfo variants of a DER-encoded RFC 5914 TrustAnchorChoice.
-fn maybe_pem(bytes: &[u8]) -> Result<Vec<u8>> {
+pub fn maybe_pem(bytes: &[u8]) -> Result<Vec<u8>> {
     if !bytes.is_empty() && matches!(bytes[0], 0x30 | 0xA1 | 0xA2) {
         Ok(bytes.to_vec())
     } else {

--- a/pittv3-service/src/config.rs
+++ b/pittv3-service/src/config.rs
@@ -147,3 +147,52 @@ impl ServiceState {
         })
     }
 }
+
+#[cfg(test)]
+mod config_tests {
+    use super::ServiceConfig;
+    use std::path::PathBuf;
+
+    /// The contract a deployment relies on: `client_dir` set in the configuration file alone, with
+    /// no command-line flag, is what gets served.
+    #[test]
+    fn client_dir_is_read_from_the_configuration_file() {
+        let json = r#"{
+            "bind": "0.0.0.0:8080",
+            "client_dir": "/var/lib/pittv3/client",
+            "stores_dir": "/var/lib/pittv3/stores"
+        }"#;
+        let cfg: ServiceConfig = serde_json::from_str(json).expect("should parse");
+        assert_eq!(
+            cfg.client_dir,
+            Some(PathBuf::from("/var/lib/pittv3/client"))
+        );
+        assert_eq!(
+            cfg.stores_dir,
+            Some(PathBuf::from("/var/lib/pittv3/stores"))
+        );
+        assert_eq!(cfg.bind, "0.0.0.0:8080");
+        // Untouched fields keep their defaults, so a partial file is a valid file.
+        assert!(cfg.builtin_stores);
+        assert!(cfg.enable_validation);
+        assert!(!cfg.allow_dynamic_build);
+    }
+
+    /// The trap worth knowing about: the struct does NOT deny unknown fields, so a misspelled key
+    /// is accepted and ignored. `clientDir` or `client-dir` leaves `client_dir` at None and the
+    /// service starts happily serving no application at all -- no parse error, no warning.
+    #[test]
+    fn a_misspelled_key_is_silently_ignored_rather_than_refused() {
+        for wrong in [
+            r#"{"clientDir": "/var/lib/pittv3/client"}"#,
+            r#"{"client-dir": "/var/lib/pittv3/client"}"#,
+            r#"{"clientdir": "/var/lib/pittv3/client"}"#,
+        ] {
+            let cfg: ServiceConfig = serde_json::from_str(wrong).expect("still parses");
+            assert_eq!(
+                cfg.client_dir, None,
+                "{wrong} should not have set client_dir"
+            );
+        }
+    }
+}

--- a/pittv3-service/src/main.rs
+++ b/pittv3-service/src/main.rs
@@ -3,6 +3,8 @@
 
 use std::path::PathBuf;
 
+use actix_web::dev::Service;
+use actix_web::http::header::{HeaderValue, CACHE_CONTROL};
 use actix_web::{web, App, HttpServer};
 use clap::Parser;
 use log::info;
@@ -136,6 +138,28 @@ async fn main() -> std::io::Result<()> {
 
     HttpServer::new(move || {
         let app = App::new()
+            // Cache-Control for the browser application. Trunk content-hashes the js and wasm but
+            // NOT index.html, so a browser holding a stale index.html asks for the previous build's
+            // hashed assets, gets 404s, and the application does not start. Serving the app from
+            // this binary means there is no web server in front to set the header, so it is set
+            // here or not at all -- and "not at all" is what made a redeploy look like a code bug
+            // more than once. The policy is the one in pittv3-wasm/apache.htaccess.
+            .wrap_fn(|req, srv| {
+                // Endpoint responses are left alone: they are not static files, and a handler that
+                // has something to say about caching its own answer should not be overridden here.
+                let served_from_disk =
+                    !(req.path().starts_with("/api/") || req.path().starts_with("/stores/"));
+                let policy = cache_control_for(req.path());
+                let fut = srv.call(req);
+                async move {
+                    let mut res = fut.await?;
+                    if served_from_disk && !res.headers().contains_key(CACHE_CONTROL) {
+                        res.headers_mut()
+                            .insert(CACHE_CONTROL, HeaderValue::from_static(policy));
+                    }
+                    Ok(res)
+                }
+            })
             .app_data(state.clone())
             // The cap is applied by the JSON extractor rather than by a handler, so an oversized
             // body is refused as it arrives instead of after it has been buffered and decoded.
@@ -158,9 +182,97 @@ async fn main() -> std::io::Result<()> {
     .await
 }
 
+/// Cache-Control for a static file the service serves, keyed on whether its name carries a content
+/// hash.
+///
+/// Trunk emits `<name>-<16 hex>.js` and `<name>-<16 hex>_bg.wasm`, whose contents cannot change
+/// without the name changing, so those are safe to keep for a year. Everything else -- index.html
+/// above all -- must be revalidated, because the same name will hold different bytes after the next
+/// deploy.
+///
+/// Deliberately conservative: the hash is looked for in the **file name** only, so an asset under a
+/// hashed *directory* (Trunk's `snippets/<crate>-<hash>/…`) revalidates rather than being pinned. A
+/// wrong "immutable" cannot be withdrawn for a year, while an unnecessary revalidation costs one
+/// conditional request answered with 304.
+fn cache_control_for(path: &str) -> &'static str {
+    const IMMUTABLE: &str = "public, max-age=31536000, immutable";
+    const REVALIDATE: &str = "no-cache, must-revalidate";
+
+    let file = match path.rsplit('/').next() {
+        Some(f) => f,
+        None => return REVALIDATE,
+    };
+    match content_hashed(file) {
+        true => IMMUTABLE,
+        false => REVALIDATE,
+    }
+}
+
+/// Whether `file` carries a Trunk content hash: a `-` followed by exactly 16 hex digits, ending the
+/// stem. Matching the shape rather than any hex run keeps a name like `crl-2026.der` out of it.
+fn content_hashed(file: &str) -> bool {
+    let stem = file
+        .strip_suffix("_bg.wasm")
+        .or_else(|| file.strip_suffix(".wasm"))
+        .or_else(|| file.strip_suffix(".js"))
+        .unwrap_or("");
+    match stem.rfind('-') {
+        Some(dash) => {
+            let tail = &stem[dash + 1..];
+            tail.len() == 16 && tail.bytes().all(|b| b.is_ascii_hexdigit())
+        }
+        None => false,
+    }
+}
+
 fn enabled(flag: bool) -> &'static str {
     match flag {
         true => "enabled",
         false => "disabled",
+    }
+}
+
+#[cfg(test)]
+mod cache_tests {
+    use super::{cache_control_for, content_hashed};
+
+    /// The names Trunk actually produced for the deployed bundle.
+    #[test]
+    fn trunk_hashed_assets_are_pinned() {
+        assert!(content_hashed("pittv3-wasm-60c2dfcf11d6e584_bg.wasm"));
+        assert!(content_hashed("pittv3-wasm-60c2dfcf11d6e584.js"));
+        assert_eq!(
+            cache_control_for("/pittv3-wasm-60c2dfcf11d6e584_bg.wasm"),
+            "public, max-age=31536000, immutable"
+        );
+    }
+
+    /// index.html is the one that must never be pinned -- it is unhashed and names the hashed
+    /// assets, so a stale copy points at a previous deploy's files and the app fails to start.
+    #[test]
+    fn the_document_and_anything_unhashed_revalidates() {
+        for path in [
+            "/",
+            "/index.html",
+            "/resources/dod_nipr_prod_ta.cbor",
+            "/snippets/dioxus-web-5b126e270dcd269f/src/js/eval.js",
+        ] {
+            assert_eq!(
+                cache_control_for(path),
+                "no-cache, must-revalidate",
+                "{path} should revalidate"
+            );
+        }
+    }
+
+    /// A hash-shaped test rather than "contains hex": a plausible unhashed name must not be pinned,
+    /// because a wrong immutable cannot be withdrawn for a year.
+    #[test]
+    fn a_name_that_merely_contains_hex_is_not_treated_as_hashed() {
+        assert!(!content_hashed("bundle-abc123.js"));
+        assert!(!content_hashed("crl-2026.der"));
+        assert!(!content_hashed("app.js"));
+        // 16 hex digits, but not in the stem-terminal position Trunk uses.
+        assert!(!content_hashed("60c2dfcf11d6e584-app.js"));
     }
 }

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -20,7 +20,7 @@ use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::report::{TargetReport, ValidationReport};
 
 use pittv3_gui_lib::export::{path_entries, paths_text, zip_paths};
-use pittv3_gui_lib::retrieval::harvest_revocation_work;
+use pittv3_gui_lib::retrieval::{add_uploaded_crl, harvest_revocation_work, staple_uploaded_ocsp};
 
 use crate::relay::{chase_certificates, retrieve_crls, retrieve_ocsp, FetchBudget, Tier};
 use crate::validate::{
@@ -160,22 +160,29 @@ fn load_use_rev_cache() -> bool {
 /// the value is not written back to the model.
 ///
 /// Revocation status checking is materialized the same way and for the same class of reason:
-/// certval's default for an absent `PS_CHECK_REVOCATION_STATUS` is *true*, and nothing in the
-/// browser can fetch a CRL or an OCSP response until a relay exists, so an unstated preference
-/// means off here.
+/// certval's default for an absent `PS_CHECK_REVOCATION_STATUS` is *true*, and a browser cannot
+/// always obtain a CRL or an OCSP response, so an unstated preference depends on whether this run
+/// can get hold of any.
 ///
 /// This line is load-bearing: `pittv3_gui_lib::validate` calls `check_revocation` for a path that
 /// otherwise validates, and that check consults stapled revocation data and registered CRL sources
-/// rather than fetching. So what an unstated preference should mean depends on the tier. In
-/// [`Tier::Local`] nothing can be retrieved and an unstated preference means off, or every run
-/// would come back `RevocationStatusNotDetermined` for want of data the page cannot obtain. In
+/// rather than fetching. There are **two** ways a run comes by such data — retrieving it through a
+/// relay, or being handed it by the user — and `supplied_revocation_data` is the second. Keying the
+/// default on the tier alone is what made the upload buttons inert: a [`Tier::Local`] run switched
+/// checking off and then never consulted the CRL it had just been given. With neither, an unstated
+/// preference still means off, or every run would come back `RevocationStatusNotDetermined` for
+/// want of data the page cannot obtain. In
 /// [`Tier::Relayed`] the data can be retrieved, and checking is the point of having chosen that
 /// tier, so an unstated preference means on.
 ///
 /// A stated preference is honored either way — the settings form says outright that these settings
 /// apply only where the tool can fetch, and a user who asks for checking in the local tier gets
 /// what they asked for, undetermined status included.
-fn run_settings(model: &SettingsModel, tier: Tier) -> CertificationPathSettings {
+fn run_settings(
+    model: &SettingsModel,
+    tier: Tier,
+    supplied_revocation_data: bool,
+) -> CertificationPathSettings {
     let mut cps = CertificationPathSettings::default();
     model.apply(&mut cps);
     if model.time_of_interest.is_none() {
@@ -183,8 +190,12 @@ fn run_settings(model: &SettingsModel, tier: Tier) -> CertificationPathSettings 
             cps.set_time_of_interest(toi);
         }
     }
+    // The unstated default asks whether this run can obtain revocation data at all -- retrieving is
+    // one way to obtain it, and being handed it by the user is the other. Keying this on the tier
+    // alone predates the upload buttons and made them inert: a no-network run would switch checking
+    // off and then never consult the CRL or OCSP response it had just been given.
     if model.check_revocation_status.is_none() {
-        cps.set_check_revocation_status(tier.retrieves());
+        cps.set_check_revocation_status(tier.retrieves() || supplied_revocation_data);
     }
     cps
 }
@@ -295,6 +306,16 @@ fn App() -> Element {
     let mut uploaded_cas = use_signal(Vec::<(String, Vec<u8>)>::new);
     let mut loaded_ees = use_signal(Vec::<(String, Vec<u8>)>::new);
     let mut loaded_zips = use_signal(Vec::<(String, Vec<u8>)>::new);
+    // Revocation data supplied by hand, for a run with no network to fetch it. Held here rather
+    // than pushed straight into the prepared environment because that environment is rebuilt
+    // whenever the trust material or settings change, and a rebuild would take the uploads with
+    // it. These are folded in at Validate instead, so they survive every rebuild.
+    let mut uploaded_crls = use_signal(Vec::<(String, Vec<u8>)>::new);
+    let mut uploaded_ocsp = use_signal(Vec::<(String, Vec<u8>)>::new);
+    // Whether this run has revocation data of its own. Read when the settings for a run are built,
+    // because it is one of the two ways a run can obtain any -- see `run_settings`.
+    let have_revocation_uploads =
+        move || !uploaded_crls().is_empty() || !uploaded_ocsp().is_empty();
     // The uploads panel's expanded state is deliberately NOT tracked here — see the store
     // dropdown's `onchange`, which pushes it open once when "None" is selected and otherwise
     // leaves the browser to own it.
@@ -656,7 +677,7 @@ fn App() -> Element {
         // each Validate replaces the prior results rather than appending to them
         targets.write().clear();
         notes.write().clear();
-        let cps = run_settings(&settings(), tier());
+        let cps = run_settings(&settings(), tier(), have_revocation_uploads());
         for (name, bytes) in loaded_zips() {
             let (reports, lines) = validate_hackathon_zip(&name, bytes, &cps, validate_all());
             notes.write().extend(lines);
@@ -717,7 +738,7 @@ fn App() -> Element {
         #[cfg(target_family = "wasm")]
         gloo_timers::future::TimeoutFuture::new(16).await;
 
-        let cps = run_settings(&settings(), tier());
+        let cps = run_settings(&settings(), tier(), have_revocation_uploads());
 
         // Rebuild the prepared environment only when it is stale (or absent); otherwise reuse the
         // cached one, skipping the store fetch, reparse and partial-path discovery.
@@ -736,6 +757,49 @@ fn App() -> Element {
         // The retrieval budget is per click rather than per step, so a chase that spent it does not
         // leave a revocation retrieval to discover the same limit again.
         let mut budget = FetchBudget::new();
+
+        // Uploaded revocation data goes in before the tier is consulted, so it reaches BOTH tiers.
+        // A no-network run has no other way to obtain any, and a retrieving run must not go
+        // and fetch what it was already given -- the harvest below skips a certificate whose
+        // status is already settled. Deliberately outside `tier().retrieves()`: that branch is
+        // false in exactly the no-network case this exists for. Not gated on
+        // check_revocation_status either: supplying a file is an explicit act, and a run that
+        // ignores it should say so through the settings rather than by discarding it silently.
+        if !uploaded_crls().is_empty() || !uploaded_ocsp().is_empty() {
+            let guard = prepared_env.read();
+            if let Some((prepared, _)) = guard.as_ref() {
+                for (name, bytes) in uploaded_crls() {
+                    match add_uploaded_crl(prepared, &bytes) {
+                        true => notes.write().push(ResultLine {
+                            class: "info",
+                            text: format!("Added CRL from {name}"),
+                        }),
+                        false => notes.write().push(ResultLine {
+                            class: "err",
+                            text: format!("{name} is not a CRL"),
+                        }),
+                    }
+                }
+                for (name, bytes) in uploaded_ocsp() {
+                    let outcome = staple_uploaded_ocsp(prepared, &cps, &loaded_ees(), &bytes);
+                    if outcome.matched > 0 {
+                        notes.write().push(ResultLine {
+                            class: "info",
+                            text: format!(
+                                "Stapled OCSP response from {name} to {} certificate(s)",
+                                outcome.matched
+                            ),
+                        });
+                    }
+                    for note in outcome.notes {
+                        notes.write().push(ResultLine {
+                            class: "err",
+                            text: format!("{name}: {note}"),
+                        });
+                    }
+                }
+            }
+        }
 
         // --- retrieve, when the tier permits it ---
         //
@@ -957,6 +1021,58 @@ fn App() -> Element {
                                         },
                                         "Clear"
                                     }
+                                }
+                            }
+                        }
+
+                        details { class: "panel", id: "revocation-panel",
+                            summary { "Revocation data (CRLs and OCSP responses)" }
+                            div { class: "controls custom",
+                                label { "CRL(s): " }
+                                // Unfiltered for the same reason as the OCSP input below: .crl is
+                                // the common extension but nothing requires it, and add_uploaded_crl
+                                // already answers "is not a CRL" from the bytes. Widening what can
+                                // be selected cannot break a file that was selectable before.
+                                input {
+                                    r#type: "file",
+                                    multiple: true,
+                                    onchange: move |ev| async move {
+                                        let files = read_files(&ev).await;
+                                        extend_unique(uploaded_crls, files);
+                                    },
+                                }
+                                label { "OCSP response(s): " }
+                                // Deliberately unfiltered. An OCSP response has no settled file
+                                // extension -- tools write .ors, .der, .resp, or none at all -- and
+                                // an `accept` list greys out anything it failed to anticipate, so a
+                                // wrong guess here blocks the file rather than merely failing to
+                                // suggest it. The bytes are what decide: staple_uploaded_ocsp says
+                                // "Not an OCSP response" for anything that is not one, which is a
+                                // better gate than the name and cannot lock the user out.
+                                input {
+                                    r#type: "file",
+                                    multiple: true,
+                                    onchange: move |ev| async move {
+                                        let files = read_files(&ev).await;
+                                        extend_unique(uploaded_ocsp, files);
+                                    },
+                                }
+                                span { class: "hint",
+                                    "{uploaded_crls().len()} CRL(s), {uploaded_ocsp().len()} OCSP response(s) loaded "
+                                    button {
+                                        onclick: move |_| {
+                                            uploaded_crls.write().clear();
+                                            uploaded_ocsp.write().clear();
+                                        },
+                                        "Clear"
+                                    }
+                                }
+                                span { class: "hint",
+                                    "Supplied at Validate, so a run with no network can still determine \
+                                     revocation status. An OCSP response is matched to the certificates \
+                                     it answers about by its CertID, so it does not matter which one you \
+                                     loaded it for. Any file may be chosen — what it contains decides, \
+                                     not what it is called. CRLs may be DER or PEM."
                                 }
                             }
                         }
@@ -1358,15 +1474,25 @@ mod tests {
     /// `RevocationStatusNotDetermined` for want of data the page cannot obtain.
     #[test]
     fn revocation_checking_is_off_unless_asked_for_in_the_local_tier() {
-        let cps = run_settings(&SettingsModel::default(), Tier::Local);
+        let cps = run_settings(&SettingsModel::default(), Tier::Local, false);
         assert!(!cps.get_check_revocation_status());
+    }
+
+    /// Uploading a CRL or an OCSP response is the other way a run obtains revocation data, so it
+    /// moves the same unstated default the relay tier moves. Without this the upload buttons are
+    /// inert in exactly the tier they exist for: checking stays off and the stapled data is never
+    /// consulted, which reads as `RevocationStatusNotDetermined` and looks like the staple failed.
+    #[test]
+    fn supplied_revocation_data_turns_checking_on_in_the_local_tier() {
+        let cps = run_settings(&SettingsModel::default(), Tier::Local, true);
+        assert!(cps.get_check_revocation_status());
     }
 
     /// With a relay the data can be retrieved, and checking is the reason to have chosen that tier,
     /// so the unstated preference reverses. This is the one setting whose default the tier moves.
     #[test]
     fn revocation_checking_is_on_unless_refused_in_the_relayed_tier() {
-        let cps = run_settings(&SettingsModel::default(), Tier::Relayed);
+        let cps = run_settings(&SettingsModel::default(), Tier::Relayed, false);
         assert!(cps.get_check_revocation_status());
     }
 
@@ -1379,13 +1505,16 @@ mod tests {
             check_revocation_status: Some(true),
             ..SettingsModel::default()
         };
-        assert!(run_settings(&asked_for, Tier::Local).get_check_revocation_status());
+        assert!(run_settings(&asked_for, Tier::Local, false).get_check_revocation_status());
 
         let refused = SettingsModel {
             check_revocation_status: Some(false),
             ..SettingsModel::default()
         };
-        assert!(!run_settings(&refused, Tier::Relayed).get_check_revocation_status());
+        assert!(!run_settings(&refused, Tier::Relayed, false).get_check_revocation_status());
+
+        // An upload does not override a refusal: the user said no.
+        assert!(!run_settings(&refused, Tier::Local, true).get_check_revocation_status());
     }
 
     /// The tier is what the settings form's per-capability notices key off, so the two have to move

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -68,7 +68,7 @@ const VIEW_LABELS: &[&str] = &[
     "Validate",
     "Settings",
     "Results",
-    "Resources",
+    "Store artifacts",
     "Hackathon",
     "Help",
 ];
@@ -987,6 +987,12 @@ fn App() -> Element {
                             if !store_hint.is_empty() {
                                 span { class: "hint", "This store is {store_hint}." }
                             }
+                            // What asking a service for its stores produced. Shown here rather than
+                            // on a tab of its own: it explains the contents of the selector directly
+                            // above it, which is the only place it is actionable.
+                            if !store_service_status().is_empty() {
+                                span { class: "hint", "{store_service_status}" }
+                            }
                         }
 
                         details { class: "panel", id: "uploads-panel",
@@ -1169,6 +1175,13 @@ fn App() -> Element {
                                     true => Capabilities::browser_relayed(),
                                     false => Capabilities::browser_local(),
                                 },
+                                // The same rule run_settings applies, reported rather than
+                                // re-derived, so the form cannot show a tick beside a check the run
+                                // will not make. Recomputed on every render, so selecting a tier or
+                                // loading revocation data updates the row without a save.
+                                revocation_default: Some(
+                                    tier().retrieves() || have_revocation_uploads(),
+                                ),
                                 on_save: move |edited| {
                                     settings.set(edited);
                                     settings_status.set("Settings saved".to_string());
@@ -1269,62 +1282,76 @@ fn App() -> Element {
                         div { class: "help-view",
                             h2 { "Store artifacts" }
                             p {
-                                "The built-in stores are CBOR files served alongside this app. Download any of "
-                                "them and re-upload them via the trust-anchor and intermediate-CA controls on the "
-                                "Validate tab to mix and match \u{2014} e.g. Web PKI roots with a different "
-                                "collection's intermediates, or your own trust anchors with a built-in CA store. "
-                                "They are the same format the store dropdown loads and the same format produced by "
-                                "offline store-generation tooling, so stores you build yourself upload the same way."
-                            }
-                            p { class: "hint",
-                                "The Web PKI and U.S. DoD stores were prepared on 2026-07-21; the ML-DSA-44 "
-                                "PKITS edition is static test data. Regenerate the real-world stores periodically "
-                                "to refresh their trust material."
-                            }
-                            p { class: "hint",
-                                "Where this app is served by the PITTv3 service, the stores that service holds "
-                                "appear in the dropdown alongside these and are downloaded from it rather than "
-                                "from the files below. The dropdown says which is which."
-                            }
-                            if !store_service_status().is_empty() {
-                                p { class: "hint", "{store_service_status}" }
-                            }
-                            h3 { "Web PKI (Mozilla roots + CCADB intermediates)" }
-                            ul {
-                                li {
-                                    a { href: "resources/webpki_ta.cbor", download: "webpki_ta.cbor", "webpki_ta.cbor" }
-                                    " \u{2014} trust anchors (Mozilla roots)"
-                                }
-                                li {
-                                    a { href: "resources/webpki_ca.cbor", download: "webpki_ca.cbor", "webpki_ca.cbor" }
-                                    " \u{2014} intermediate CAs (CCADB)"
-                                }
-                            }
-                            h3 { "U.S. DoD (NIPR)" }
-                            ul {
-                                li {
-                                    a { href: "resources/dod_nipr_prod_ta.cbor", download: "dod_nipr_prod_ta.cbor", "dod_nipr_prod_ta.cbor" }
-                                    " \u{2014} trust anchors (DoD roots)"
-                                }
-                                li {
-                                    a { href: "resources/dod_nipr_prod_ca.cbor", download: "dod_nipr_prod_ca.cbor", "dod_nipr_prod_ca.cbor" }
-                                    " \u{2014} intermediate CAs"
-                                }
-                            }
-                            h3 { "ML-DSA-44 PKITS" }
-                            ul {
-                                li {
-                                    a { href: "resources/pkits_ml_dsa_44_ta.cbor", download: "pkits_ml_dsa_44_ta.cbor", "pkits_ml_dsa_44_ta.cbor" }
-                                    " \u{2014} trust anchors"
-                                }
-                                li {
-                                    a { href: "resources/pkits_ml_dsa_44_ca.cbor", download: "pkits_ml_dsa_44_ca.cbor", "pkits_ml_dsa_44_ca.cbor" }
-                                    " \u{2014} intermediate CAs with partial paths"
-                                }
+                                "A trust store is a pair of CBOR files. The trust-anchor half "
+                                "(*_ta.cbor) holds roots. The CA half (*_ca.cbor) holds intermediate "
+                                "CA certificates together with precomputed partial certification "
+                                "paths \u{2014} the paths from each anchor down through the "
+                                "intermediates, worked out in advance."
                             }
                             p {
-                                "Trust-anchor stores (*_ta.cbor) hold roots; CA stores (*_ca.cbor) hold intermediate "
-                                "CA certificates with precomputed partial certification paths."
+                                "That precomputation is why the halves are worth carrying around. "
+                                "Discovering partial paths is the expensive step of preparing an "
+                                "environment; building a path against one already discovered is "
+                                "cheap. A store is therefore not merely a bag of certificates, it is "
+                                "a bag of certificates with the search already done."
+                            }
+                            h3 { "Where they come from" }
+                            p {
+                                "Three sources, all the same format, all interchangeable:"
+                            }
+                            ul {
+                                li {
+                                    strong { "Built into this app. " }
+                                    "Selectable from the dropdown on the Validate tab without any "
+                                    "network access."
+                                }
+                                li {
+                                    strong { "Served by a PITTv3 service. " }
+                                    "Where this app is served by one, the stores it holds appear in "
+                                    "the same dropdown and are downloaded from it. The dropdown says "
+                                    "which is which, and whether a store came from a trust store "
+                                    "provider or was configured by whoever runs the service \u{2014} "
+                                    "worth knowing, because a configured store may hold chased "
+                                    "material rather than published trust material."
+                                }
+                                li {
+                                    strong { "Exported from a run. " }
+                                    "Export PKI Environment on the Results view writes the trust "
+                                    "material a validation actually used, in this same format. That "
+                                    "is the way to capture a store you assembled by uploading, or by "
+                                    "letting a run chase for certificates it did not have."
+                                }
+                            }
+                            h3 { "Using them" }
+                            p {
+                                "Upload either half through the trust-anchor and intermediate-CA "
+                                "controls on the Validate tab. A .cbor upload merges all of its "
+                                "certificates into that side, so stores mix freely: Web PKI roots "
+                                "with another collection's intermediates, or your own trust anchors "
+                                "with a built-in CA store. Select \"None\" as the store to rely on "
+                                "uploads alone."
+                            }
+                            p {
+                                "Offline store-generation tooling produces the same format, so a "
+                                "store you build yourself uploads exactly like a built-in one, and a "
+                                "store exported from a run can be handed to the CLI or the desktop "
+                                "app unchanged."
+                            }
+                            h3 { "Freshness" }
+                            p {
+                                "The built-in stores are generated when this app is built, from the "
+                                "trust store provider crates, rather than being refreshed by hand. "
+                                "Their currency is therefore that of those crates at the time this "
+                                "build was made \u{2014} which is why no date is given here: the "
+                                "providers do not record when their material was collected, so any "
+                                "date this page stated would be a claim it could not check."
+                            }
+                            p { class: "hint",
+                                "The ML-DSA-44 PKITS edition is static test data and does not go "
+                                "stale. Real-world trust material does, and a root program moves "
+                                "without announcing itself here. Where currency matters, prefer a "
+                                "store served by a PITTv3 service, which can be regenerated without "
+                                "rebuilding this app."
                             }
                         }
                     },
@@ -1375,9 +1402,10 @@ fn App() -> Element {
                             ul {
                                 li {
                                     "Uploaded trust anchors and intermediate CAs may be DER or PEM certificates, "
-                                    "or a .cbor store file (the same format as the built-in stores \u{2014} see the "
-                                    "Resources tab to download them). A .cbor upload merges all of its certificates "
-                                    "into that side."
+                                    "or a .cbor store file (the same format as the built-in stores). Export PKI "
+                                    "Environment on the Results view writes that same format, so a run's trust "
+                                    "material can be saved and uploaded again. A .cbor upload merges all of its "
+                                    "certificates into that side."
                                 }
                                 li {
                                     "Uploaded trust anchors and intermediate CA certificates are used together "

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -1346,12 +1346,19 @@ fn App() -> Element {
                                 "providers do not record when their material was collected, so any "
                                 "date this page stated would be a claim it could not check."
                             }
+                            p {
+                                "A service's stores are baked in the same way and are no fresher for "
+                                "being served: the ones it marks \u{201c}provider\u{201d} were "
+                                "generated when that service was built. The exception is a store the "
+                                "dropdown marks \u{201c}configured\u{201d}, which is read from a "
+                                "directory the service was pointed at \u{2014} that one can be "
+                                "replaced and the service restarted, with nothing rebuilt. Where "
+                                "currency matters, that is the one to prefer."
+                            }
                             p { class: "hint",
                                 "The ML-DSA-44 PKITS edition is static test data and does not go "
                                 "stale. Real-world trust material does, and a root program moves "
-                                "without announcing itself here. Where currency matters, prefer a "
-                                "store served by a PITTv3 service, which can be regenerated without "
-                                "rebuilding this app."
+                                "without announcing itself here."
                             }
                         }
                     },


### PR DESCRIPTION
- add buttons to allow revocation artifacts to be supplied manually to demonstrate revocation checking works in wasm with no network access
- replace the old Resource tab that had static links with some prose on what store artifacts are (the stuff that used to be accessible via the links can be exported now on the validate page)
