### PR TITLE
Use a CBOR store's partial paths when a serialized store has not been augmented

### DIFF
--- a/certval/src/source/cert_source.rs
+++ b/certval/src/source/cert_source.rs
@@ -534,6 +534,20 @@ impl CertSource {
     pub fn num_certs(&self) -> usize {
         self.certs.len()
     }
+    /// Returns the number of partial paths the instance holds, whether deserialized with it or
+    /// recorded by [`CertSource::find_all_partial_paths`].
+    ///
+    /// Zero means path building would have to search. That is what lets a caller tell a serialized
+    /// store that carries its own graph from one that carries only certificates, and so decide
+    /// whether searching again would recompute an answer it already has.
+    pub fn num_partial_paths(&self) -> usize {
+        self.buffers_and_paths
+            .partial_paths
+            .iter()
+            .flat_map(|row| row.values())
+            .map(|paths| paths.len())
+            .sum()
+    }
     /// Returns the parsed certificate vector prepared by [`CertSource::initialize`]. Entries are
     /// `None` where the corresponding buffer could not be parsed or was invalid at the time of
     /// interest.

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -874,6 +874,10 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
     // before the settings were adjusted for the run — see `graph_fingerprint` above.
     let mut graph_from_cache = false;
 
+    // Whether the CA input was a CBOR store adopted with the partial paths it carries, which means
+    // the graph is already built and searching again would recompute it.
+    let mut ca_store_paths_adopted = false;
+
     // Start the clock for entire set of validation actions
     let start = Instant::now();
 
@@ -987,14 +991,34 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
                 // exported one at once — the `cbor` argument holds only one path.
                 let from_cbor_store = cert_source.len() == before && Path::new(ca_folder).is_file();
                 if from_cbor_store {
-                    if let Some(certs) = cbor_cert_store_certs(ca_folder) {
+                    // `before` decides which of the two a store is here. At zero nothing else has
+                    // contributed, so the store is the whole CA input and no path can span it and
+                    // another source: adopt it as it stands, partial paths included, which is what
+                    // the `cbor` argument does with the same bytes. Above zero it is being merged
+                    // with material it was not searched against, and a path spanning the two exists
+                    // only once they are searched together, so take the certificates alone and let
+                    // the search below build the graph over the union.
+                    if 0 == before {
+                        if let Some(store) = cbor_cert_store(ca_folder) {
+                            // Only skip the search if the store actually carries paths. A store
+                            // exported without them is certificates in a different container, and
+                            // adopting it would otherwise leave the run with no graph at all.
+                            ca_store_paths_adopted = store.num_partial_paths() > 0;
+                            cert_source = store;
+                        }
+                    } else if let Some(certs) = cbor_cert_store_certs(ca_folder) {
                         for cf in certs {
                             cert_source.push(cf);
                         }
                     }
                 }
                 ca_folder_certs = cert_source.len() - before;
-                if from_cbor_store {
+                if from_cbor_store && ca_store_paths_adopted {
+                    info!(
+                        "Read {ca_folder_certs} certificate(s) and {} partial path(s) from the CBOR store at {ca_folder}",
+                        cert_source.num_partial_paths()
+                    );
+                } else if from_cbor_store {
                     info!(
                         "Read {ca_folder_certs} certificate(s) from the CBOR store at {ca_folder}"
                     );
@@ -1102,8 +1126,10 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         // Certificates read from the CA folder arrive with no partial paths, and a path that spans
         // the folder and the store exists only once the two are searched together, so build the
         // graph here rather than take the store's serialized paths as complete. A graph off the
-        // cache already carries the result of this search, which is the point of caching it.
-        if 0 == pass && 0 < ca_folder_certs && !graph_from_cache {
+        // cache already carries the result of this search, which is the point of caching it, and so
+        // does a store adopted whole above -- neither is cached again here, because neither was
+        // built here.
+        if 0 == pass && 0 < ca_folder_certs && !graph_from_cache && !ca_store_paths_adopted {
             cert_source.find_all_partial_paths(&pe, &cps);
             if let Some(fingerprint) = &graph_fingerprint {
                 graph_cache::store(fingerprint, &cert_source);

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -74,10 +74,19 @@ pub fn cbor_ta_store_anchors(path: &str) -> Option<Vec<CertFile>> {
 /// against the store alone would not describe it.
 #[cfg(feature = "std")]
 pub fn cbor_cert_store_certs(path: &str) -> Option<Vec<CertFile>> {
+    cbor_cert_store(path).map(|from_cbor| from_cbor.get_buffers())
+}
+
+/// Reads the file at `path` as a CBOR certificate store, or `None` when it is not one.
+///
+/// Unlike [`cbor_cert_store_certs`] this keeps the partial paths the store carries, which is what a
+/// caller wants when the store is the entire set of CA certificates for a run: those paths already
+/// describe every path through it, so searching again would recompute an answer that was serialized
+/// precisely so it would not have to be.
+#[cfg(feature = "std")]
+pub fn cbor_cert_store(path: &str) -> Option<CertSource> {
     let bytes = get_file_as_byte_vec_pem(Path::new(path)).ok()?;
-    CertSource::new_from_cbor(&bytes)
-        .ok()
-        .map(|from_cbor| from_cbor.get_buffers())
+    CertSource::new_from_cbor(&bytes).ok()
 }
 
 /// Builds the trust anchor store named by the `ta_cbor` and `ta_folder` arguments, or `None` when

--- a/pittv3-lib/tests/graph_cache.rs
+++ b/pittv3-lib/tests/graph_cache.rs
@@ -184,3 +184,101 @@ fn the_augmented_graph_is_cached_reused_and_rekeyed() {
 
     unsafe { std::env::remove_var("PITTV3_GRAPH_CACHE") };
 }
+
+/// Builds a CBOR store at `cbor` from the certificate `ca_input` names, the way a user producing
+/// one to hand back to a later run would.
+fn generate_store(dir: &Path, ca_input: &Path, cbor: &Path) {
+    tokio_test::block_on(options_std(&Pittv3Args {
+        ta_folder: Some(
+            example("TrustAnchorRootCertificate.crt")
+                .to_str()
+                .unwrap()
+                .to_string(),
+        ),
+        ca_folder: Some(ca_input.to_str().unwrap().to_string()),
+        cbor: Some(cbor.to_str().unwrap().to_string()),
+        generate: true,
+        settings: Some(settings_file(dir)),
+        time_of_interest: TOI,
+        ..Default::default()
+    }));
+}
+
+/// A store handed to the CA input is the entire set of CA certificates for that run, and it already
+/// carries the partial paths through itself — which is the whole reason they were serialized. So it
+/// is adopted as it stands rather than being reduced to its certificates and searched again, and
+/// the first run costs what the ones after it cost. Carl's report was that "the first run is slower
+/// than I would expect given the paths have already been calculated", and it was.
+///
+/// **The observable is that nothing is cached**, because nothing was built. This module's own
+/// comment has always said only augmented graphs are cached; a store arriving through the CA row
+/// rather than through `--cbor` was the case that did not honor it, and a cache entry appearing here
+/// means the search ran.
+///
+/// The second half is the other arm of the same decision: a store merged with material it was not
+/// searched against *is* augmentation, because a path spanning the two exists only once they are
+/// searched together. That one must still search, and still cache.
+#[test]
+fn a_store_in_the_ca_row_is_adopted_with_its_paths_rather_than_searched_again() {
+    let _guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    let dir = tempfile::tempdir().unwrap();
+    let cache = dir.path().join("cache");
+    // SAFETY: this test binary is single-threaded by construction; see the module comment.
+    unsafe { std::env::set_var("PITTV3_GRAPH_CACHE", &cache) };
+
+    let good_ca = dir.path().join("good-ca.cbor");
+    generate_store(dir.path(), &example("GoodCACert.crt"), &good_ca);
+    assert!(good_ca.is_file(), "the CA store was not generated");
+
+    // The store carries the paths the adoption is for; without them there would be nothing to adopt
+    // and skipping the search would leave the run with no graph.
+    let store = pittv3_lib::std_utils::cbor_cert_store(good_ca.to_str().unwrap())
+        .expect("the generated store does not read back through the reader the run uses");
+    assert!(
+        store.num_partial_paths() > 0,
+        "the generated store carries no partial paths, so this test cannot mean what it says"
+    );
+    let certs_only = pittv3_lib::std_utils::cbor_cert_store_certs(good_ca.to_str().unwrap())
+        .expect("the generated store does not read back as certificates");
+    assert_eq!(
+        store.num_buffers(),
+        certs_only.len(),
+        "the two readers disagree about how many certificates the store holds"
+    );
+
+    let ta_folder = folder_with(&dir.path().join("ta"), &["TrustAnchorRootCertificate.crt"]);
+    let report = validate(
+        dir.path(),
+        Some(ta_folder.clone()),
+        Some(good_ca.to_str().unwrap().to_string()),
+    );
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+    assert_eq!(3, report.targets[0].paths[0].certs.len());
+    assert!(
+        cached_graphs(&cache).is_empty(),
+        "a graph was cached, so the store's paths were discarded and the search ran anyway"
+    );
+
+    // Augmentation: a second store in the CA row alongside one already loaded through `--cbor`.
+    // Now the two have never been searched together, so the search has to run -- and its result is
+    // worth caching, which is what tells the two arms apart from outside.
+    let sub_ca = dir.path().join("sub-ca.cbor");
+    generate_store(dir.path(), &example("GoodsubCACert.crt"), &sub_ca);
+
+    let report = tokio_test::block_on(options_std(&Pittv3Args {
+        cbor: Some(sub_ca.to_str().unwrap().to_string()),
+        ..args_for(
+            dir.path(),
+            Some(ta_folder),
+            Some(good_ca.to_str().unwrap().to_string()),
+        )
+    }));
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+    assert_eq!(
+        1,
+        cached_graphs(&cache).len(),
+        "an augmented graph was not cached, so the two stores were not searched together"
+    );
+
+    unsafe { std::env::remove_var("PITTV3_GRAPH_CACHE") };
+}


### PR DESCRIPTION
- When the CA input is an unaugmented CBOR store, use it's partial paths as read
- Add CertSource::num_partial_paths
- Add cbor_cert_store alongside cbor_cert_store_certs to retain partial paths