### PR TITLE
pittv3 changes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
 target
+# Harvested by pittv3-lib's ocsp_unknown_serial probe; kept out of the tree until something is
+# promoted to a fixture, but not under target/, which is disposable.
+ocsp-probe/
 certval/tests/examples/rfc822_dn_nc/generate.py
 pittv3-wasm/dist/

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5209,8 +5209,10 @@ version = "0.1.3"
 dependencies = [
  "log",
  "reqwest 0.13.4",
+ "rustls",
  "serde",
  "tokio",
+ "tokio-rustls",
 ]
 
 [[package]]
@@ -6147,6 +6149,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c54fcab019b409d04215d3a17cb438fd7fbf192ee61461f20f4fe18704bc138"
 dependencies = [
  "aws-lc-rs",
+ "log",
  "once_cell",
  "ring",
  "rustls-pki-types",

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -533,7 +533,6 @@ enum SettingsTab {
     Target,
     Revocation,
     Fetching,
-    Countries,
     Folders,
 }
 
@@ -544,9 +543,22 @@ const TABS: &[(SettingsTab, &str)] = &[
     (SettingsTab::Target, "Target"),
     (SettingsTab::Revocation, "Revocation"),
     (SettingsTab::Fetching, "Fetching"),
-    (SettingsTab::Countries, "Countries"),
     (SettingsTab::Folders, "Folders & files"),
 ];
+
+/// Whether a tab has anything to offer the frontend showing it.
+///
+/// Folders and files name paths on a machine the browser has no way to reach, so it is left out
+/// there rather than shown with a notice saying it does nothing: a tab that only ever explains its
+/// own absence of effect costs a reader more than it tells them. The values are not discarded with
+/// it — they stay in the model, so a settings file carrying paths still loads here, keeps them, and
+/// hands them back intact to the CLI or the desktop app that can act on them.
+fn tab_applies(tab: SettingsTab, caps: &Capabilities) -> bool {
+    match tab {
+        SettingsTab::Folders => caps.filesystem,
+        _ => true,
+    }
+}
 
 /// Renderer-agnostic settings editor over a [`SettingsModel`]. The `on_save` handler receives the
 /// edited model; persistence (file, server, browser storage) is the frontend's concern. `caps`
@@ -577,7 +589,7 @@ pub fn EditSettings(
     rsx! {
         div { class: "settings-editor",
             div { class: "tab-bar",
-                for (t , label) in TABS.iter() {
+                for (t , label) in TABS.iter().filter(|(t, _)| tab_applies(*t, &caps)) {
                     button {
                         r#type: "button",
                         class: if tab() == *t { "tab tab-active" } else { "tab" },
@@ -875,37 +887,7 @@ pub fn EditSettings(
                         }
                     }
                 },
-                SettingsTab::Countries => rsx! {
-                    table {
-                        tbody {
-                            BoolRow {
-                                label: "Require country code compliance",
-                                checked: m.require_country_code_indicator.unwrap_or(false),
-                                overridden: m.require_country_code_indicator.is_some(),
-                                onchange: move |v| model.write().require_country_code_indicator = Some(v),
-                            }
-                        }
-                    }
-                    StringListEditor {
-                        label: "Permitted countries",
-                        value: m.perm_countries.clone(),
-                        onchange: move |v| model.write().perm_countries = v,
-                    }
-                    StringListEditor {
-                        label: "Excluded countries",
-                        value: m.excl_countries.clone(),
-                        onchange: move |v| model.write().excl_countries = v,
-                    }
-                },
                 SettingsTab::Folders => rsx! {
-                    if !caps.filesystem {
-                        CapabilityNotice {
-                            message: "This frontend has no filesystem access, so these paths do not resolve here. \
-                                      They are kept in the settings file, which is the same format the CLI and the \
-                                      desktop app read, so a path set here takes effect when the file is used there."
-                                .to_string(),
-                        }
-                    }
                     table {
                         tbody {
                             SettingTextRow {

--- a/pittv3-relay/Cargo.toml
+++ b/pittv3-relay/Cargo.toml
@@ -4,8 +4,8 @@ version = "0.1.3"
 description = """
 Policy-enforcing byte relay used by frontends to the PKI Interoperability Test Tool v3 (PITTv3) that
 cannot reach PKI repositories themselves, i.e., browsers. It retrieves certificates, CRLs and OCSP
-responses on a caller's behalf subject to a network policy and a set of budgets, without parsing
-what it retrieves.
+responses on a caller's behalf, and takes the certificates a TLS host presents, subject to a network
+policy and a set of budgets, without parsing what it retrieves.
 """
 authors = [""]
 license = "Apache-2.0 OR MIT"
@@ -27,6 +27,11 @@ log = { version = "0.4.33" }
 # reqwest is pinned to the version certval uses so a workspace build resolves one HTTP client and
 # one TLS backend rather than two.
 reqwest = { version = "0.13.4" }
+# The handshake that takes a server's certificates is made here rather than through the HTTP client,
+# which reports only what it retrieved and never who presented it. `ring` is named rather than left
+# to the default so the provider does not depend on which crate in the workspace resolved first.
+rustls = { version = "0.23.42", default-features = false, features = ["logging", "ring", "std", "tls12"] }
+tokio-rustls = { version = "0.26.4", default-features = false, features = ["logging", "ring", "tls12"] }
 serde = { version = "1.0.228", features = ["derive"] }
 # "net" for the address resolution the policy performs itself before a socket is opened, "time" for
 # the per-request timeout.

--- a/pittv3-relay/README.md
+++ b/pittv3-relay/README.md
@@ -12,11 +12,22 @@ identity, and does not distinguish a CRL from any other sequence of bytes. Condi
 headers pass through so a caller can benefit from `If-Modified-Since` the same way the PITTv3 CLI
 does when it maintains a download folder.
 
+It also takes the certificates a TLS server presents, which is retrieval of a different shape: the
+artifact is not served at a URI, it is what a host sends when spoken to. A browser cannot obtain it
+at all — it holds the certificate of every site it talks to and hands over none of them — so a
+handshake made here is the only way the certificate a site serves reaches an application that wants
+to validate it. The handshake accepts any certificate, deliberately: a chain a verifier would reject
+is exactly the chain someone reaches for this tool to look at. What it does not skip is the peer's
+handshake signature, so what comes back belongs to the party that answered rather than to anything
+that could reach the address. Nothing is sent over the connection and nothing is parsed; a stapled
+OCSP response is kept because the peer volunteered it.
+
 Because the URIs it is asked to retrieve come from certificates supplied by whoever is using the
 service, every request is treated as attacker-chosen. The `policy` module enforces a scheme and port
 allowlist, resolves each hostname itself and rejects addresses that are loopback, private,
 link-local, unique-local, multicast or otherwise not a public destination, and then connects to the
-addresses it resolved rather than resolving a second time inside the HTTP client. Redirects are
+addresses it resolved rather than resolving a second time inside the HTTP client. A handshake goes
+through the same checks, so it cannot reach a host, an address or a port a retrieval could not. Redirects are
 refused unless a limit is configured, and each hop is checked afresh. Budgets bound the size of a
 response, the time a request may take, and the size of a request body.
 

--- a/pittv3-relay/src/lib.rs
+++ b/pittv3-relay/src/lib.rs
@@ -4,6 +4,7 @@
 #![warn(missing_docs, rust_2018_idioms, unused_qualifications)]
 
 pub mod budget;
+pub mod peek;
 pub mod policy;
 
 use std::sync::Arc;
@@ -13,6 +14,7 @@ use log::debug;
 use serde::{Deserialize, Serialize};
 
 pub use budget::{BudgetExhausted, ChaseBudget, ChaseBudgetLimits, FetchBudget};
+pub use peek::{PeekRequest, PeekResponse};
 pub use policy::{is_public_address, CheckedUri, NetworkPolicy, PolicyError, PolicyResolver};
 
 /// Verbs PKI retrieval needs. `GET` covers certificates and CRLs named by authority information
@@ -101,8 +103,10 @@ pub struct FetchResponse {
 pub enum FetchError {
     /// The URI, its host's addresses, or a redirect target was refused by the network policy.
     Policy(PolicyError),
-    /// The retrieval did not complete within the time allowed.
-    Timeout,
+    /// The exchange did not complete within the time allowed, which is reported: "timed out" alone
+    /// leaves a caller unable to tell a host that is slow from one that never answers, and unable
+    /// to tell either from a budget set too low.
+    Timeout(Duration),
     /// The response body exceeded the cap, either as claimed by `Content-Length` or as observed
     /// while streaming. The cap that was exceeded is reported.
     TooLarge(u64),
@@ -118,7 +122,7 @@ impl core::fmt::Display for FetchError {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         match self {
             FetchError::Policy(e) => write!(f, "refused by policy: {e}"),
-            FetchError::Timeout => write!(f, "timed out"),
+            FetchError::Timeout(after) => write!(f, "timed out after {after:?}"),
             FetchError::TooLarge(cap) => write!(f, "response exceeded the {cap}-byte cap"),
             FetchError::RequestTooLarge(cap) => write!(f, "request exceeded the {cap}-byte cap"),
             FetchError::Transport(e) => write!(f, "transport failure: {e}"),
@@ -217,7 +221,7 @@ impl Relay {
             Ok(r) => r,
             Err(e) if e.is_timeout() => {
                 debug!("Retrieval of {} timed out after {timeout:?}", request.uri);
-                return Err(FetchError::Timeout);
+                return Err(FetchError::Timeout(timeout));
             }
             Err(e) => {
                 debug!("Retrieval of {} failed with {e}", request.uri);
@@ -236,7 +240,7 @@ impl Relay {
         let final_uri = response.url().to_string();
         let content_type = header_string(&response, reqwest::header::CONTENT_TYPE);
         let last_modified = header_string(&response, reqwest::header::LAST_MODIFIED);
-        let body = read_capped_body(response, max_bytes, &request.uri).await?;
+        let body = read_capped_body(response, max_bytes, &request.uri, timeout).await?;
 
         Ok(FetchResponse {
             status,
@@ -305,6 +309,7 @@ async fn read_capped_body(
     mut response: reqwest::Response,
     max_bytes: u64,
     uri: &str,
+    timeout: Duration,
 ) -> Result<Vec<u8>, FetchError> {
     if let Some(len) = response.content_length() {
         if len > max_bytes {
@@ -324,7 +329,7 @@ async fn read_capped_body(
                 buf.extend_from_slice(&chunk);
             }
             Ok(None) => break,
-            Err(e) if e.is_timeout() => return Err(FetchError::Timeout),
+            Err(e) if e.is_timeout() => return Err(FetchError::Timeout(timeout)),
             Err(e) => {
                 debug!("Failed to read the body from {uri} with {e}");
                 return Err(FetchError::Transport(e.to_string()));

--- a/pittv3-relay/src/peek.rs
+++ b/pittv3-relay/src/peek.rs
@@ -1,0 +1,361 @@
+//! Retrieving the certificates a TLS server presents.
+//!
+//! A browser holds the certificate of every site it talks to and will not hand it over: there is no
+//! API that yields the peer chain, and there is no way to open a socket and read one. So a person
+//! who wants to validate the certificate a host serves has to obtain it some other way — with
+//! `openssl s_client` and a text editor, today — before the application they came to use can say
+//! anything about it. This module is the other way.
+//!
+//! What it does is deliberately small: connect, complete a handshake, keep what the peer sent, and
+//! close. Nothing is requested over the connection, no application data is written, and nothing here
+//! parses a certificate — that stays true of this crate as a whole.
+//!
+//! **The handshake accepts any certificate, on purpose.** A chain that a verifier would reject —
+//! expired, self-signed, wrong name, unknown issuer — is precisely the chain someone reaches for
+//! this tool to look at, so refusing it would deny the tool its subject. What is *not* skipped is
+//! the peer's handshake signature, which is checked with the real algorithms: that is what makes the
+//! chain we return the chain belonging to the party we actually spoke to, rather than to whoever
+//! could answer on that address. Judging the chain is the caller's job, and the caller is a path
+//! validator.
+
+use std::sync::{Arc, Mutex};
+use std::time::{Duration, Instant};
+
+use log::debug;
+use rustls::client::danger::{HandshakeSignatureValid, ServerCertVerified, ServerCertVerifier};
+use rustls::crypto::{verify_tls12_signature, verify_tls13_signature, CryptoProvider};
+use rustls::pki_types::{CertificateDer, ServerName, UnixTime};
+use rustls::{ClientConfig, DigitallySignedStruct, SignatureScheme};
+use tokio::net::TcpStream;
+
+use crate::policy::PolicyError;
+use crate::{FetchError, Relay};
+
+/// A host to take the certificates from.
+#[derive(Clone, Debug, Default)]
+pub struct PeekRequest {
+    /// URI naming the host, which must be `https`. A port other than the default is honored when
+    /// the policy permits it.
+    pub uri: String,
+    /// Timeout for the whole exchange, when shorter than the configured timeout.
+    pub timeout: Option<Duration>,
+}
+
+impl PeekRequest {
+    /// Builds a request for the host `uri` names.
+    pub fn new(uri: impl Into<String>) -> Self {
+        PeekRequest {
+            uri: uri.into(),
+            timeout: None,
+        }
+    }
+}
+
+/// What a host presented.
+#[derive(Clone, Debug)]
+pub struct PeekResponse {
+    /// Host the handshake was made with, as written in the URI and sent as the server name.
+    pub host: String,
+    /// Port connected to.
+    pub port: u16,
+    /// Protocol version negotiated, e.g., `TLSv1.3`.
+    pub protocol: Option<String>,
+    /// Certificates the server sent, in the order it sent them. A server following RFC 8446 sends
+    /// its own certificate first; nothing here enforces that, because a server that does not is
+    /// exactly the kind of finding this tool exists to surface.
+    pub certificates: Vec<Vec<u8>>,
+    /// OCSP response the server stapled, when it stapled one. Kept because it is revocation data
+    /// the caller now holds without asking a responder for it, and because a stapled response that
+    /// answers about a different certificate than the one it accompanies is a real misconfiguration
+    /// that only a stapled copy can reveal.
+    pub stapled_ocsp: Option<Vec<u8>>,
+}
+
+impl Relay {
+    /// Completes a TLS handshake with the host `request` names and returns what it presented.
+    ///
+    /// The URI is checked and its host resolved by the same policy every retrieval goes through, so
+    /// a deployment that refuses a host or a private address refuses it here too. Only `https` is
+    /// accepted: the other schemes the policy may permit do not begin with a handshake.
+    pub async fn peek(&self, request: &PeekRequest) -> Result<PeekResponse, FetchError> {
+        let dest = self.policy().check_uri(&request.uri)?;
+        // The policy's scheme list governs retrieval, where `http` is ordinary. Here it would mean
+        // opening a handshake against a port that is not speaking TLS, so it is refused by name
+        // rather than left to fail as a transport error nobody can interpret.
+        if dest.url.scheme() != "https" {
+            return Err(FetchError::Policy(PolicyError::Scheme(
+                dest.url.scheme().to_string(),
+            )));
+        }
+        let addresses = self.policy().resolve(&dest).await?;
+        let (host, port) = (dest.host.clone(), dest.port);
+
+        let timeout = match request.timeout {
+            Some(t) => t.min(self.budget().timeout),
+            None => self.budget().timeout,
+        };
+
+        let provider = provider();
+        // Held past the builder: the stapled OCSP response is handed to the verifier during the
+        // handshake and is reachable nowhere else afterwards, so the verifier is where it is kept.
+        let verifier = Arc::new(Harvest {
+            provider: provider.clone(),
+            stapled: Mutex::new(None),
+        });
+        let config = ClientConfig::builder_with_provider(provider)
+            .with_safe_default_protocol_versions()
+            .map_err(|e| FetchError::Setup(e.to_string()))?
+            .dangerous()
+            .with_custom_certificate_verifier(verifier.clone())
+            .with_no_client_auth();
+        // A name is what a virtual host keys off, so it is sent as given rather than as whatever
+        // address the name resolved to. `to_owned` because the handshake outlives the borrow.
+        let server_name = ServerName::try_from(host.clone())
+            .map_err(|_| FetchError::Policy(PolicyError::Malformed(host.clone())))?;
+
+        let connector = tokio_rustls::TlsConnector::from(Arc::new(config));
+        let deadline = Instant::now() + timeout;
+        let count = addresses.len();
+        // What went wrong at the last address that answered at all. A refusal and a silence are
+        // different facts about a host, and the difference is the whole diagnosis: a port nothing
+        // listens on looks exactly like a slow server until something says which it was.
+        let mut answered_badly = None;
+        let mut established = None;
+
+        for (attempted, address) in addresses.into_iter().enumerate() {
+            let remaining = deadline.saturating_duration_since(Instant::now());
+            if remaining.is_zero() {
+                break;
+            }
+            // Each address gets an equal share of what is left, rather than the first being allowed
+            // to spend the whole allowance. A host that publishes several addresses and blackholes
+            // one of them is ordinary; giving up on the host because of it is not, and an address
+            // that fails quickly hands its unused share to the ones after it.
+            let share = remaining / (count - attempted) as u32;
+            let attempt = async {
+                let tcp = TcpStream::connect(address)
+                    .await
+                    .map_err(|e| e.to_string())?;
+                connector
+                    .connect(server_name.clone(), tcp)
+                    .await
+                    .map_err(|e| e.to_string())
+            };
+
+            match tokio::time::timeout(share, attempt).await {
+                Ok(Ok(tls)) => {
+                    established = Some(tls);
+                    break;
+                }
+                Ok(Err(e)) => {
+                    debug!("{address} failed for {host}: {e}");
+                    answered_badly = Some(format!("{address}: {e}"));
+                }
+                Err(_) => {
+                    debug!("{address} did not answer for {host} within {share:?}");
+                }
+            }
+        }
+
+        let Some(stream) = established else {
+            return match answered_badly {
+                Some(e) => Err(FetchError::Transport(e)),
+                None => Err(FetchError::Timeout(timeout)),
+            };
+        };
+
+        let (_, connection) = stream.get_ref();
+        let certificates = connection
+            .peer_certificates()
+            .unwrap_or_default()
+            .iter()
+            .map(|c| c.as_ref().to_vec())
+            .collect::<Vec<Vec<u8>>>();
+        // A handshake that completes without the peer sending a certificate is possible in the
+        // abstract and useless here, and reporting an empty list would leave the caller to guess
+        // whether the connection or the parsing failed.
+        if certificates.is_empty() {
+            return Err(FetchError::Transport(format!(
+                "{host} completed a handshake without presenting a certificate"
+            )));
+        }
+        // Named rather than debug-printed: `TLSv1_3` is the enum's spelling, "TLS 1.3" is the
+        // protocol's, and this string is shown to a person.
+        let protocol = connection.protocol_version().map(|v| match v {
+            rustls::ProtocolVersion::TLSv1_3 => "TLS 1.3".to_string(),
+            rustls::ProtocolVersion::TLSv1_2 => "TLS 1.2".to_string(),
+            other => format!("{other:?}"),
+        });
+        // A poisoned lock would mean the verifier panicked mid-handshake, which cannot leave a
+        // handshake to complete; taking the stapled response as absent rather than unwrapping keeps
+        // an impossible case from being the one thing that can panic here.
+        let stapled_ocsp = verifier
+            .stapled
+            .lock()
+            .ok()
+            .and_then(|mut held| held.take());
+
+        Ok(PeekResponse {
+            host,
+            port,
+            protocol,
+            certificates,
+            stapled_ocsp,
+        })
+    }
+}
+
+/// The provider the handshake uses, named rather than taken from the process default. A default is
+/// installed only if something installed it, and more than one is reachable in a workspace this
+/// crate shares with an HTTP client; picking here means the handshake does not depend on what else
+/// happened to run first.
+fn provider() -> Arc<CryptoProvider> {
+    Arc::new(rustls::crypto::ring::default_provider())
+}
+
+/// Accepts every certificate and verifies every handshake signature. See the module documentation
+/// for why that pairing is the right one here.
+#[derive(Debug)]
+struct Harvest {
+    provider: Arc<CryptoProvider>,
+    /// Stapled OCSP response seen during the handshake. The verifier is the only thing the peer's
+    /// stapled response is given to, so keeping it is the only way to have it afterwards.
+    stapled: Mutex<Option<Vec<u8>>>,
+}
+
+impl ServerCertVerifier for Harvest {
+    fn verify_server_cert(
+        &self,
+        _end_entity: &CertificateDer<'_>,
+        _intermediates: &[CertificateDer<'_>],
+        _server_name: &ServerName<'_>,
+        ocsp_response: &[u8],
+        _now: UnixTime,
+    ) -> Result<ServerCertVerified, rustls::Error> {
+        if !ocsp_response.is_empty() {
+            if let Ok(mut held) = self.stapled.lock() {
+                *held = Some(ocsp_response.to_vec());
+            }
+        }
+        Ok(ServerCertVerified::assertion())
+    }
+
+    fn verify_tls12_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls12_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn verify_tls13_signature(
+        &self,
+        message: &[u8],
+        cert: &CertificateDer<'_>,
+        dss: &DigitallySignedStruct,
+    ) -> Result<HandshakeSignatureValid, rustls::Error> {
+        verify_tls13_signature(
+            message,
+            cert,
+            dss,
+            &self.provider.signature_verification_algorithms,
+        )
+    }
+
+    fn supported_verify_schemes(&self) -> Vec<SignatureScheme> {
+        self.provider
+            .signature_verification_algorithms
+            .supported_schemes()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::budget::FetchBudget;
+    use crate::policy::NetworkPolicy;
+
+    fn relay() -> Relay {
+        Relay::new(NetworkPolicy::default(), FetchBudget::default()).unwrap()
+    }
+
+    /// The scheme is refused before anything is resolved, so a URI naming a plaintext port never
+    /// becomes a handshake against a server that is not expecting one.
+    #[tokio::test]
+    async fn peek_refuses_a_scheme_that_does_not_begin_with_a_handshake() {
+        let error = relay()
+            .peek(&PeekRequest::new("http://example.com/"))
+            .await
+            .unwrap_err();
+        let FetchError::Policy(PolicyError::Scheme(scheme)) = &error else {
+            panic!("expected a scheme refusal, got {error}");
+        };
+        assert_eq!(scheme, "http");
+    }
+
+    /// The same address rules the retrieval path enforces apply here; a literal naming a private
+    /// address is refused from the URI alone.
+    #[tokio::test]
+    async fn peek_refuses_a_private_address() {
+        let error = relay()
+            .peek(&PeekRequest::new("https://127.0.0.1/"))
+            .await
+            .unwrap_err();
+        let FetchError::Policy(PolicyError::Address(_)) = &error else {
+            panic!("expected an address refusal, got {error}");
+        };
+    }
+
+    /// Takes the certificates from a real host, which is the only way to exercise the handshake
+    /// itself: everything above this point stops before a socket is opened.
+    ///
+    /// Ignored by default because it needs the network, and on a machine that routes outbound
+    /// traffic through a proxy it needs direct egress on 443 as well — a raw handshake cannot go
+    /// through an HTTP proxy. Run it with `cargo test -p pittv3_relay -- --ignored --nocapture`,
+    /// optionally naming a host in `PITTV3_PEEK_HOST`.
+    #[tokio::test]
+    #[ignore = "requires direct outbound TLS"]
+    async fn peek_takes_the_chain_a_host_presents() {
+        let host = std::env::var("PITTV3_PEEK_HOST")
+            .unwrap_or_else(|_| "https://letsencrypt.org".to_string());
+        let response = relay().peek(&PeekRequest::new(&host)).await.unwrap();
+
+        assert_eq!(response.port, 443);
+        assert!(
+            !response.certificates.is_empty(),
+            "a completed handshake presented no certificate"
+        );
+        // Not parsed — this crate does not know what a certificate is — but a chain whose entries
+        // do not begin with a SEQUENCE is not one, and that is worth catching here rather than two
+        // layers up where it looks like a decoding fault.
+        for certificate in &response.certificates {
+            assert_eq!(certificate.first(), Some(&0x30));
+        }
+        println!(
+            "{host}: {:?}, {} certificates, stapled OCSP {:?} bytes",
+            response.protocol,
+            response.certificates.len(),
+            response.stapled_ocsp.as_ref().map(|o| o.len())
+        );
+    }
+
+    /// A port outside the policy's list is refused, so a peek cannot be used to sweep ports on a
+    /// host the policy does permit.
+    #[tokio::test]
+    async fn peek_refuses_a_port_outside_the_policy() {
+        let error = relay()
+            .peek(&PeekRequest::new("https://example.com:8443/"))
+            .await
+            .unwrap_err();
+        let FetchError::Policy(PolicyError::Port(port)) = &error else {
+            panic!("expected a port refusal, got {error}");
+        };
+        assert_eq!(*port, 8443);
+    }
+}

--- a/pittv3-service/README.md
+++ b/pittv3-service/README.md
@@ -10,6 +10,15 @@ The endpoints are:
 
 - `POST /api/fetch` retrieves one artifact through `pittv3_relay`, which enforces the network policy
   and the per-retrieval budgets. The service does not look at what comes back.
+- `POST /api/tls` completes a TLS handshake with a named host and returns the certificates it
+  presented, plus any OCSP response it stapled. A browser holds the certificate of every site it
+  talks to and exposes none of them, so this is the only way the browser application can be given
+  the certificate a site serves. Nothing is requested over the connection and nothing is parsed
+  here. The handshake accepts any certificate — the chain someone is asking about is often one a
+  verifier would reject, and judging it is what `/api/validate` and the browser are for — while the
+  peer's handshake signature is verified, so the chain returned belongs to the party that answered.
+  Turn it off with `allow_tls_peek` for a deployment whose relay is meant to reach PKI repositories
+  and nothing else.
 - `POST /api/validate` validates the certificates in the request and returns a `ValidationReport`,
   the same structure the CLI writes and the GUIs display.
 - `GET /api/stores` lists the trust stores the service holds, in the shape the browser

--- a/pittv3-service/src/config.rs
+++ b/pittv3-service/src/config.rs
@@ -81,6 +81,12 @@ pub struct ServiceConfig {
     /// certificates turns this off, which is a meaningful posture rather than a degraded one: the
     /// relayed tier is the one where certificates never leave the browser.
     pub enable_validation: bool,
+    /// Serves `POST /api/tls`, which completes a handshake with a named host and returns the
+    /// certificates it presented. On by default: it reaches only public hosts on the ports the
+    /// network policy already permits, it sends nothing and asks for nothing, and it is what lets a
+    /// browser validate the certificate a site serves at all. Turn it off for a deployment whose
+    /// relay is meant to reach PKI repositories and nothing else.
+    pub allow_tls_peek: bool,
     /// Retrieves the CRLs named by the paths a validation builds, so revocation status can be
     /// determined rather than reported as undetermined. On by default: a caller that sent
     /// certificates for validation asked for them to be validated, and revocation is part of that.
@@ -102,6 +108,7 @@ impl Default for ServiceConfig {
             limits: RequestLimits::default(),
             allow_dynamic_build: false,
             enable_validation: true,
+            allow_tls_peek: true,
             fetch_revocation_data: true,
         }
     }

--- a/pittv3-service/src/dto.rs
+++ b/pittv3-service/src/dto.rs
@@ -52,6 +52,31 @@ mod b64_opt {
     }
 }
 
+/// Base64 for a list of byte strings, i.e., a certificate chain.
+mod b64_vec {
+    use super::*;
+
+    pub fn serialize<S: Serializer>(items: &[Vec<u8>], s: S) -> Result<S::Ok, S::Error> {
+        let encoded = items
+            .iter()
+            .map(|b| STANDARD.encode(b))
+            .collect::<Vec<String>>();
+        encoded.serialize(s)
+    }
+
+    pub fn deserialize<'de, D: Deserializer<'de>>(d: D) -> Result<Vec<Vec<u8>>, D::Error> {
+        let encoded = Vec::<String>::deserialize(d)?;
+        encoded
+            .iter()
+            .map(|e| {
+                STANDARD
+                    .decode(e.as_bytes())
+                    .map_err(serde::de::Error::custom)
+            })
+            .collect()
+    }
+}
+
 /// What a client asks the relay to retrieve.
 #[derive(Clone, Debug, Deserialize, Serialize)]
 pub struct FetchRequestBody {
@@ -90,6 +115,52 @@ pub struct FetchResponseBody {
     /// Response body.
     #[serde(with = "b64")]
     pub body: Vec<u8>,
+}
+
+/// What a client asks the service to take the certificates from.
+///
+/// A URI rather than a host and a port because that is what the network policy judges, and because
+/// it is what a person has in hand: the address bar contents of the site they are asking about. A
+/// value with no scheme is read as `https`, which is the only scheme a handshake can begin with,
+/// and anything past the authority is ignored — the certificate a host presents does not depend on
+/// the path asked for.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PeekRequestBody {
+    /// Host to take the certificates from, e.g., `https://example.com` or `example.com:443`.
+    pub uri: String,
+}
+
+impl PeekRequestBody {
+    /// Returns the URI to hand the relay, supplying the scheme when the caller wrote none.
+    ///
+    /// Only a missing scheme is added. A value naming some other scheme is passed through unchanged
+    /// so that the policy refuses it by name, rather than being quietly rewritten into a request the
+    /// caller did not make.
+    pub fn normalized_uri(&self) -> String {
+        let trimmed = self.uri.trim();
+        match trimmed.contains("://") {
+            true => trimmed.to_string(),
+            false => format!("https://{trimmed}"),
+        }
+    }
+}
+
+/// What a host presented.
+#[derive(Clone, Debug, Deserialize, Serialize)]
+pub struct PeekResponseBody {
+    /// Host the handshake was made with.
+    pub host: String,
+    /// Port connected to.
+    pub port: u16,
+    /// Protocol version negotiated.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub protocol: Option<String>,
+    /// Certificates the server sent, in the order it sent them.
+    #[serde(with = "b64_vec")]
+    pub certificates: Vec<Vec<u8>>,
+    /// OCSP response the server stapled, when it stapled one.
+    #[serde(default, with = "b64_opt", skip_serializing_if = "Option::is_none")]
+    pub stapled_ocsp: Option<Vec<u8>>,
 }
 
 /// A certificate with the name to report it under. The name is the client's label -- an uploaded
@@ -170,6 +241,47 @@ mod tests {
         })
         .unwrap();
         assert!(encoded.contains(r#""body":"BAUG""#));
+    }
+
+    /// What a person types into a box is a site, not a URI, and the scheme is the part they leave
+    /// out. Supplying it is the only rewriting done: a value naming another scheme keeps it, so the
+    /// policy refuses `http` by name rather than the service silently making a different request.
+    #[test]
+    fn a_peek_request_supplies_the_scheme_but_never_changes_one() {
+        let bare: PeekRequestBody = serde_json::from_str(r#"{"uri":"example.com"}"#).unwrap();
+        assert_eq!(bare.normalized_uri(), "https://example.com");
+
+        let with_port: PeekRequestBody =
+            serde_json::from_str(r#"{"uri":" example.com:8443 "}"#).unwrap();
+        assert_eq!(with_port.normalized_uri(), "https://example.com:8443");
+
+        let whole: PeekRequestBody =
+            serde_json::from_str(r#"{"uri":"https://example.com/a/path"}"#).unwrap();
+        assert_eq!(whole.normalized_uri(), "https://example.com/a/path");
+
+        let plaintext: PeekRequestBody =
+            serde_json::from_str(r#"{"uri":"http://example.com"}"#).unwrap();
+        assert_eq!(plaintext.normalized_uri(), "http://example.com");
+    }
+
+    /// The chain travels as a list of base64 strings, and the stapled response is absent rather
+    /// than empty when the server stapled nothing.
+    #[test]
+    fn a_peek_response_carries_a_chain_as_base64() {
+        let encoded = serde_json::to_string(&PeekResponseBody {
+            host: "example.com".to_string(),
+            port: 443,
+            protocol: Some("TLSv1_3".to_string()),
+            certificates: vec![vec![1, 2, 3], vec![4, 5, 6]],
+            stapled_ocsp: None,
+        })
+        .unwrap();
+        assert!(encoded.contains(r#""certificates":["AQID","BAUG"]"#));
+        assert!(!encoded.contains("stapled_ocsp"));
+
+        let decoded: PeekResponseBody = serde_json::from_str(&encoded).unwrap();
+        assert_eq!(decoded.certificates, vec![vec![1, 2, 3], vec![4, 5, 6]]);
+        assert!(decoded.stapled_ocsp.is_none());
     }
 
     #[test]

--- a/pittv3-service/src/main.rs
+++ b/pittv3-service/src/main.rs
@@ -59,6 +59,12 @@ struct Args {
     /// revocation status undetermined unless the caller supplied the data.
     #[clap(long)]
     no_revocation_fetch: bool,
+
+    /// Refuses `POST /api/tls`, so the service will not complete a handshake with a host on a
+    /// client's behalf. For a deployment whose relay is meant to reach PKI repositories and
+    /// nothing else.
+    #[clap(long)]
+    no_tls_peek: bool,
 }
 
 fn load_config(args: &Args) -> Result<ServiceConfig, String> {
@@ -92,6 +98,9 @@ fn load_config(args: &Args) -> Result<ServiceConfig, String> {
     }
     if args.no_revocation_fetch {
         config.fetch_revocation_data = false;
+    }
+    if args.no_tls_peek {
+        config.allow_tls_peek = false;
     }
     Ok(config)
 }
@@ -130,10 +139,11 @@ async fn main() -> std::io::Result<()> {
         .collect::<Vec<String>>()
         .join(", ");
     info!(
-        "Serving {} trust store(s) [{offered}]; validation {}, chasing {}",
+        "Serving {} trust store(s) [{offered}]; validation {}, chasing {}, host handshakes {}",
         state.stores.len(),
         enabled(state.config.enable_validation),
-        enabled(state.config.allow_dynamic_build)
+        enabled(state.config.allow_dynamic_build),
+        enabled(state.config.allow_tls_peek)
     );
 
     HttpServer::new(move || {

--- a/pittv3-service/src/routes.rs
+++ b/pittv3-service/src/routes.rs
@@ -8,10 +8,13 @@ use actix_web::{web, HttpResponse, Responder};
 use log::warn;
 use serde::Serialize;
 
-use pittv3_relay::{FetchError, FetchRequest};
+use pittv3_relay::{FetchError, FetchRequest, PeekRequest};
 
 use crate::config::ServiceState;
-use crate::dto::{FetchRequestBody, FetchResponseBody, ValidateRequestBody, ValidateResponseBody};
+use crate::dto::{
+    FetchRequestBody, FetchResponseBody, PeekRequestBody, PeekResponseBody, ValidateRequestBody,
+    ValidateResponseBody,
+};
 use crate::orchestrate::{self, ValidationInput};
 
 /// Body returned when a request cannot be served.
@@ -35,6 +38,7 @@ pub fn configure(cfg: &mut web::ServiceConfig) {
         web::scope("/api")
             .route("/health", web::get().to(health))
             .route("/fetch", web::post().to(fetch))
+            .route("/tls", web::post().to(tls))
             .route("/stores", web::get().to(stores))
             .route("/validate", web::post().to(validate)),
     )
@@ -78,6 +82,36 @@ async fn fetch(
     }
 }
 
+/// Takes the certificates a host presents, so a client that cannot open a socket can validate the
+/// certificate a site serves.
+///
+/// Nothing is requested over the connection and nothing is parsed here: the handshake completes,
+/// what the peer sent is returned, and judging it is the client's job.
+async fn tls(state: web::Data<ServiceState>, body: web::Json<PeekRequestBody>) -> impl Responder {
+    if !state.config.allow_tls_peek {
+        return HttpResponse::NotFound().json(ErrorBody::new(
+            "this deployment does not make handshakes on a client's behalf",
+        ));
+    }
+
+    let body = body.into_inner();
+    let request = PeekRequest {
+        uri: body.normalized_uri(),
+        timeout: None,
+    };
+
+    match state.relay.peek(&request).await {
+        Ok(response) => HttpResponse::Ok().json(PeekResponseBody {
+            host: response.host,
+            port: response.port,
+            protocol: response.protocol,
+            certificates: response.certificates,
+            stapled_ocsp: response.stapled_ocsp,
+        }),
+        Err(e) => fetch_error_response(e),
+    }
+}
+
 /// Maps a retrieval failure onto a status that says whose problem it is: a refusal is the
 /// requester's, a failure reaching the repository is the repository's, and a client cannot tell
 /// those apart from the message alone.
@@ -87,7 +121,7 @@ fn fetch_error_response(error: FetchError) -> HttpResponse {
         FetchError::RequestTooLarge(_) => {
             HttpResponse::PayloadTooLarge().json(ErrorBody::new(error.to_string()))
         }
-        FetchError::Timeout => {
+        FetchError::Timeout(_) => {
             HttpResponse::GatewayTimeout().json(ErrorBody::new(error.to_string()))
         }
         FetchError::TooLarge(_) | FetchError::Transport(_) => {

--- a/pittv3-wasm/README.md
+++ b/pittv3-wasm/README.md
@@ -21,6 +21,19 @@ accumulate across uploads, so a set of loaded certificates can be re-validated a
 trust configuration or settings. Values that govern the RFC 5280 path validation inputs, e.g., the
 initial policy set and related indicators, can be edited in the UI.
 
+The **End entity certificate** group takes what is to be validated from one of two sources, chosen
+with the *Load from* control: a **File**, or a **TLS server**. The second exists because a browser
+holds the certificate of every site it talks to and hands over none of them, so the certificate
+people most often want to look at — the one a site is serving right now — is the one that could not
+be uploaded without going away and fetching it with another tool first. Naming a host has the
+service complete a handshake with it and keep what it sent: the host's own certificate is loaded
+here, anything sent with it joins the CA certificates path building draws on, and a stapled OCSP
+response is kept as revocation data. Nothing is requested over the connection, and making the
+handshake does not judge the certificate — that is what Validate is for, which is the point, since a
+chain a browser refuses is usually the reason someone came. It needs a service, so it works only in
+the relayed tier. Both sources feed one list, and switching between them discards nothing, so the
+count beside *Loaded* is what a run will validate however the certificates arrived.
+
 A **Retrieval** selector on the Validate tab chooses what the app may fetch. *In this browser only*
 is the historical behavior and the only option when no service is serving the page: nothing leaves
 it, paths are built from the selected store and uploads, and revocation status stays undetermined
@@ -32,6 +45,13 @@ do, and an OCSP request identifies the certificate being asked about even though
 itself is not sent. The setting also drives the settings form's per-capability notices, and flips
 what an unstated revocation preference means, since with a relay the check can actually be
 satisfied.
+
+*Retrieve through the service* is the tier a served page starts on. A deployment that runs a
+service is one that means to retrieve, and starting elsewhere there makes the first run report
+missing issuers and undetermined revocation status for want of a switch nobody was told to flip.
+The selector is one click either way, and its hint states what leaves the page. A statically hosted
+copy has no service to answer `api/health`, so it starts — and stays — in the browser-only tier
+with the selector disabled and a line saying why.
 
 The harvesting and folding around that retrieval are `pittv3_gui_lib::retrieval`, shared with the
 server-hosted tier, so the same certificate validated either way goes through the same code.

--- a/pittv3-wasm/assets/pittv3-wasm.css
+++ b/pittv3-wasm/assets/pittv3-wasm.css
@@ -38,6 +38,23 @@ h1 {
   margin-top: 0;
 }
 
+/* Build identity, in the bottom corner. Fixed so it is in the same place whatever is on screen and
+   whatever has been scrolled past; pointer-events: none so it is never in the way of a control it
+   happens to sit over; its own background so text scrolling underneath does not read through it. */
+.version {
+  position: fixed;
+  right: 0.6rem;
+  bottom: 0.4rem;
+  z-index: 10;
+  margin: 0;
+  padding: 0.1rem 0.4rem;
+  border-radius: 6px;
+  background: Canvas;
+  color: var(--muted);
+  font-size: 0.75rem;
+  pointer-events: none;
+}
+
 details.panel {
   border: 1px solid var(--border);
   border-radius: 8px;

--- a/pittv3-wasm/build.rs
+++ b/pittv3-wasm/build.rs
@@ -15,8 +15,80 @@
 
 use std::fs;
 use std::path::Path;
+use std::time::{SystemTime, UNIX_EPOCH};
 
 use certval_stores_core::{serialize_environment, TrustStoreProvider};
+
+/// Stamps the time of this build into `PITTV3_BUILD_TIME`, which the header
+/// shows so a person can tell whether the page in front of them is the build
+/// they just deployed.
+///
+/// The interesting part is what this script is told to rerun for, because a
+/// stamp is only worth showing if it moves when the application does — and
+/// only worth having if it does *not* move when the application does not. A
+/// value that changed on every invocation would change this crate's
+/// compilation inputs on every invocation, and rebuilding pittv3-wasm from
+/// scratch costs minutes; that is the cost of "always fresh", and it is not
+/// worth paying. So the triggers are the things whose change means a different
+/// application: this crate's own sources and manifest, the workspace lock (so
+/// an external dependency moving counts), and the in-tree crates the
+/// application is built out of. Each of those already forces a recompile, so
+/// the stamp rides along for nothing.
+///
+/// What it therefore cannot notice: a rebuild of byte-identical inputs. That
+/// reads as the earlier time, which is the honest answer — it is the same
+/// application.
+fn stamp_build_time() {
+    for path in [
+        "build.rs",
+        "Cargo.toml",
+        "src",
+        "../Cargo.lock",
+        "../certval/src",
+        "../pittv3-lib/src",
+        "../pittv3-gui-lib/src",
+    ] {
+        println!("cargo::rerun-if-changed={path}");
+    }
+
+    // A clock before the epoch is not worth a build failure, and 0 renders as a
+    // date nobody will mistake for a real one.
+    let secs = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0);
+    println!("cargo::rustc-env=PITTV3_BUILD_TIME={}", utc_minute(secs));
+}
+
+/// Renders a Unix timestamp as `YYYY-MM-DD HH:MM UTC`.
+///
+/// To the minute: the second a build started is noise next to the question
+/// being asked, which is "is this the one I just made". Written out rather than
+/// pulled from a date library, because one line of output does not merit a
+/// dependency in the build graph.
+fn utc_minute(secs: u64) -> String {
+    let (days, rest) = ((secs / 86_400) as i64, secs % 86_400);
+    let (year, month, day) = civil_from_days(days);
+    let (hour, minute) = (rest / 3600, (rest % 3600) / 60);
+    format!("{year:04}-{month:02}-{day:02} {hour:02}:{minute:02} UTC")
+}
+
+/// Days since the Unix epoch to a civil year, month and day, by Howard
+/// Hinnant's `civil_from_days`. Verified against `date -u` across the epoch,
+/// the 2000 and 2024 leap years and the 2100 century non-leap.
+fn civil_from_days(z: i64) -> (i64, i64, i64) {
+    let z = z + 719_468;
+    let era = z.div_euclid(146_097);
+    let doe = z.rem_euclid(146_097);
+    let yoe = (doe - doe / 1460 + doe / 36524 - doe / 146_096) / 365;
+    let year = yoe + era * 400;
+    let doy = doe - (365 * yoe + yoe / 4 - yoe / 100);
+    let mp = (5 * doy + 2) / 153;
+    let day = doy - (153 * mp + 2) / 5 + 1;
+    let month = if mp < 10 { mp + 3 } else { mp - 9 };
+    let year = if month <= 2 { year + 1 } else { year };
+    (year, month, day)
+}
 
 /// One generated store: which provider environment it comes from, and the file
 /// names `STORES` expects. `ca` is `None` for an anchors-only environment.
@@ -56,7 +128,7 @@ fn artifacts() -> Vec<Artifact> {
 }
 
 fn main() {
-    println!("cargo::rerun-if-changed=build.rs");
+    stamp_build_time();
 
     let dir = Path::new("resources");
     for a in artifacts() {

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -25,7 +25,7 @@ use pittv3_gui_lib::export::{path_entries, paths_text, zip_paths};
 use pittv3_gui_lib::retrieval::{add_uploaded_crl, harvest_revocation_work, staple_uploaded_ocsp};
 
 use crate::relay::{
-    chase_certificates, retrieve_crls, retrieve_ocsp, FetchBudget, RelayFetcher, Tier,
+    chase_certificates, relay_peek, retrieve_crls, retrieve_ocsp, FetchBudget, RelayFetcher, Tier,
 };
 use crate::validate::{
     merge_service_stores, prepare_validation, shipped_catalog, validate_hackathon_zip,
@@ -68,6 +68,15 @@ const VALIDATE_ALL_KEY: &str = "pittv3.validate_all";
 const REV_CACHE_KEY: &str = "pittv3.use_rev_cache";
 
 /// Sidebar views in display order
+/// Version of this build, from the manifest.
+const VERSION: &str = env!("CARGO_PKG_VERSION");
+
+/// When this build was made, stamped by `build.rs` — see `stamp_build_time` there for what moves it
+/// and what deliberately does not. Shown beside the version because until there are releases to tell
+/// apart, the version is the same string every time and the build time is the one that answers "is
+/// this what I just deployed".
+const BUILT: &str = env!("PITTV3_BUILD_TIME");
+
 const VIEW_LABELS: &[&str] = &[
     "Validate",
     "Settings",
@@ -177,8 +186,8 @@ fn load_use_rev_cache() -> bool {
 /// checking off and then never consulted the CRL it had just been given. With neither, an unstated
 /// preference still means off, or every run would come back `RevocationStatusNotDetermined` for
 /// want of data the page cannot obtain. In
-/// [`Tier::Relayed`] the data can be retrieved, and checking is the point of having chosen that
-/// tier, so an unstated preference means on.
+/// [`Tier::Relayed`] the data can be retrieved, and checking is the point of that tier, so an
+/// unstated preference means on.
 ///
 /// A stated preference is honored either way — the settings form says outright that these settings
 /// apply only where the tool can fetch, and a user who asks for checking in the local tier gets
@@ -310,6 +319,16 @@ fn App() -> Element {
     let mut uploaded_tas = use_signal(Vec::<(String, Vec<u8>)>::new);
     let mut uploaded_cas = use_signal(Vec::<(String, Vec<u8>)>::new);
     let mut loaded_ees = use_signal(Vec::<(String, Vec<u8>)>::new);
+    // Which of the two ways of naming an end entity certificate the form is offering. Not a
+    // property of what gets loaded -- both sources feed the one list, and switching does not
+    // discard what the other brought in -- only of which control is on show.
+    let mut ee_from_server = use_signal(|| false);
+    // The host someone typed in place of choosing a file, and what came of asking about it. A
+    // browser will not hand over the certificate of a site it is talking to, so for the certificate
+    // most people actually want to look at, uploading a file was never an option they had.
+    let mut peek_uri = use_signal(String::new);
+    let mut peek_status = use_signal(String::new);
+    let mut peek_running = use_signal(|| false);
     let mut loaded_zips = use_signal(Vec::<(String, Vec<u8>)>::new);
     // Revocation data supplied by hand, for a run with no network to fetch it. Held here rather
     // than pushed straight into the prepared environment because that environment is rebuilt
@@ -342,9 +361,12 @@ fn App() -> Element {
     // selectable. Determined once at startup; a statically hosted copy leaves it false and the
     // selector says why.
     let mut service_present = use_signal(|| false);
-    // Which tier a run uses. Local until a service is found *and* the user asks for retrieval:
-    // choosing to disclose the URIs a certificate names is the user's to make, not a default that
-    // follows from a deployment happening to offer it.
+    // Which tier a run uses. Local while the health request is outstanding, since a retrieval
+    // before then has nothing to reach, and relayed from the moment a service answers: a deployment
+    // that runs a service exists to do the retrieving, and starting local there means every first
+    // run comes back missing the paths and the revocation status the service was stood up to
+    // supply. The choice remains the user's -- the selector is one click, and its hint states what
+    // leaves the page -- but the default now follows the deployment.
     let mut tier = use_signal(Tier::default);
 
     // Why the Check URIs button is unavailable, or None when it is available. One place, so the
@@ -352,7 +374,7 @@ fn App() -> Element {
     // has to state its reason rather than silently joining an anonymous `||` chain.
     let uri_blocked_because = move || -> Option<&'static str> {
         if uri_running() {
-            return Some("A check is already running.");
+            return Some("A check is now running.");
         }
         if uri_target().is_none() {
             return Some("Choose a certificate to check.");
@@ -371,9 +393,36 @@ fn App() -> Element {
         }
         None
     };
-    // Certificates retrieved by following AIA and SIA URIs during this session. Held apart from the
-    // uploads so that clearing uploads does not discard them and so the notes can say where a
-    // certificate in the path came from; they feed preparation exactly as an upload does.
+    // Why taking a host's certificates is unavailable, or None when it is available. Same shape as
+    // `uri_blocked_because` above and for the same reason: the button, its hint and the reason line
+    // cannot disagree if there is only one of them.
+    let peek_blocked_because = move || -> Option<&'static str> {
+        if peek_running() {
+            return Some("A handshake is now running.");
+        }
+        if peek_uri().trim().is_empty() {
+            return Some("Enter a host to take the certificates from.");
+        }
+        if !tier().retrieves() {
+            return match service_present() {
+                true => Some(
+                    "A handshake with the host is made by the service, so this needs retrieval \
+                     turned on.",
+                ),
+                false => Some(
+                    "A handshake with the host is made by the service, and no PITTv3 service is \
+                     serving this page.",
+                ),
+            };
+        }
+        None
+    };
+
+    // Certificates this session retrieved rather than was given: those found by following AIA and
+    // SIA URIs, and the intermediates a host sent alongside its own certificate during a handshake.
+    // Held apart from the uploads so that clearing uploads does not discard them and so the notes
+    // can say where a certificate in the path came from; they feed preparation exactly as an upload
+    // does.
     let mut chased_cas = use_signal(Vec::<(String, Vec<u8>)>::new);
     // Fetched CBOR for the most recently used store, cached as (store id, ta, ca) so repeated
     // validations with the same selection do not re-download it. Keyed by identifier rather than by
@@ -438,6 +487,13 @@ fn App() -> Element {
             }
         };
         service_present.set(healthy);
+        // The relayed tier becomes the default as soon as there is something to relay through.
+        // Nothing here can overwrite a choice already made: both ways of changing the tier -- the
+        // selector and the Check URIs remedy button -- are gated on `service_present`, which was
+        // false until the line above, so this is the first value the user could have had a say in.
+        if healthy {
+            tier.set(Tier::Relayed);
+        }
 
         let bytes = match fetch_bytes(SERVICE_STORES_URL).await {
             Ok(bytes) => bytes,
@@ -710,6 +766,72 @@ fn App() -> Element {
     // is clicked
     let load_ee = move |name: String, bytes: Vec<u8>| {
         extend_unique(loaded_ees, vec![(name, bytes)]);
+    };
+
+    // Has the service complete a handshake with a named host and loads what it presented, so a
+    // site's certificate arrives here the same way a file would.
+    //
+    // What the host sent is split by the role each certificate plays rather than kept as a "chain":
+    // the first is what the handshake was about and becomes the end entity, and the rest join the
+    // pool path building draws on. Nothing here trusts the order beyond that first position, which
+    // is the one RFC 8446 actually pins down -- a host that sends its intermediates in a strange
+    // order is a finding for the report, not a reason to fail here.
+    let take_presented_certificates = move |_| async move {
+        let asked = peek_uri().trim().to_string();
+        if asked.is_empty() {
+            return;
+        }
+        peek_running.set(true);
+        peek_status.set(format!("Asking {asked} for its certificates..."));
+
+        match relay_peek(&asked).await {
+            Ok(presented) => {
+                // The default port is left unsaid; any other is part of what was asked for and is
+                // shown, because "example.com" and "example.com:8443" are different services.
+                let source = match presented.port {
+                    443 => presented.host.clone(),
+                    port => format!("{}:{port}", presented.host),
+                };
+                let mut certificates = presented.certificates.into_iter();
+                let Some(end_entity) = certificates.next() else {
+                    peek_status.set(format!("{source} presented no certificate."));
+                    peek_running.set(false);
+                    return;
+                };
+                load_ee(source.clone(), end_entity);
+
+                let chain = certificates
+                    .enumerate()
+                    .map(|(i, der)| (format!("{source} sent #{}", i + 2), der))
+                    .collect::<Vec<(String, Vec<u8>)>>();
+                let intermediates = chain.len();
+                extend_unique(chased_cas, chain);
+
+                let stapled = presented.stapled_ocsp.is_some();
+                if let Some(response) = presented.stapled_ocsp {
+                    extend_unique(
+                        uploaded_ocsp,
+                        vec![(format!("{source} stapled response"), response)],
+                    );
+                }
+
+                let over = match presented.protocol {
+                    Some(p) => format!(" over {p}"),
+                    None => String::new(),
+                };
+                let mut said = format!("{source}{over}: end entity loaded");
+                if intermediates > 0 {
+                    said.push_str(&format!(", {intermediates} sent with it"));
+                }
+                if stapled {
+                    said.push_str(", stapled OCSP response kept as revocation data");
+                }
+                said.push('.');
+                peek_status.set(said);
+            }
+            Err(e) => peek_status.set(format!("{asked}: {e}")),
+        }
+        peek_running.set(false);
     };
 
     // validates the loaded self-contained hackathon artifacts_certs_r5.zip archive(s); lives on its
@@ -1019,7 +1141,6 @@ fn App() -> Element {
                 code { "certval" }
                 " compiled to WebAssembly. Certificates never leave this page."
             }
-
             AppShell {
                 items: VIEW_LABELS.to_vec(),
                 selected: view(),
@@ -1188,23 +1309,92 @@ fn App() -> Element {
                             }
                         }
 
-                        div { class: "controls",
-                            label { "End Entity Certificate(s): " }
-                            input {
-                                r#type: "file",
-                                multiple: true,
-                                accept: ".der,.crt,.cer,.pem",
-                                onchange: move |ev| async move {
-                                    for (name, bytes) in read_files(&ev).await {
-                                        load_ee(name, bytes);
+                        // One group with a source picker rather than two boxes offering the same
+                        // thing. A file and a host are two ways of naming the same input, and shown
+                        // as siblings they read as two separate things to fill in -- the second of
+                        // which most people would leave alone without knowing it was the only way
+                        // to reach the certificate they came for. Which control is shown follows
+                        // the choice; what has been loaded is reported either way, because the list
+                        // is shared and switching sources does not discard it.
+                        fieldset {
+                            legend { "End entity certificate" }
+                            div { class: "controls",
+                                label { "Load from: " }
+                                div { class: "radio-group",
+                                    label { class: "radio",
+                                        input {
+                                            r#type: "radio",
+                                            name: "ee-source",
+                                            checked: !ee_from_server(),
+                                            onchange: move |_| ee_from_server.set(false),
+                                        }
+                                        " File"
                                     }
-                                },
-                            }
-                            span { class: "hint",
-                                "{loaded_ees().len()} certificate(s) loaded "
-                                button {
-                                    onclick: move |_| loaded_ees.write().clear(),
-                                    "Clear"
+                                    label { class: "radio",
+                                        input {
+                                            r#type: "radio",
+                                            name: "ee-source",
+                                            checked: ee_from_server(),
+                                            onchange: move |_| ee_from_server.set(true),
+                                        }
+                                        " TLS server"
+                                    }
+                                }
+
+                                if ee_from_server() {
+                                    label { r#for: "peek-uri", "Host: " }
+                                    span {
+                                        input {
+                                            id: "peek-uri",
+                                            r#type: "text",
+                                            placeholder: "example.com",
+                                            value: "{peek_uri}",
+                                            oninput: move |ev| peek_uri.set(ev.value()),
+                                        }
+                                        button {
+                                            disabled: peek_blocked_because().is_some(),
+                                            onclick: take_presented_certificates,
+                                            "Get certificates"
+                                        }
+                                    }
+                                    // Beside the control it explains, naming the condition that
+                                    // actually applies rather than the one that usually does.
+                                    if let Some(reason) = peek_blocked_because() {
+                                        span { class: "hint", "{reason}" }
+                                    }
+                                    if !peek_status().is_empty() {
+                                        span { class: "hint", "{peek_status}" }
+                                    }
+                                    span { class: "hint",
+                                        "The service completes a handshake and keeps what the host \
+                                         sent: its own certificate is loaded here, anything sent \
+                                         with it joins the CA certificates path building draws on, \
+                                         and a stapled OCSP response is kept as revocation data. \
+                                         Nothing is requested over the connection. The certificate \
+                                         is not judged by making the handshake — that is what \
+                                         Validate is for."
+                                    }
+                                } else {
+                                    label { "File(s): " }
+                                    input {
+                                        r#type: "file",
+                                        multiple: true,
+                                        accept: ".der,.crt,.cer,.pem",
+                                        onchange: move |ev| async move {
+                                            for (name, bytes) in read_files(&ev).await {
+                                                load_ee(name, bytes);
+                                            }
+                                        },
+                                    }
+                                }
+
+                                label { "Loaded: " }
+                                span {
+                                    "{loaded_ees().len()} certificate(s) "
+                                    button {
+                                        onclick: move |_| loaded_ees.write().clear(),
+                                        "Clear"
+                                    }
                                 }
                             }
                         }
@@ -1522,7 +1712,7 @@ fn App() -> Element {
                             button {
                                 // One disabled state served three unrelated conditions, so a dead
                                 // button looked identical whether no certificate was chosen, the
-                                // tier could not retrieve, or a check was already running -- and the
+                                // tier could not retrieve, or a check was running -- and the
                                 // only explanation sat forty lines up and covered one of the three.
                                 title: uri_blocked_because()
                                     .unwrap_or("Fetch and check every URI this certificate names"),
@@ -1707,6 +1897,13 @@ fn App() -> Element {
                     },
                 }
             }
+
+            // Parked in a corner rather than under the title, where it sat in the reading path of
+            // every visit while answering a question nobody asks until something is wrong. Pinned
+            // rather than placed at the end of the document so that finding it does not mean
+            // scrolling past a long report, and inert to the pointer so it can never take a click
+            // meant for what is underneath it.
+            p { class: "version", "Version {VERSION} · built {BUILT}" }
         }
     }
 }

--- a/pittv3-wasm/src/relay.rs
+++ b/pittv3-wasm/src/relay.rs
@@ -10,7 +10,8 @@
 //! [`pittv3_gui_lib::retrieval`] — so a certificate validated here and the same certificate
 //! validated on the server go through the same code and cannot disagree.
 //!
-//! Nothing here decides *whether* to retrieve. That is [`Tier`], and it is the user's choice.
+//! Nothing here decides *whether* to retrieve. That is [`Tier`], which follows the deployment by
+//! default and the user whenever they say otherwise.
 
 use pittv3_gui_lib::retrieval::{
     certificates_in, harvest_chase_uris, MemoryCrlSource, OcspRequestItem, OcspResponses,
@@ -44,6 +45,10 @@ const MAX_ROUNDS: usize = 4;
 #[cfg(target_family = "wasm")]
 const FETCH_URL: &str = "api/fetch";
 
+/// Where the service takes a host's certificates, relative to this application.
+#[cfg(target_family = "wasm")]
+const TLS_URL: &str = "api/tls";
+
 /// Which of PITTv3's tiers a run uses, i.e., what the browser is permitted to do about material it
 /// does not hold.
 #[derive(Clone, Copy, Debug, Default, Eq, PartialEq)]
@@ -52,10 +57,19 @@ pub enum Tier {
     /// selected store and what has been uploaded, and revocation status can only come from
     /// revocation data supplied the same way. This is what this application has always done, and
     /// it is the only tier available when no service is serving it.
+    ///
+    /// It is this enum's default because it is the only tier that is always correct: a run has to
+    /// have somewhere to start before the health request has said whether a relay exists. Which
+    /// tier a *served* application settles on is a separate question, answered in `main.rs` when
+    /// that request comes back, and the answer there is [`Tier::Relayed`].
     #[default]
     Local,
     /// Path building and revocation checking may retrieve, through the service's relay. The
     /// certificates being validated stay in the page; the URIs they name do not.
+    ///
+    /// The default wherever a service answers `api/health`: a deployment that runs one is a
+    /// deployment that means to retrieve, and the alternative is a first run that reports missing
+    /// issuers and undetermined revocation status for want of a switch nobody was told to flip.
     Relayed,
 }
 
@@ -146,6 +160,108 @@ struct FetchResponseBody {
     #[serde(default)]
     final_uri: String,
     body: String,
+}
+
+/// What a host presented during a handshake the service made on this page's behalf.
+///
+/// A browser cannot obtain this for itself: it holds the certificate of every site it talks to and
+/// exposes none of them, and it cannot open a socket to ask. So the certificate someone actually
+/// wants to look at — the one their bank, or their agency, or a host that just started failing
+/// serves — is the one certificate this application could not be given, until the service made the
+/// handshake instead.
+pub struct Presented {
+    /// Host the handshake was made with.
+    pub host: String,
+    /// Port connected to.
+    pub port: u16,
+    /// Protocol version negotiated, when the service reported one.
+    pub protocol: Option<String>,
+    /// Certificates the host sent, in the order it sent them.
+    pub certificates: Vec<Vec<u8>>,
+    /// OCSP response the host stapled, if it stapled one.
+    pub stapled_ocsp: Option<Vec<u8>>,
+}
+
+/// The wire form of what the service answers with. Separate from [`Presented`] because the bytes
+/// travel as base64 and nothing above this module should have to know that.
+#[cfg(target_family = "wasm")]
+#[derive(Deserialize)]
+struct PeekResponseBody {
+    host: String,
+    port: u16,
+    #[serde(default)]
+    protocol: Option<String>,
+    certificates: Vec<String>,
+    #[serde(default)]
+    stapled_ocsp: Option<String>,
+}
+
+/// The request, which is the address bar contents of the site being asked about. The service
+/// supplies the scheme when there is none.
+#[cfg(target_family = "wasm")]
+#[derive(Serialize)]
+struct PeekRequestBody<'a> {
+    uri: &'a str,
+}
+
+/// Asks the service what certificates `uri` presents.
+#[cfg(target_family = "wasm")]
+pub async fn relay_peek(uri: &str) -> Result<Presented, String> {
+    use base64::engine::general_purpose::STANDARD;
+    use base64::Engine as _;
+
+    let request = serde_json::to_string(&PeekRequestBody { uri })
+        .map_err(|e| format!("could not encode the request: {e}"))?;
+    let response = gloo_net::http::Request::post(TLS_URL)
+        .header("Content-Type", "application/json")
+        .body(request)
+        .map_err(|e| e.to_string())?
+        .send()
+        .await
+        .map_err(|e| e.to_string())?;
+
+    let bytes = response.binary().await.map_err(|e| e.to_string())?;
+    // As with a retrieval, a refusal carries the rule it ran into, and that message is the whole
+    // value of the answer -- "refused by policy: port not permitted: 8443" is actionable in a way
+    // that a status code is not.
+    if !response.ok() {
+        let message = serde_json::from_slice::<serde_json::Value>(&bytes)
+            .ok()
+            .and_then(|v| v.get("error").and_then(|e| e.as_str().map(str::to_string)))
+            .unwrap_or_else(|| format!("HTTP {}", response.status()));
+        return Err(message);
+    }
+
+    let decoded: PeekResponseBody =
+        serde_json::from_slice(&bytes).map_err(|e| format!("unexpected answer: {e}"))?;
+    let mut certificates = vec![];
+    for encoded in &decoded.certificates {
+        let der = STANDARD
+            .decode(encoded.as_bytes())
+            .map_err(|e| format!("a certificate was not valid base64: {e}"))?;
+        certificates.push(der);
+    }
+    let stapled_ocsp = match &decoded.stapled_ocsp {
+        Some(encoded) => Some(
+            STANDARD
+                .decode(encoded.as_bytes())
+                .map_err(|e| format!("the stapled response was not valid base64: {e}"))?,
+        ),
+        None => None,
+    };
+    Ok(Presented {
+        host: decoded.host,
+        port: decoded.port,
+        protocol: decoded.protocol,
+        certificates,
+        stapled_ocsp,
+    })
+}
+
+/// Host builds have no service to ask, the same as every other exchange in this module.
+#[cfg(not(target_family = "wasm"))]
+pub async fn relay_peek(_uri: &str) -> Result<Presented, String> {
+    Err("retrieval is only available in the browser build".to_string())
 }
 
 /// One retrieval's outcome.


### PR DESCRIPTION
- Make retrieval through service the default
- Add version and build stamp to the UI
- Add an option to load an EE cert by harvesting from a TLS session to a given host