### PR TITLE
Variety of pittv3-wasm-related changes

### DIFF
--- a/pittv3-gui-lib/src/gui_uri_check.rs
+++ b/pittv3-gui-lib/src/gui_uri_check.rs
@@ -1,0 +1,81 @@
+//! Rendering for a "Check URIs in certificate" report, shared by the frontends.
+//!
+//! Only the *results* are shared, deliberately. How a certificate is chosen differs in kind between
+//! the frontends — the desktop names a file on disk, the browser is handed one by a file input and
+//! has no path to read — and so does how the check reaches a repository, which is an HTTP client in
+//! one and a relay in the other. Forcing a single dialog over those would mean inventing an
+//! abstraction over the filesystem to share some chrome. What is genuinely the same is the grid: the
+//! same columns, the same taxonomy, the same colours, so a result means one thing wherever it is
+//! read.
+
+use dioxus::prelude::*;
+
+use pittv3_lib::uri_check::{UriCheckReport, UriStatus};
+
+/// CSS class selecting the colour for a URI-check result, reusing the validation badge palette so a
+/// green here means what a green means on a path.
+pub fn uri_status_class(status: UriStatus) -> &'static str {
+    match status {
+        UriStatus::CorrectData => "badge-valid",
+        UriStatus::IncorrectData
+        | UriStatus::UnknownAccessMethod
+        | UriStatus::ResponderCertPolicyError => "badge-invalid",
+        UriStatus::NotAvailable | UriStatus::BlacklistedHost => "badge-revoked",
+        UriStatus::Warning
+        | UriStatus::WarningMissingAia
+        | UriStatus::WarningMissingCrlDp
+        | UriStatus::CrlNotCheckedNoIssuerCert => "badge-undetermined",
+    }
+}
+
+/// The results of one URI check: what was checked, against which issuer, and a row per URI.
+///
+/// An empty result set is reported as such rather than left blank — a certificate naming no URIs is
+/// a finding, not an absence of one, and the taxonomy has entries for exactly that case.
+#[component]
+pub fn UriCheckResults(report: UriCheckReport) -> Element {
+    rsx! {
+        div { class: "uri-results",
+            p { class: "results-summary", "Target: {report.target.subject}" }
+            if let Some(issuer) = &report.issuer {
+                p { class: "results-summary",
+                    if report.issuer_auto_discovered {
+                        "Issuer (auto-discovered): {issuer.subject}"
+                    } else {
+                        "Issuer: {issuer.subject}"
+                    }
+                }
+            }
+            if let Some(err) = &report.error {
+                p { class: "badge badge-invalid", "{err}" }
+            } else if report.results.is_empty() {
+                p { class: "hint", "No URIs found to check." }
+            } else {
+                table { class: "cert-table",
+                    thead {
+                        tr {
+                            th { "URI" }
+                            th { "Result" }
+                            th { "Timing (ms)" }
+                            th { "Extension" }
+                        }
+                    }
+                    tbody {
+                        for r in report.results.iter() {
+                            tr {
+                                td { "{r.uri}" }
+                                td {
+                                    span { class: "badge {uri_status_class(r.status)}",
+                                        "{r.status.label()}"
+                                    }
+                                }
+                                td { "{r.timing_ms}" }
+                                td { "{r.extension.label()}" }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+}

--- a/pittv3-gui-lib/src/lib.rs
+++ b/pittv3-gui-lib/src/lib.rs
@@ -11,6 +11,7 @@ pub mod gui_rows;
 pub mod gui_settings;
 pub mod gui_settings_model;
 pub mod gui_shell;
+pub mod gui_uri_check;
 pub mod gui_utils;
 pub mod retrieval;
 pub mod settings_store;

--- a/pittv3-lib/Cargo.toml
+++ b/pittv3-lib/Cargo.toml
@@ -63,10 +63,13 @@ tokio-test = "0.4.5"
 # webpki can be paired with any other feature and simply adds a means of initializing a TaSource from the webpki-roots crate
 [features]
 default = ["remote", "webpki"]
-revocation = ["certval/revocation"]
+# cms is here rather than under `remote` because the URI checker parses certs-only SignedData
+# (`.p7c`, what an SIA caRepository commonly serves) and that checker now runs wherever `revocation`
+# does -- including a browser, which reaches repositories through a relay rather than an HTTP client.
+revocation = ["certval/revocation", "dep:cms"]
 std_app = ["certval/revocation"]
 std = ["std_app", "certval/std", "revocation", "walkdir", "csv"]
-remote = ["certval/remote", "revocation", "std", "dep:reqwest", "dep:cms"]
+remote = ["certval/remote", "revocation", "std", "dep:reqwest"]
 pqc = ["certval/pqc"]
 webpki = ["certval/webpki"]
 sha1_sig = ["rsa"]

--- a/pittv3-lib/src/der_or_pem.rs
+++ b/pittv3-lib/src/der_or_pem.rs
@@ -1,0 +1,55 @@
+//! Accepting a certificate in whichever encoding its file happened to hold.
+//!
+//! This exists because getting it wrong is not loud. Every entry point that takes bytes from a
+//! caller has to tolerate PEM, and one that does not fails in a way that looks like something else
+//! entirely: on 2026-08-20 a PEM target validated normally while contributing nothing to the
+//! revocation harvest, so every certificate reported `undetermined` with no explanation, and the
+//! same encoding later stopped the URI checker before it began. Two bugs, one cause, in code that
+//! had each grown its own parse.
+//!
+//! So the rule is: decode here, once, at every boundary where caller bytes arrive — and never let a
+//! DER-only parse be the first thing a file meets.
+
+use certval::{Error, Result};
+
+/// Returns DER bytes given a buffer that may be PEM or DER encoded.
+///
+/// DER is detected by its leading tag rather than by attempting a parse: `SEQUENCE` covers
+/// certificates and the certificate variant of `TrustAnchorChoice`, and the two context tags cover
+/// the `tbsCert` and `taInfo` variants of a DER-encoded RFC 5914 `TrustAnchorChoice`. Anything else
+/// is offered to the PEM decoder, and a failure there means the bytes are neither.
+pub fn maybe_pem(bytes: &[u8]) -> Result<Vec<u8>> {
+    if !bytes.is_empty() && matches!(bytes[0], 0x30 | 0xA1 | 0xA2) {
+        return Ok(bytes.to_vec());
+    }
+    match pem_rfc7468::decode_vec(bytes) {
+        Ok((_label, der)) => Ok(der),
+        Err(_) => Err(Error::Unrecognized),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The two encodings of one certificate must reduce to the same bytes — the property every
+    /// caller of this depends on, and the one whose absence caused both bugs above.
+    #[test]
+    fn pem_and_der_reduce_to_the_same_der() {
+        let der = include_bytes!("../../certval/tests/examples/amazon.com/2-target.der").to_vec();
+        let pem = include_bytes!("../../certval/tests/examples/amazon.com/2-target.pem").to_vec();
+        assert_ne!(der, pem, "fixtures must genuinely differ in encoding");
+        assert_eq!(
+            maybe_pem(&der).unwrap(),
+            der,
+            "DER passes through unchanged"
+        );
+        assert_eq!(maybe_pem(&pem).unwrap(), der, "PEM decodes to the same DER");
+    }
+
+    #[test]
+    fn neither_encoding_is_refused_rather_than_guessed() {
+        assert!(maybe_pem(b"").is_err());
+        assert!(maybe_pem(b"not a certificate in any encoding").is_err());
+    }
+}

--- a/pittv3-lib/src/lib.rs
+++ b/pittv3-lib/src/lib.rs
@@ -6,6 +6,9 @@
 extern crate alloc;
 
 pub mod args;
+// Available in every build: it is the decode every entry point taking caller bytes has to do, and a
+// build that cannot do it is one where a PEM file fails in a way that looks like something else.
+pub mod der_or_pem;
 #[cfg(feature = "std")]
 pub mod graph_cache;
 pub mod help;

--- a/pittv3-lib/src/uri_check.rs
+++ b/pittv3-lib/src/uri_check.rs
@@ -205,14 +205,50 @@ impl UriCheckReport {
     }
 }
 
-#[cfg(feature = "remote")]
-pub use remote_impl::{check_uris_from_bytes, check_uris_in_cert};
+/// What one retrieval produced: whether it succeeded, the bytes, and how long it took.
+///
+/// Timing belongs to the fetcher rather than to the checker because the clock does: `std::time::Instant`
+/// panics under wasm, where `web_time` is the equivalent. Returning it here keeps every platform
+/// detail on the far side of this trait.
+#[derive(Clone, Debug, Default)]
+pub struct FetchOutcome {
+    /// Whether the retrieval produced a usable body.
+    pub ok: bool,
+    /// The bytes retrieved; empty when `ok` is false.
+    pub body: Vec<u8>,
+    /// Elapsed time for the retrieval, in milliseconds, as the results grid reports it.
+    pub elapsed_ms: u64,
+}
 
+/// How the URI checker reaches a repository.
+///
+/// The checker cannot hoist its retrievals the way the revocation harvest does: certificates fetched
+/// from AIA and SIA accumulate as it goes, and an issuer discovered part-way through is what the
+/// later CRL and OCSP checks are verified against. The fetching is therefore injected rather than
+/// lifted out, which is also what lets a browser supply a relay where a command line supplies an
+/// HTTP client.
+pub trait UriFetcher {
+    /// Retrieves a URI. Implementations report failure rather than erroring: an unreachable
+    /// repository is an outcome this tool exists to report, not a fault in the run.
+    fn get(&self, uri: &str) -> impl core::future::Future<Output = FetchOutcome>;
+
+    /// Posts a DER-encoded OCSP request to a responder and returns its answer.
+    fn post_ocsp(
+        &self,
+        uri: &str,
+        request: &[u8],
+    ) -> impl core::future::Future<Output = FetchOutcome>;
+}
+
+#[cfg(feature = "revocation")]
+pub use check_impl::check_uris_in_cert;
 #[cfg(feature = "remote")]
-mod remote_impl {
+pub use remote_impl::{check_uris_from_bytes, ReqwestFetcher};
+
+#[cfg(feature = "revocation")]
+mod check_impl {
     use super::*;
-    use core::time::Duration;
-    use std::time::Instant;
+    use crate::der_or_pem::maybe_pem;
 
     use certval::*;
 
@@ -223,33 +259,8 @@ mod remote_impl {
         ID_CE_FRESHEST_CRL, ID_PE_AUTHORITY_INFO_ACCESS, ID_PE_SUBJECT_INFO_ACCESS,
     };
     use der::{Decode, Encode};
-    use log::debug;
     use x509_cert::crl::CertificateList;
     use x509_cert::ext::pkix::name::{DistributionPointName, GeneralName};
-
-    // A single 10 second per-request timeout mirrors certval's remote fetch client.
-    const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
-
-    /// Convenience entry point that builds an RFC 5280 [`PkiEnvironment`] and default settings, then
-    /// runs [`check_uris_in_cert`]. Both the CLI and GUI use this so neither has to construct a PKI
-    /// environment itself. `time_of_interest` is the usual Unix-seconds value (0 disables the
-    /// validity check). Signature verification requires the `rsa`/`eddsa`/`pqc` crypto features to be
-    /// enabled; without them every verification is treated as a failure.
-    pub async fn check_uris_from_bytes(
-        target_der: &[u8],
-        issuer_der: Option<&[u8]>,
-        auto_discover: bool,
-        time_of_interest: u64,
-        blocklist: &[String],
-    ) -> UriCheckReport {
-        let mut cps = CertificationPathSettings::default();
-        if let Ok(toi) = TimeOfInterest::from_unix_secs(time_of_interest) {
-            cps.set_time_of_interest(toi);
-        }
-        let mut pe = PkiEnvironment::default();
-        pe.populate_5280_pki_environment();
-        check_uris_in_cert(&pe, &cps, target_der, issuer_der, auto_discover, blocklist).await
-    }
 
     /// Checks every HTTP URI carried in the target certificate's AIA, SIA, CRL DP and freshest-CRL
     /// extensions and returns a per-URI reachability + correctness report modeled on PITTv2's
@@ -258,15 +269,24 @@ mod remote_impl {
     /// `issuer_der`, when present, enables CRL-signature verification and OCSP checking. When it is
     /// absent and `auto_discover` is true, the first AIA caIssuers pointer that yields the issuer is
     /// adopted for those checks. `blocklist` names hosts/URIs to skip (reported as blocklisted).
-    pub async fn check_uris_in_cert(
+    pub async fn check_uris_in_cert<F: UriFetcher>(
         pe: &PkiEnvironment,
         cps: &CertificationPathSettings,
+        fetcher: &F,
         target_der: &[u8],
         issuer_der: Option<&[u8]>,
         auto_discover: bool,
         blocklist: &[String],
     ) -> UriCheckReport {
-        let target = match PDVCertificate::try_from(target_der) {
+        // Whichever encoding the caller's file held. See `crate::der_or_pem`: a DER-only parse
+        // here is what stopped this check before it began on a PEM certificate.
+        let target_der = &match maybe_pem(target_der) {
+            Ok(der) => der,
+            Err(e) => {
+                return UriCheckReport::failed(format!("failed to parse target certificate: {e:?}"))
+            }
+        };
+        let target = match PDVCertificate::try_from(target_der.as_slice()) {
             Ok(c) => c,
             Err(e) => {
                 return UriCheckReport::failed(format!("failed to parse target certificate: {e:?}"))
@@ -274,22 +294,27 @@ mod remote_impl {
         };
 
         let mut issuer = match issuer_der {
-            Some(der) => match PDVCertificate::try_from(der) {
-                Ok(c) => Some(c),
-                Err(e) => {
-                    return UriCheckReport::failed(format!(
-                        "failed to parse issuer certificate: {e:?}"
-                    ))
+            Some(der) => {
+                let der = match maybe_pem(der) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        return UriCheckReport::failed(format!(
+                            "failed to parse issuer certificate: {e:?}"
+                        ))
+                    }
+                };
+                match PDVCertificate::try_from(der.as_slice()) {
+                    Ok(c) => Some(c),
+                    Err(e) => {
+                        return UriCheckReport::failed(format!(
+                            "failed to parse issuer certificate: {e:?}"
+                        ))
+                    }
                 }
-            },
+            }
             None => None,
         };
         let issuer_supplied = issuer.is_some();
-
-        let client = match reqwest::Client::builder().build() {
-            Ok(c) => c,
-            Err(e) => return UriCheckReport::failed(format!("failed to build HTTP client: {e}")),
-        };
 
         let mut report = UriCheckReport {
             target: CertSummary::from_cert(&target),
@@ -316,7 +341,7 @@ mod remote_impl {
         for uri in ca_issuers {
             let r = check_uri_certificate(
                 pe,
-                &client,
+                fetcher,
                 &uri,
                 &target,
                 false,
@@ -332,7 +357,7 @@ mod remote_impl {
         }
         for uri in ocsp {
             let r =
-                check_uri_ocsp(pe, &client, &uri, &target, issuer.as_ref(), blocklist, cps).await;
+                check_uri_ocsp(pe, fetcher, &uri, &target, issuer.as_ref(), blocklist, cps).await;
             report.results.push(r);
         }
 
@@ -340,7 +365,7 @@ mod remote_impl {
         for uri in collect_sia(&target) {
             let r = check_uri_certificate(
                 pe,
-                &client,
+                fetcher,
                 &uri,
                 &target,
                 true,
@@ -369,7 +394,7 @@ mod remote_impl {
         for uri in crl_dps {
             let r = check_uri_crl(
                 pe,
-                &client,
+                fetcher,
                 &uri,
                 &target,
                 issuer.as_ref(),
@@ -386,7 +411,7 @@ mod remote_impl {
         for uri in collect_crl_dps(&target, ID_CE_FRESHEST_CRL) {
             let r = check_uri_crl(
                 pe,
-                &client,
+                fetcher,
                 &uri,
                 &target,
                 issuer.as_ref(),
@@ -484,37 +509,6 @@ mod remote_impl {
 
     fn is_blocklisted(uri: &str, blocklist: &[String]) -> bool {
         blocklist.iter().any(|b| uri.contains(b.as_str()))
-    }
-
-    /// Fetches raw bytes for a URI, returning (success, body). Success is false on any transport
-    /// error, non-2xx status, or an HTML error page.
-    async fn http_get(client: &reqwest::Client, uri: &str) -> (bool, Vec<u8>) {
-        let resp = match client.get(uri).timeout(REQUEST_TIMEOUT).send().await {
-            Ok(r) => r,
-            Err(e) => {
-                debug!("fetch failed for {uri}: {e}");
-                return (false, vec![]);
-            }
-        };
-        if !resp.status().is_success() {
-            return (false, vec![]);
-        }
-        let is_html = resp
-            .headers()
-            .get("Content-Type")
-            .and_then(|v| v.to_str().ok())
-            .map(|s| s.starts_with("text/html"))
-            .unwrap_or(false);
-        if is_html {
-            return (false, vec![]);
-        }
-        match resp.bytes().await {
-            Ok(b) => (true, b.to_vec()),
-            Err(e) => {
-                debug!("body read failed for {uri}: {e}");
-                (false, vec![])
-            }
-        }
     }
 
     /// Parses fetched bytes into certificates, handling a single DER certificate, a PEM bundle, or a
@@ -665,9 +659,9 @@ mod remote_impl {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn check_uri_certificate(
+    async fn check_uri_certificate<F: UriFetcher>(
         pe: &PkiEnvironment,
-        client: &reqwest::Client,
+        fetcher: &F,
         uri: &str,
         target: &PDVCertificate,
         from_sia: bool,
@@ -682,9 +676,11 @@ mod remote_impl {
             return row(uri, extension, UriStatus::BlacklistedHost, 0, None);
         }
 
-        let start = Instant::now();
-        let (ok, bytes) = http_get(client, uri).await;
-        let timing_ms = start.elapsed().as_millis() as u64;
+        let FetchOutcome {
+            ok,
+            body: bytes,
+            elapsed_ms: timing_ms,
+        } = fetcher.get(uri).await;
         let certs = parse_certs(&bytes);
 
         let all_good = check_certs(pe, &certs, target, from_sia, issuer, auto_discover);
@@ -711,9 +707,9 @@ mod remote_impl {
         row(uri, extension, status, timing_ms, detail)
     }
 
-    async fn check_uri_ocsp(
+    async fn check_uri_ocsp<F: UriFetcher>(
         pe: &PkiEnvironment,
-        client: &reqwest::Client,
+        fetcher: &F,
         uri: &str,
         target: &PDVCertificate,
         issuer: Option<&PDVCertificate>,
@@ -737,18 +733,45 @@ mod remote_impl {
             }
         };
 
-        let _ = client; // OCSP transport is handled inside certval's OCSP client.
-        let mut cpr = CertificationPathResults::new();
-        let start = Instant::now();
-        let sent = send_ocsp_request(pe, cps, uri, target, issuer.decoded(), &mut cpr, 0).await;
-        let timing_ms = start.elapsed().as_millis() as u64;
-
-        let status = if sent.is_ok() {
-            UriStatus::CorrectData
-        } else {
-            UriStatus::IncorrectData
+        // Built, posted and processed here rather than handed to certval's `send_ocsp_request`,
+        // which opens a socket of its own and exists only under `remote`. These three steps are
+        // available under `revocation`, which is what lets a browser run this check through a relay.
+        let request = match build_ocsp_request(target.decoded(), issuer.decoded(), None) {
+            Ok(r) => r,
+            Err(e) => {
+                return row(
+                    uri,
+                    UriExtension::Ocsp,
+                    UriStatus::IncorrectData,
+                    0,
+                    Some(format!("could not build an OCSP request: {e:?}")),
+                )
+            }
         };
-        let detail = sent.err().map(|e| format!("{e:?}"));
+
+        let FetchOutcome {
+            ok,
+            body,
+            elapsed_ms: timing_ms,
+        } = fetcher.post_ocsp(uri, &request).await;
+        if !ok {
+            return row(
+                uri,
+                UriExtension::Ocsp,
+                UriStatus::NotAvailable,
+                timing_ms,
+                None,
+            );
+        }
+
+        let mut cpr = CertificationPathResults::new();
+        let processed =
+            process_ocsp_response(pe, cps, &mut cpr, &body, issuer.decoded(), 0, uri, target);
+        let status = match processed.is_ok() {
+            true => UriStatus::CorrectData,
+            false => UriStatus::IncorrectData,
+        };
+        let detail = processed.err().map(|e| format!("{e:?}"));
         row(uri, UriExtension::Ocsp, status, timing_ms, detail)
     }
 
@@ -792,9 +815,9 @@ mod remote_impl {
     }
 
     #[allow(clippy::too_many_arguments)]
-    async fn check_uri_crl(
+    async fn check_uri_crl<F: UriFetcher>(
         pe: &PkiEnvironment,
-        client: &reqwest::Client,
+        fetcher: &F,
         uri: &str,
         target: &PDVCertificate,
         issuer: Option<&PDVCertificate>,
@@ -807,9 +830,11 @@ mod remote_impl {
             return row(uri, extension, UriStatus::BlacklistedHost, 0, None);
         }
 
-        let start = Instant::now();
-        let (ok, bytes) = http_get(client, uri).await;
-        let timing_ms = start.elapsed().as_millis() as u64;
+        let FetchOutcome {
+            ok,
+            body: bytes,
+            elapsed_ms: timing_ms,
+        } = fetcher.get(uri).await;
 
         let crl = CertificateList::from_der(&bytes);
         let status = match crl {
@@ -856,5 +881,156 @@ mod remote_impl {
             timing_ms,
             detail,
         }
+    }
+}
+
+#[cfg(feature = "remote")]
+mod remote_impl {
+    use super::*;
+    use core::time::Duration;
+    use std::time::Instant;
+
+    use certval::*;
+    use log::debug;
+
+    // A single 10 second per-request timeout mirrors certval's remote fetch client.
+    const REQUEST_TIMEOUT: Duration = Duration::from_secs(10);
+
+    /// The [`UriFetcher`] the command line and the desktop use: an HTTP client of its own.
+    ///
+    /// A browser cannot use this — it has no way to reach an arbitrary host — and supplies a fetcher
+    /// backed by the relay instead. Everything above this line is common to both.
+    #[derive(Debug, Default)]
+    pub struct ReqwestFetcher {
+        client: Option<reqwest::Client>,
+    }
+
+    impl ReqwestFetcher {
+        /// Builds a fetcher. A client that will not build leaves this reporting every retrieval as
+        /// unavailable, which is the same shape as a repository that cannot be reached.
+        pub fn new() -> Self {
+            ReqwestFetcher {
+                client: reqwest::Client::builder().build().ok(),
+            }
+        }
+    }
+
+    impl UriFetcher for ReqwestFetcher {
+        async fn get(&self, uri: &str) -> FetchOutcome {
+            let Some(client) = &self.client else {
+                return FetchOutcome::default();
+            };
+            let start = Instant::now();
+            let (ok, body) = http_get(client, uri).await;
+            FetchOutcome {
+                ok,
+                body,
+                elapsed_ms: start.elapsed().as_millis() as u64,
+            }
+        }
+
+        async fn post_ocsp(&self, uri: &str, request: &[u8]) -> FetchOutcome {
+            let Some(client) = &self.client else {
+                return FetchOutcome::default();
+            };
+            let start = Instant::now();
+            let sent = client
+                .post(uri)
+                .header("Content-Type", "application/ocsp-request")
+                .body(request.to_vec())
+                .timeout(REQUEST_TIMEOUT)
+                .send()
+                .await;
+            let elapsed_ms = start.elapsed().as_millis() as u64;
+            match sent {
+                Ok(resp) if resp.status().is_success() => match resp.bytes().await {
+                    Ok(b) => FetchOutcome {
+                        ok: true,
+                        body: b.to_vec(),
+                        elapsed_ms,
+                    },
+                    Err(e) => {
+                        debug!("OCSP body read failed for {uri}: {e}");
+                        FetchOutcome {
+                            elapsed_ms,
+                            ..Default::default()
+                        }
+                    }
+                },
+                Ok(_) => FetchOutcome {
+                    elapsed_ms,
+                    ..Default::default()
+                },
+                Err(e) => {
+                    debug!("OCSP post failed for {uri}: {e}");
+                    FetchOutcome {
+                        elapsed_ms,
+                        ..Default::default()
+                    }
+                }
+            }
+        }
+    }
+
+    /// Fetches raw bytes for a URI, returning (success, body). Success is false on any transport
+    /// error, non-2xx status, or an HTML error page.
+    async fn http_get(client: &reqwest::Client, uri: &str) -> (bool, Vec<u8>) {
+        let resp = match client.get(uri).timeout(REQUEST_TIMEOUT).send().await {
+            Ok(r) => r,
+            Err(e) => {
+                debug!("fetch failed for {uri}: {e}");
+                return (false, vec![]);
+            }
+        };
+        if !resp.status().is_success() {
+            return (false, vec![]);
+        }
+        let is_html = resp
+            .headers()
+            .get("Content-Type")
+            .and_then(|v| v.to_str().ok())
+            .map(|s| s.starts_with("text/html"))
+            .unwrap_or(false);
+        if is_html {
+            return (false, vec![]);
+        }
+        match resp.bytes().await {
+            Ok(b) => (true, b.to_vec()),
+            Err(e) => {
+                debug!("body read failed for {uri}: {e}");
+                (false, vec![])
+            }
+        }
+    }
+
+    /// Convenience entry point that builds an RFC 5280 [`PkiEnvironment`] and default settings, then
+    /// runs [`check_uris_in_cert`]. Both the CLI and GUI use this so neither has to construct a PKI
+    /// environment itself. `time_of_interest` is the usual Unix-seconds value (0 disables the
+    /// validity check). Signature verification requires the `rsa`/`eddsa`/`pqc` crypto features to be
+    /// enabled; without them every verification is treated as a failure.
+    pub async fn check_uris_from_bytes(
+        target_der: &[u8],
+        issuer_der: Option<&[u8]>,
+        auto_discover: bool,
+        time_of_interest: u64,
+        blocklist: &[String],
+    ) -> UriCheckReport {
+        let mut cps = CertificationPathSettings::default();
+        if let Ok(toi) = TimeOfInterest::from_unix_secs(time_of_interest) {
+            cps.set_time_of_interest(toi);
+        }
+        let mut pe = PkiEnvironment::default();
+        pe.populate_5280_pki_environment();
+        let fetcher = ReqwestFetcher::new();
+        check_uris_in_cert(
+            &pe,
+            &cps,
+            &fetcher,
+            target_der,
+            issuer_der,
+            auto_discover,
+            blocklist,
+        )
+        .await
     }
 }

--- a/pittv3-service/src/orchestrate.rs
+++ b/pittv3-service/src/orchestrate.rs
@@ -20,7 +20,7 @@ use certval::{
 // there to be one implementation of it.
 use pittv3_gui_lib::retrieval::{certificates_in, harvest_revocation_work};
 use pittv3_gui_lib::validate::{prepare_validation, validate_prepared, PreparedValidation};
-use pittv3_lib::report::{TargetReport, ValidationReport};
+use pittv3_lib::report::{RevocationStatus, TargetReport, ValidationReport};
 use pittv3_relay::{ChaseBudget, FetchRequest, Relay};
 
 use crate::config::{RequestLimits, ServiceState};
@@ -196,12 +196,23 @@ async fn run(
 /// other outbound request this service makes: certval here is built without `remote` and cannot
 /// open a socket of its own, so the network policy and the budgets cannot be gone around.
 ///
-/// CRLs are retrieved first because one covers every certificate its issuer published it for,
-/// while an OCSP request answers about exactly one — so a distribution point can settle several
-/// positions at the price of one retrieval, and every certificate it settles is one this then does
-/// not have to ask a responder about.
+/// **OCSP is retrieved first, and a CRL only for what OCSP left undetermined.** The reverse was
+/// tried first, reasoning that one CRL covers every certificate its issuer published it for while a
+/// responder answers about one, so a distribution point could settle several positions for the price
+/// of one retrieval. Measurement said otherwise, on two independent PKIs: DoD's
+/// `DODEMAILCA_63.crl` is 9.5 MB and Amazon's `r2m04.crl` is 2.24 MB, against OCSP responses of a
+/// few hundred bytes — and certval consults stapled OCSP before any registered CRL source, so with
+/// both in hand the OCSP always decided and the CRL was downloaded and ignored. On a bounded
+/// per-request budget that is most of the budget spent on data that changes no outcome, and the
+/// person waiting for a first answer waits on the download.
 ///
-/// A failure is a note rather than an error. Revocation status that cannot be determined is already
+/// Knowing what OCSP settled takes a validation pass: the revocation checker writes its
+/// determinations into the cache registered on the environment, and [`harvest_revocation_work`]
+/// skips a certificate whose status that cache already answers. So the middle step here validates
+/// and throws the reports away — they are recomputed by the caller once the CRLs are in — purely so
+/// the second harvest can tell which positions still need one.
+///
+/// A retrieval failure is a note rather than an error throughout: an undetermined status is
 /// an outcome the report expresses, and one unreachable repository should not turn a run into a
 /// failure.
 async fn retrieve_revocation_data(
@@ -213,46 +224,14 @@ async fn retrieve_revocation_data(
 ) -> usize {
     let work = harvest_revocation_work(prepared, settings, &input.targets);
     if work.is_empty() {
+        notes.push("no revocation data to retrieve for the paths built".to_string());
         return 0;
     }
 
     let mut budget = ChaseBudget::new(state.config.chase_budget.clone());
     let mut added = 0;
 
-    let crl_sink = prepared.crl_source();
-    for uri in &work.crl_dp {
-        if let Err(exhausted) = budget.check() {
-            notes.push(format!("stopped retrieving CRLs: {exhausted}"));
-            break;
-        }
-        let request = FetchRequest {
-            max_response_bytes: Some(budget.remaining_bytes()),
-            timeout: Some(budget.remaining_time()),
-            ..FetchRequest::get(uri.clone())
-        };
-        match state.relay.fetch(&request).await {
-            Ok(response) => {
-                budget.spend(response.body.len() as u64);
-                if response.status != 200 {
-                    notes.push(format!("{uri} answered with status {}", response.status));
-                    continue;
-                }
-                match crl_sink.add(&response.body) {
-                    true => added += 1,
-                    false => notes.push(format!("{uri} did not serve a CRL")),
-                }
-            }
-            Err(e) => {
-                budget.spend(0);
-                notes.push(format!("could not retrieve {uri}: {e}"));
-            }
-        }
-    }
-    if added > 0 {
-        notes.push(format!("retrieved {added} CRL(s)"));
-    }
-
-    // A certificate a CRL already answered for is not asked about again, and neither is one whose
+    // A certificate whose answer is already held is not asked about again, and neither is one whose
     // second responder would repeat a question the first has settled.
     let ocsp_sink = prepared.ocsp_responses();
     let mut responses = 0;
@@ -290,6 +269,76 @@ async fn retrieve_revocation_data(
     }
     if responses > 0 {
         notes.push(format!("retrieved {responses} OCSP response(s)"));
+    }
+
+    // What OCSP settled, so the CRL half can skip it. The reports are discarded: this runs only to
+    // let the revocation checker write its determinations into the cache, which the second harvest
+    // reads through `get_status`. Without a cache registered nothing is recorded, the second harvest
+    // returns the same work as the first, and this degrades to retrieving both -- which is the old
+    // behaviour, not a failure.
+    // Whether anything is still unresolved, read from the validation's own reports rather than from
+    // the revocation cache. The cache would work here -- this service always registers one -- but
+    // the browser cannot rely on that, since its cache is a user setting, and the two tiers have to
+    // reach the same conclusion by the same means or they are not the same code.
+    let crl_dp = match responses > 0 {
+        true => {
+            let (reports, _) =
+                validate_prepared(prepared, settings, &input.targets, input.validate_all);
+            // Conservative on purpose: a path with no outcomes recorded counts as unresolved, so
+            // this only skips on positive evidence that every position is settled.
+            let unresolved = reports.iter().any(|t| {
+                t.paths.iter().any(|p| {
+                    p.revocation.is_empty()
+                        || p.revocation
+                            .iter()
+                            .any(|o| o.status == RevocationStatus::Undetermined)
+                })
+            });
+            match unresolved {
+                true => work.crl_dp.clone(),
+                false => {
+                    notes.push(format!(
+                        "skipped {} CRL retrieval(s): OCSP settled every certificate",
+                        work.crl_dp.len()
+                    ));
+                    vec![]
+                }
+            }
+        }
+        false => work.crl_dp.clone(),
+    };
+
+    let crl_sink = prepared.crl_source();
+    for uri in &crl_dp {
+        if let Err(exhausted) = budget.check() {
+            notes.push(format!("stopped retrieving CRLs: {exhausted}"));
+            break;
+        }
+        let request = FetchRequest {
+            max_response_bytes: Some(budget.remaining_bytes()),
+            timeout: Some(budget.remaining_time()),
+            ..FetchRequest::get(uri.clone())
+        };
+        match state.relay.fetch(&request).await {
+            Ok(response) => {
+                budget.spend(response.body.len() as u64);
+                if response.status != 200 {
+                    notes.push(format!("{uri} answered with status {}", response.status));
+                    continue;
+                }
+                match crl_sink.add(&response.body) {
+                    true => added += 1,
+                    false => notes.push(format!("{uri} did not serve a CRL")),
+                }
+            }
+            Err(e) => {
+                budget.spend(0);
+                notes.push(format!("could not retrieve {uri}: {e}"));
+            }
+        }
+    }
+    if added > 0 {
+        notes.push(format!("retrieved {added} CRL(s)"));
     }
 
     added + responses

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -10,23 +10,27 @@ use std::sync::Arc;
 use dioxus::prelude::*;
 use web_time::{SystemTime, UNIX_EPOCH};
 
-use certval::{CertificationPathSettings, RevocationCache, TimeOfInterest};
+use certval::{CertificationPathSettings, PkiEnvironment, RevocationCache, TimeOfInterest};
 use pittv3_gui_lib::gui_results::ResultsView;
 use pittv3_gui_lib::gui_settings::{Capabilities, EditSettings};
 use pittv3_gui_lib::gui_settings_model::SettingsModel;
 use pittv3_gui_lib::gui_shell::AppShell;
+use pittv3_gui_lib::gui_uri_check::UriCheckResults;
 use pittv3_gui_lib::settings_store::SettingsStore;
 use pittv3_gui_lib::PITTV3_CSS;
-use pittv3_lib::report::{TargetReport, ValidationReport};
+use pittv3_lib::report::{RevocationStatus, TargetReport, ValidationReport};
+use pittv3_lib::uri_check::{check_uris_in_cert, UriCheckReport};
 
 use pittv3_gui_lib::export::{path_entries, paths_text, zip_paths};
 use pittv3_gui_lib::retrieval::{add_uploaded_crl, harvest_revocation_work, staple_uploaded_ocsp};
 
-use crate::relay::{chase_certificates, retrieve_crls, retrieve_ocsp, FetchBudget, Tier};
+use crate::relay::{
+    chase_certificates, retrieve_crls, retrieve_ocsp, FetchBudget, RelayFetcher, Tier,
+};
 use crate::validate::{
     merge_service_stores, prepare_validation, shipped_catalog, validate_hackathon_zip,
     validate_prepared, validate_prepared_retaining, PreparedValidation, ResultLine, RetainedPath,
-    StoreDescriptor, SAMPLE_INVALID, SAMPLE_VALID,
+    StoreDescriptor,
 };
 
 /// Store selection value indicating no baked-in store, i.e., uploaded trust anchors only
@@ -69,6 +73,7 @@ const VIEW_LABELS: &[&str] = &[
     "Settings",
     "Results",
     "Store artifacts",
+    "Check URIs",
     "Hackathon",
     "Help",
 ];
@@ -312,6 +317,13 @@ fn App() -> Element {
     // it. These are folded in at Validate instead, so they survive every rebuild.
     let mut uploaded_crls = use_signal(Vec::<(String, Vec<u8>)>::new);
     let mut uploaded_ocsp = use_signal(Vec::<(String, Vec<u8>)>::new);
+    // "Check URIs in certificate": a single certificate examined on its own, independent of path
+    // processing, so it keeps its own inputs rather than borrowing the Validate view's.
+    let mut uri_target = use_signal(|| None::<(String, Vec<u8>)>);
+    let mut uri_issuer = use_signal(|| None::<(String, Vec<u8>)>);
+    let mut uri_auto = use_signal(|| true);
+    let mut uri_running = use_signal(|| false);
+    let mut uri_report = use_signal(|| None::<UriCheckReport>);
     // Whether this run has revocation data of its own. Read when the settings for a run are built,
     // because it is one of the two ways a run can obtain any -- see `run_settings`.
     let have_revocation_uploads =
@@ -356,6 +368,10 @@ fn App() -> Element {
     // alongside it would re-fetch revocation data a retrieval had already paid for. Settings changes
     // are the case that does invalidate them, and the effect that watches settings clears this.
     let rev_cache = use_signal(|| Arc::new(RevocationCache::new()));
+    // Confirmation for the Clear button below. Clearing is invisible otherwise -- nothing on screen
+    // changes -- so without a word back the only way to tell it happened is to run again and watch
+    // the retrieval notes.
+    let mut rev_cache_status = use_signal(String::new);
     // The paths this run validated, kept so their artifacts can be exported without validating
     // again. Retaining costs nothing to compute -- the paths and results exist for the duration of
     // the validation regardless -- and re-validating to produce an export would describe a
@@ -851,18 +867,82 @@ fn App() -> Element {
                         prepared.ocsp_responses().clone(),
                     )
                 };
-                // CRLs first: one covers every certificate its issuer published it for, so a
-                // distribution point can settle several positions at the price of one retrieval,
-                // whereas an OCSP request answers about exactly one certificate.
-                if !work.crl_dp.is_empty() {
-                    let (_added, crl_notes) =
-                        retrieve_crls(&work.crl_dp, &crl_sink, &mut budget).await;
-                    notes.write().extend(crl_notes);
+                // Said out loud, because silence here is indistinguishable from a retrieval that
+                // found nothing to do -- and an empty work list is exactly how a PEM target failed
+                // on 2026-08-20, reporting every position undetermined with no explanation.
+                if work.is_empty() {
+                    notes.write().push(ResultLine {
+                        class: "info",
+                        text: "No revocation data to retrieve for the paths built".to_string(),
+                    });
                 }
+                // OCSP first, and a CRL only for what OCSP leaves undetermined. The reverse was
+                // tried first, reasoning that one CRL covers every certificate its issuer published
+                // it for while a responder answers about one. Measurement said otherwise on two
+                // independent PKIs -- DoD's DODEMAILCA_63.crl is 9.5 MB and Amazon's r2m04.crl is
+                // 2.24 MB, against OCSP responses of a few hundred bytes -- and certval consults
+                // stapled OCSP before any registered CRL source, so with both in hand the OCSP
+                // always decided and the CRL was fetched and ignored. That is most of a click's
+                // budget spent on data that changes no outcome, and it is what the person waiting
+                // for a first answer is waiting on.
+                let mut retrieved_ocsp = 0;
                 if !work.ocsp.is_empty() {
-                    let (_added, ocsp_notes) =
+                    let (added, ocsp_notes) =
                         retrieve_ocsp(&work.ocsp, &ocsp_sink, &mut budget).await;
+                    retrieved_ocsp = added;
                     notes.write().extend(ocsp_notes);
+                }
+
+                // Which positions OCSP settled. Knowing that takes a validation pass: the checker
+                // writes its determinations into the registered cache, and harvest_revocation_work
+                // skips a certificate whose status that cache already answers. The reports are
+                // discarded -- the run validates again below, once the CRLs are in.
+                //
+                // With the revocation cache turned off nothing is recorded, the second harvest
+                // returns what the first did, and this degrades to retrieving both. That is the old
+                // behaviour rather than a failure, which is why it is not gated on the setting.
+                // Whether anything is still unresolved, read from the validation's own reports
+                // rather than from the revocation cache. Asking the cache would tie this to the
+                // "reuse determinations" setting -- turn that off and every CRL gets fetched again,
+                // which is a bandwidth decision quietly riding on a per-path-evidence one. The
+                // reports say what was actually determined, whatever the cache is doing.
+                let crl_dp = match retrieved_ocsp > 0 {
+                    true => {
+                        let guard = prepared_env.read();
+                        let (prepared, _) = guard.as_ref().unwrap();
+                        let (reports, _) =
+                            validate_prepared(prepared, &cps, &loaded_ees(), validate_all());
+                        // Conservative on purpose: a path with no outcomes recorded counts as
+                        // unresolved, so this only skips on positive evidence that every position is
+                        // settled. It can never turn a determinable path into an undetermined one.
+                        let unresolved = reports.iter().any(|t| {
+                            t.paths.iter().any(|p| {
+                                p.revocation.is_empty()
+                                    || p.revocation
+                                        .iter()
+                                        .any(|o| o.status == RevocationStatus::Undetermined)
+                            })
+                        });
+                        match unresolved {
+                            true => work.crl_dp.clone(),
+                            false => {
+                                notes.write().push(ResultLine {
+                                    class: "info",
+                                    text: format!(
+                                        "skipped {} CRL retrieval(s): OCSP settled every certificate",
+                                        work.crl_dp.len()
+                                    ),
+                                });
+                                vec![]
+                            }
+                        }
+                    }
+                    false => work.crl_dp.clone(),
+                };
+
+                if !crl_dp.is_empty() {
+                    let (_added, crl_notes) = retrieve_crls(&crl_dp, &crl_sink, &mut budget).await;
+                    notes.write().extend(crl_notes);
                 }
             }
         }
@@ -1095,17 +1175,6 @@ fn App() -> Element {
                                     }
                                 },
                             }
-                            label { "Sample Certificate: " }
-                            span {
-                                button {
-                                    onclick: move |_| load_ee(SAMPLE_VALID.0.to_string(), SAMPLE_VALID.1.to_vec()),
-                                    "Load valid sample (ML-DSA-44)"
-                                }
-                                button {
-                                    onclick: move |_| load_ee(SAMPLE_INVALID.0.to_string(), SAMPLE_INVALID.1.to_vec()),
-                                    "Load invalid sample (ML-DSA-44)"
-                                }
-                            }
                             span { class: "hint",
                                 "{loaded_ees().len()} certificate(s) loaded "
                                 button {
@@ -1140,10 +1209,27 @@ fn App() -> Element {
                                 checked: use_rev_cache(),
                                 onchange: move |ev| use_rev_cache.set(ev.checked()),
                             }
+                            // Clearing is its own action rather than a side effect of toggling the
+                            // checkbox above. Turning the reuse setting off does clear the cache, but
+                            // using that to clear it also changes how the run behaves -- which is a
+                            // real trap: it silently gives up the CRL retrievals OCSP would otherwise
+                            // have spared.
+                            button {
+                                onclick: move |_| {
+                                    rev_cache().clear();
+                                    rev_cache_status
+                                        .set("Revocation determinations cleared.".to_string());
+                                },
+                                "Clear cached determinations"
+                            }
                             span { class: "hint",
                                 "On, a certificate checked on one path is not checked again on another. "
                                 "Off, every path obtains its own revocation data — slower, but each path "
-                                "then carries the evidence for its own result, which an export needs."
+                                "then carries the evidence for its own result, which an export needs. "
+                                "Clear discards what has been determined so far without changing either."
+                            }
+                            if !rev_cache_status().is_empty() {
+                                span { class: "hint", "{rev_cache_status}" }
                             }
                         }
 
@@ -1363,6 +1449,112 @@ fn App() -> Element {
                         }
                     },
                     4 => rsx! {
+                        div { class: "help-view",
+                            h2 { "Check URIs in certificate" }
+                            p {
+                                "Fetches every HTTP URI a certificate names — authority information "
+                                "access, subject information access, CRL distribution points and "
+                                "freshest CRL — and reports each one on its own. This is a check of "
+                                "the repositories, not of the certificate: it builds no path and "
+                                "reaches no verdict about trust."
+                            }
+                            p { class: "hint",
+                                "An issuer, supplied or auto-discovered from AIA, is what makes CRL "
+                                "signature verification and OCSP possible; without one those rows "
+                                "report that they could not be checked rather than failing."
+                            }
+                        }
+                        if !tier().retrieves() {
+                            div { class: "controls",
+                                span { class: "hint",
+                                    "This check retrieves from the repositories a certificate names, "
+                                    "so it needs the service. Choose \"Retrieve through the service\" "
+                                    "on the Validate tab."
+                                }
+                            }
+                        }
+                        div { class: "controls custom",
+                            label { "Certificate: " }
+                            input {
+                                r#type: "file",
+                                onchange: move |ev| async move {
+                                    if let Some((name, bytes)) = read_files(&ev).await.into_iter().next() {
+                                        uri_target.set(Some((name, bytes)));
+                                        uri_report.set(None);
+                                    }
+                                },
+                            }
+                            label { "Issuer (optional): " }
+                            input {
+                                r#type: "file",
+                                onchange: move |ev| async move {
+                                    if let Some((name, bytes)) = read_files(&ev).await.into_iter().next() {
+                                        uri_issuer.set(Some((name, bytes)));
+                                    }
+                                },
+                            }
+                            label { r#for: "uri-auto", "Auto-discover the issuer: " }
+                            input {
+                                id: "uri-auto",
+                                r#type: "checkbox",
+                                checked: uri_auto(),
+                                onchange: move |ev| uri_auto.set(ev.checked()),
+                            }
+                            span { class: "hint",
+                                match uri_target() {
+                                    Some((name, _)) => format!("{name} loaded"),
+                                    None => "no certificate chosen".to_string(),
+                                }
+                            }
+                        }
+                        div { class: "controls center-row",
+                            button {
+                                disabled: uri_running() || uri_target().is_none() || !tier().retrieves(),
+                                onclick: move |_| async move {
+                                    let Some((_, target)) = uri_target() else {
+                                        return;
+                                    };
+                                    uri_running.set(true);
+                                    uri_report.set(None);
+                                    // Its own environment and settings: this check answers about a
+                                    // certificate rather than about a path, so the trust material
+                                    // selected on the Validate tab has no bearing on it.
+                                    let mut cps = CertificationPathSettings::default();
+                                    if let Ok(toi) = TimeOfInterest::from_unix_secs(now_as_unix_epoch()) {
+                                        cps.set_time_of_interest(toi);
+                                    }
+                                    let mut pe = PkiEnvironment::default();
+                                    pe.populate_5280_pki_environment();
+                                    let issuer = uri_issuer();
+                                    let report = check_uris_in_cert(
+                                        &pe,
+                                        &cps,
+                                        &RelayFetcher::new(),
+                                        &target,
+                                        issuer.as_ref().map(|(_, b)| b.as_slice()),
+                                        uri_auto(),
+                                        &[],
+                                    )
+                                    .await;
+                                    uri_report.set(Some(report));
+                                    uri_running.set(false);
+                                },
+                                if uri_running() { "Checking\u{2026}" } else { "Check URIs" }
+                            }
+                            button {
+                                onclick: move |_| {
+                                    uri_report.set(None);
+                                    uri_target.set(None);
+                                    uri_issuer.set(None);
+                                },
+                                "Clear"
+                            }
+                        }
+                        if let Some(report) = uri_report() {
+                            UriCheckResults { report }
+                        }
+                    },
+                    5 => rsx! {
                         div { class: "controls",
                             label { "Hackathon artifacts zip: " }
                             input {

--- a/pittv3-wasm/src/relay.rs
+++ b/pittv3-wasm/src/relay.rs
@@ -16,6 +16,8 @@ use pittv3_gui_lib::retrieval::{
     certificates_in, harvest_chase_uris, MemoryCrlSource, OcspRequestItem, OcspResponses,
 };
 use pittv3_gui_lib::validate::ResultLine;
+use pittv3_lib::uri_check::{FetchOutcome, UriFetcher};
+use web_time::Instant;
 // Only the browser build exchanges anything with the relay; the host build has no relay to reach,
 // so the wire types and their derives are compiled only there.
 #[cfg(target_family = "wasm")]
@@ -235,14 +237,21 @@ fn err(text: String) -> ResultLine {
 /// reporting rather than absorbing: a repository that redirects is a fact about that PKI, and it is
 /// the redirected-to host the relay's policy actually judged.
 fn redirect_note(requested: &str, response: &Retrieved) -> Option<ResultLine> {
-    let moved = !response.final_uri.is_empty() && response.final_uri != requested;
-    match moved {
-        true => Some(info(format!(
-            "{requested} redirected to {}",
-            response.final_uri
-        ))),
-        false => None,
+    if response.final_uri.is_empty() || response.final_uri == requested {
+        return None;
     }
+    // A bare authority redirecting to itself with a path of "/" is the same resource, and saying so
+    // is noise: an OCSP responder named without a path does this on every request, which buried the
+    // two notes that mattered under four that did not. Anything else -- a different host, a
+    // different path, a different scheme -- is still reported, because that is the fact about the
+    // PKI worth knowing and it is the redirected-to host the policy actually judged.
+    if response.final_uri.trim_end_matches('/') == requested.trim_end_matches('/') {
+        return None;
+    }
+    Some(info(format!(
+        "{requested} redirected to {}",
+        response.final_uri
+    )))
 }
 
 /// Chases the authority and subject information access URIs named by `seeds` and whatever they
@@ -431,6 +440,95 @@ pub async fn retrieve_ocsp(
         notes.push(info(format!("Retrieved {added} OCSP response(s)")));
     }
     (added, notes)
+}
+
+/// The [`UriFetcher`] the browser uses: every retrieval goes through the relay.
+///
+/// This is the whole of what the URI checker needed from a browser. The relay already moves exactly
+/// these two shapes for revocation retrieval -- a bare `GET` for a certificate bundle or a CRL, and
+/// a `POST` of a DER OCSP request -- so the checker reaches repositories a page cannot reach itself
+/// without the service growing an endpoint for it.
+///
+/// A budget is held here rather than by the checker because it is the retrieving that has to be
+/// bounded: a certificate naming a subject information access URI that serves a bundle naming more
+/// turns one check into an unbounded amount of fetching. Exhaustion reports each further URI as
+/// unavailable rather than erroring, which is how the results grid already renders a repository that
+/// could not be reached.
+pub struct RelayFetcher {
+    budget: core::cell::RefCell<FetchBudget>,
+}
+
+impl RelayFetcher {
+    /// A fetcher with a budget of its own for one check.
+    pub fn new() -> Self {
+        RelayFetcher {
+            budget: core::cell::RefCell::new(FetchBudget::new()),
+        }
+    }
+
+    /// Records a retrieval and reports whether it was permitted to happen at all.
+    fn afford(&self, bytes: usize) -> bool {
+        let mut budget = self.budget.borrow_mut();
+        let allowed = budget.available();
+        budget.spend(bytes);
+        allowed
+    }
+}
+
+impl Default for RelayFetcher {
+    fn default() -> Self {
+        RelayFetcher::new()
+    }
+}
+
+impl UriFetcher for RelayFetcher {
+    async fn get(&self, uri: &str) -> FetchOutcome {
+        if !self.afford(0) {
+            return FetchOutcome::default();
+        }
+        let start = Instant::now();
+        let outcome = relay_fetch(uri).await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        match outcome {
+            // The status is reported by the checker, not translated here: a 404 on an authority
+            // information access URI is a fact about the certificate, and the grid says so.
+            Ok(r) if r.status == 200 => {
+                self.afford(r.body.len());
+                FetchOutcome {
+                    ok: true,
+                    body: r.body,
+                    elapsed_ms,
+                }
+            }
+            Ok(_) | Err(_) => FetchOutcome {
+                elapsed_ms,
+                ..Default::default()
+            },
+        }
+    }
+
+    async fn post_ocsp(&self, uri: &str, request: &[u8]) -> FetchOutcome {
+        if !self.afford(request.len()) {
+            return FetchOutcome::default();
+        }
+        let start = Instant::now();
+        let outcome = relay_ocsp(uri, request).await;
+        let elapsed_ms = start.elapsed().as_millis() as u64;
+        match outcome {
+            Ok(r) if r.status == 200 => {
+                self.afford(r.body.len());
+                FetchOutcome {
+                    ok: true,
+                    body: r.body,
+                    elapsed_ms,
+                }
+            }
+            Ok(_) | Err(_) => FetchOutcome {
+                elapsed_ms,
+                ..Default::default()
+            },
+        }
+    }
 }
 
 #[cfg(test)]

--- a/pittv3-wasm/src/validate.rs
+++ b/pittv3-wasm/src/validate.rs
@@ -195,21 +195,26 @@ pub fn merge_service_stores(
     added
 }
 
-/// Sample end entity certificate from the ML-DSA-44 PKITS edition that should validate
-pub const SAMPLE_VALID: (&str, &[u8]) = (
-    "ValidCertificatePathTest1EE.der",
-    include_bytes!("../resources/sample_valid_ml_dsa_44.der"),
-);
-
-/// Sample end entity certificate from the ML-DSA-44 PKITS edition that should fail validation
-/// with a signature verification error, i.e., the end entity certificate signature is bad
-pub const SAMPLE_INVALID: (&str, &[u8]) = (
-    "InvalidEESignatureTest3EE.der",
-    include_bytes!("../resources/sample_invalid_ml_dsa_44.der"),
-);
-
 #[cfg(test)]
 mod tests {
+    // Kept as test fixtures rather than as something the app offers. They were the zero-input demo
+    // when this was a PQC demonstration; it is a full PITTv3 frontend now, and a sample whose PKITS
+    // URIs resolve nowhere reports every position undetermined, which reads as breakage. The
+    // end-to-end coverage they give -- a known-good and a known-bad path through the real validator
+    // -- is worth keeping, so they live here.
+    /// Sample end entity certificate from the ML-DSA-44 PKITS edition that should validate
+    pub const SAMPLE_VALID: (&str, &[u8]) = (
+        "ValidCertificatePathTest1EE.der",
+        include_bytes!("../resources/sample_valid_ml_dsa_44.der"),
+    );
+
+    /// Sample end entity certificate from the ML-DSA-44 PKITS edition that should fail validation
+    /// with a signature verification error, i.e., the end entity certificate signature is bad
+    pub const SAMPLE_INVALID: (&str, &[u8]) = (
+        "InvalidEESignatureTest3EE.der",
+        include_bytes!("../resources/sample_invalid_ml_dsa_44.der"),
+    );
+
     // These exercise the shared validation path against this crate's generated store resources,
     // so they live here rather than in pittv3-gui-lib, which has no fixtures of its own. certval
     // is named explicitly because the module above re-exports the validation API rather than


### PR DESCRIPTION
- stop downloading both ocsp and crls after harvesting uris and instead harvest ocsp then only harvest crls upon failure to determine status
- better handling of pem downloads
- add sia/aia checker tab a la the similar feature in the desktop app
- drop the ml-dsa sample certs