### PR TITLE
Version, package name and README updates

### DIFF
--- a/.github/workflows/certval.yml
+++ b/.github/workflows/certval.yml
@@ -24,14 +24,14 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
       # pittv3-relay and pittv3-service are excluded for the same reason: both declare 1.88, and
-      # pittv3-service depends on pittv3_gui_lib, so leaving them in drags the dioxus tree back
+      # pittv3-service depends on pittv3-gui-lib, so leaving them in drags the dioxus tree back
       # into these legs transitively and defeats the exclusion above. They are covered in
       # pittv3-ui.yml, which runs on stable.
       # the UI crates are excluded: the dioxus 0.7 dependency tree requires rustc >= 1.88
       # (home/built/image/time), above the 1.85 MSRV here, and pittv3-gui additionally needs
       # Linux system packages (libwebkit2gtk-4.1-dev, libgtk-3-dev, libxdo-dev) absent from
       # the runner; re-include as the desktop work stabilizes
-      - run: cargo hack build --each-feature --workspace --exclude pittv3-gui --exclude pittv3_gui_lib --exclude pittv3-wasm --exclude pittv3_relay --exclude pittv3-service
+      - run: cargo hack build --each-feature --workspace --exclude pittv3-gui --exclude pittv3-gui-lib --exclude pittv3-wasm --exclude pittv3-relay --exclude pittv3-service
 
   test:
     runs-on: ubuntu-latest
@@ -47,7 +47,7 @@ jobs:
           toolchain: ${{ matrix.rust }}
       - uses: RustCrypto/actions/cargo-hack-install@master
       # see build job note: UI crates excluded (dioxus tree MSRV + system packages)
-      - run: cargo hack test --each-feature --workspace --exclude pittv3-gui --exclude pittv3_gui_lib --exclude pittv3-wasm --exclude pittv3_relay --exclude pittv3-service
+      - run: cargo hack test --each-feature --workspace --exclude pittv3-gui --exclude pittv3-gui-lib --exclude pittv3-wasm --exclude pittv3-relay --exclude pittv3-service
 
   # --each-feature never combines features, so the std+rsa test population
   # (revocation.rs, rfc822_dn_name_constraints.rs, the pkits_2048 std variants)
@@ -91,10 +91,10 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with: { components: clippy }
       # see build job note: UI crates excluded (dioxus tree MSRV + system packages)
-      - run: cargo clippy --workspace --all-targets --exclude pittv3-gui --exclude pittv3_gui_lib --exclude pittv3-wasm --exclude pittv3_relay --exclude pittv3-service -- -D warnings
+      - run: cargo clippy --workspace --all-targets --exclude pittv3-gui --exclude pittv3-gui-lib --exclude pittv3-wasm --exclude pittv3-relay --exclude pittv3-service -- -D warnings
       # --all-features cannot catch warnings that only exist when a feature is ABSENT (an import
       # used solely by a gated path), which is why the default-feature run above is kept as well.
-      - run: cargo clippy --workspace --all-targets --all-features --exclude pittv3-gui --exclude pittv3_gui_lib --exclude pittv3-wasm --exclude pittv3_relay --exclude pittv3-service -- -D warnings
+      - run: cargo clippy --workspace --all-targets --all-features --exclude pittv3-gui --exclude pittv3-gui-lib --exclude pittv3-wasm --exclude pittv3-relay --exclude pittv3-service -- -D warnings
 
   # Broken doc links are invisible to check, clippy and test: they surface only when rustdoc
   # resolves them, so a dead `[Foo]` ships in the published docs. certval declares
@@ -108,11 +108,11 @@ jobs:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
       # see build job note: UI crates excluded (dioxus tree MSRV + system packages)
-      - run: cargo doc --workspace --no-deps --exclude pittv3-gui --exclude pittv3_gui_lib --exclude pittv3-wasm --exclude pittv3_relay --exclude pittv3-service
+      - run: cargo doc --workspace --no-deps --exclude pittv3-gui --exclude pittv3-gui-lib --exclude pittv3-wasm --exclude pittv3-relay --exclude pittv3-service
       # A link to a `#[cfg(feature = ...)]` item resolves only when that feature is on, so the two
       # runs catch different things: this one the links that need a feature, the one above the
       # links that break without it.
-      - run: cargo doc --workspace --no-deps --all-features --exclude pittv3-gui --exclude pittv3_gui_lib --exclude pittv3-wasm --exclude pittv3_relay --exclude pittv3-service
+      - run: cargo doc --workspace --no-deps --all-features --exclude pittv3-gui --exclude pittv3-gui-lib --exclude pittv3-wasm --exclude pittv3-relay --exclude pittv3-service
 
   # certval is no_std-capable; prove it links for an embedded target. Build-only
   # (no test runner on the target). thumbv7em-none-eabihf deliberately — an

--- a/.github/workflows/pittv3-ui.yml
+++ b/.github/workflows/pittv3-ui.yml
@@ -36,10 +36,10 @@ jobs:
         env:
           DEBIAN_FRONTEND: noninteractive
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo check -p pittv3_gui_lib
+      - run: cargo check -p pittv3-gui-lib
       - run: cargo check -p pittv3-gui
 
-  # The service depends on pittv3_gui_lib for the shared validation path, so it carries the same
+  # The service depends on pittv3-gui-lib for the shared validation path, so it carries the same
   # 1.88 floor and belongs here rather than in certval.yml's MSRV legs. Tested rather than merely
   # checked: unlike the GUI crates these have a headless test surface.
   service:
@@ -48,7 +48,7 @@ jobs:
     steps:
       - uses: actions/checkout@v4
       - uses: dtolnay/rust-toolchain@stable
-      - run: cargo test -p pittv3_relay -p pittv3-service
+      - run: cargo test -p pittv3-relay -p pittv3-service
 
   wasm:
     runs-on: ubuntu-latest
@@ -83,9 +83,9 @@ jobs:
       - uses: dtolnay/rust-toolchain@stable
         with:
           targets: wasm32-unknown-unknown
-      - run: cargo doc -p pittv3_gui_lib -p pittv3-gui --no-deps
-      # pittv3_gui_lib gates items on `std`, and a link to one resolves only when it is enabled;
+      - run: cargo doc -p pittv3-gui-lib -p pittv3-gui --no-deps
+      # pittv3-gui-lib gates items on `std`, and a link to one resolves only when it is enabled;
       # the run above covers the links that must hold without it.
-      - run: cargo doc -p pittv3_gui_lib --no-deps --all-features
+      - run: cargo doc -p pittv3-gui-lib --no-deps --all-features
       - run: cargo doc -p pittv3-wasm --target wasm32-unknown-unknown --no-deps
-      - run: cargo doc -p pittv3_relay -p pittv3-service --no-deps
+      - run: cargo doc -p pittv3-relay -p pittv3-service --no-deps

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -800,6 +800,41 @@ dependencies = [
 [[package]]
 name = "certval"
 version = "0.1.4"
+source = "git+https://github.com/carl-wallace/rust-pki.git?branch=main#4de48cffc7468bc839f766cec39bfa01a89dbc13"
+dependencies = [
+ "base64ct",
+ "bitvec",
+ "cfg-if",
+ "ciborium",
+ "cidr",
+ "cms",
+ "const-oid",
+ "der",
+ "ecdsa",
+ "flagset",
+ "hex-literal",
+ "log",
+ "p256",
+ "p384",
+ "p521",
+ "pem-rfc7468",
+ "pkiprocmacros 0.1.2 (git+https://github.com/carl-wallace/rust-pki.git?branch=main)",
+ "readonly",
+ "serde",
+ "serde_json",
+ "sha1 0.11.0",
+ "sha2 0.11.0",
+ "signature",
+ "spki",
+ "subtle-encoding",
+ "walkdir",
+ "x509-cert",
+ "x509-ocsp",
+]
+
+[[package]]
+name = "certval"
+version = "0.2.0-pre"
 dependencies = [
  "base64ct",
  "bitvec",
@@ -847,46 +882,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "certval"
-version = "0.1.4"
-source = "git+https://github.com/carl-wallace/rust-pki.git?branch=main#4de48cffc7468bc839f766cec39bfa01a89dbc13"
-dependencies = [
- "base64ct",
- "bitvec",
- "cfg-if",
- "ciborium",
- "cidr",
- "cms",
- "const-oid",
- "der",
- "ecdsa",
- "flagset",
- "hex-literal",
- "log",
- "p256",
- "p384",
- "p521",
- "pem-rfc7468",
- "pkiprocmacros 0.1.2 (git+https://github.com/carl-wallace/rust-pki.git?branch=main)",
- "readonly",
- "serde",
- "serde_json",
- "sha1 0.11.0",
- "sha2 0.11.0",
- "signature",
- "spki",
- "subtle-encoding",
- "walkdir",
- "x509-cert",
- "x509-ocsp",
-]
-
-[[package]]
 name = "certval_stores_core"
 version = "0.1.0"
 source = "git+https://github.com/carl-wallace/certval-stores.git?branch=main#41bb7d37a416aaae65044de80a61aadb9a784b5e"
 dependencies = [
- "certval 0.1.4 (git+https://github.com/carl-wallace/rust-pki.git?branch=main)",
+ "certval 0.1.4",
  "log",
 ]
 
@@ -5059,7 +5059,7 @@ checksum = "a89322df9ebe1c1578d689c92318e070967d1042b512afbe49518723f4e6d5cd"
 
 [[package]]
 name = "pittv3"
-version = "0.1.3"
+version = "0.2.0-pre"
 dependencies = [
  "assert_cmd",
  "cfg-if",
@@ -5067,7 +5067,7 @@ dependencies = [
  "hex-literal",
  "log",
  "log4rs",
- "pittv3_lib",
+ "pittv3-lib",
  "predicates",
  "tempfile",
  "tokio",
@@ -5076,9 +5076,9 @@ dependencies = [
 
 [[package]]
 name = "pittv3-gui"
-version = "0.1.3"
+version = "0.2.0-pre"
 dependencies = [
- "certval 0.1.4",
+ "certval 0.2.0-pre",
  "certval_stores_core",
  "certval_stores_fpki",
  "certval_stores_mozilla",
@@ -5091,8 +5091,8 @@ dependencies = [
  "home",
  "log",
  "log4rs",
- "pittv3_gui_lib",
- "pittv3_lib",
+ "pittv3-gui-lib",
+ "pittv3-lib",
  "rfd",
  "serde_json",
  "tempfile",
@@ -5100,62 +5100,11 @@ dependencies = [
 ]
 
 [[package]]
-name = "pittv3-service"
-version = "0.1.3"
-dependencies = [
- "actix-files",
- "actix-rt",
- "actix-web",
- "base64",
- "bytes",
- "certval 0.1.4",
- "certval_stores_core",
- "certval_stores_fpki",
- "certval_stores_mozilla",
- "certval_stores_nipr",
- "certval_stores_pbdev",
- "clap",
- "env_logger 0.11.11",
- "log",
- "pittv3_gui_lib",
- "pittv3_lib",
- "pittv3_relay",
- "serde",
- "serde_json",
- "tempfile",
-]
-
-[[package]]
-name = "pittv3-wasm"
-version = "0.1.3"
-dependencies = [
- "base64",
- "certval 0.1.4",
- "certval_stores_core",
- "certval_stores_mozilla",
- "certval_stores_nipr",
- "dioxus",
- "getrandom 0.4.3",
- "gloo-net",
- "gloo-timers",
- "js-sys",
- "log",
- "pem-rfc7468",
- "pittv3_gui_lib",
- "pittv3_lib",
- "serde",
- "serde_json",
- "web-sys",
- "web-time",
- "zip",
-]
-
-[[package]]
-name = "pittv3_gui_lib"
-version = "0.1.3"
+name = "pittv3-gui-lib"
+version = "0.2.0-pre"
 dependencies = [
  "anyhow",
- "certval 0.1.4",
+ "certval 0.2.0-pre",
  "cms",
  "der",
  "dioxus",
@@ -5164,7 +5113,7 @@ dependencies = [
  "log",
  "log4rs",
  "pem-rfc7468",
- "pittv3_lib",
+ "pittv3-lib",
  "serde",
  "serde_json",
  "web-time",
@@ -5174,12 +5123,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "pittv3_lib"
-version = "0.1.3"
+name = "pittv3-lib"
+version = "0.2.0-pre"
 dependencies = [
  "async-recursion",
  "bytes",
- "certval 0.1.4",
+ "certval 0.2.0-pre",
  "ciborium",
  "cms",
  "const-oid",
@@ -5204,8 +5153,8 @@ dependencies = [
 ]
 
 [[package]]
-name = "pittv3_relay"
-version = "0.1.3"
+name = "pittv3-relay"
+version = "0.2.0-pre"
 dependencies = [
  "log",
  "reqwest 0.13.4",
@@ -5213,6 +5162,57 @@ dependencies = [
  "serde",
  "tokio",
  "tokio-rustls",
+]
+
+[[package]]
+name = "pittv3-service"
+version = "0.2.0-pre"
+dependencies = [
+ "actix-files",
+ "actix-rt",
+ "actix-web",
+ "base64",
+ "bytes",
+ "certval 0.2.0-pre",
+ "certval_stores_core",
+ "certval_stores_fpki",
+ "certval_stores_mozilla",
+ "certval_stores_nipr",
+ "certval_stores_pbdev",
+ "clap",
+ "env_logger 0.11.11",
+ "log",
+ "pittv3-gui-lib",
+ "pittv3-lib",
+ "pittv3-relay",
+ "serde",
+ "serde_json",
+ "tempfile",
+]
+
+[[package]]
+name = "pittv3-wasm"
+version = "0.2.0-pre"
+dependencies = [
+ "base64",
+ "certval 0.2.0-pre",
+ "certval_stores_core",
+ "certval_stores_mozilla",
+ "certval_stores_nipr",
+ "dioxus",
+ "getrandom 0.4.3",
+ "gloo-net",
+ "gloo-timers",
+ "js-sys",
+ "log",
+ "pem-rfc7468",
+ "pittv3-gui-lib",
+ "pittv3-lib",
+ "serde",
+ "serde_json",
+ "web-sys",
+ "web-time",
+ "zip",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,7 +16,7 @@ members = [
 # The service and the relay it mounts pull in a web server and its runtime, which nobody working on
 # the validation library needs compiled. Leaving them out of the default set keeps a bare
 # `cargo build` or `cargo test` at the weight it has always had; build them by naming them, i.e.,
-# `cargo test -p pittv3_relay -p pittv3-service`.
+# `cargo test -p pittv3-relay -p pittv3-service`.
 default-members = [
     "certval",
     "pkiprocmacros",

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Rust Certification Path Processing [![dependency status][deps-image]][deps-link]
+# Rust Certification Path Processing
 
 Pure Rust Libraries and tools related to certification path processing. 
 
@@ -7,21 +7,54 @@ build is required to try it.
 
 ## Crates
 
-| Name           | Description                                                                                |
-| -------------- | ------------------------------------------------------------------------------------------ |
-| `certval`      | Certification path validation implementation                                               |
-| `pittv3`       | Command-line version of PITTv2 (minus some features) that uses Rust undercarriage          |
-| `pittv3-wasm`  | Browser (WASM) frontend for PITTv3, hosted at <https://pittv3.redhoundsoftware.com>        |
-| `pkiprocmacros`| Procedural macros that support certval and friends                                         |
+| Name              | Description                                                                         |
+| ----------------- |-------------------------------------------------------------------------------------|
+| `certval`         | Certification path building and validation implementation                           |
+| `pittv3`          | Command-line version of PKI Interoperability Test Tool functionality                |
+| `pittv3-lib`      | Argument structure and processing logic shared by every PITTv3 frontend             |
+| `pittv3-gui`      | Desktop (dioxus-desktop) frontend for PITTv3                                        |
+| `pittv3-gui-lib`  | User interface components shared by the desktop and browser frontends               |
+| `pittv3-wasm`     | Browser (WASM) frontend for PITTv3, hosted at <https://pittv3.redhoundsoftware.com> |
+| `pittv3-relay`    | Retrieves PKI artifacts over HTTP for a caller that cannot retrieve them itself     |
+| `pittv3-service`  | Serves the browser frontend, the relay it calls, and server-side validation         |
+| `pkiprocmacros`   | Procedural macros that support certval and friends                                  |
+
+The `certval` crate is the focal point of this repo. The various `pittv3` crates provide different ways of 
+exercising `certval`'s capabilities. Five different `pittv3` interfaces are provided: command line, desktop GUI,
+WASM, WASM + relay, and a (limited) scriptable service API. The WASM + relay option hosted at 
+<https://pittv3.redhoundsoftware.com> provides a means to exercise the library without building or installing
+any components and without having end entity certificates leave the web browser.
+
+## Standards
+
+`certval` validates certification paths per [RFC 5280], with the trust anchor constraint
+processing of [RFC 5937] over trust anchors expressed as [RFC 5914] `TrustAnchorChoice` values.
+Certificate policy processing follows the graph-based algorithm of [RFC 9618]. Revocation
+status is determined from CRLs and from OCSP ([RFC 6960], including the nonce handling of
+[RFC 8954]), and path building based on the practices described in [RFC 4158]. Signatures are
+verified for RSA, ECDSA, Ed25519, ML-DSA ([FIPS 204]) and SLH-DSA ([FIPS 205]).
+
+Conformance is measured against [x509-limbo] and the NIST [PKITS] suite; `certval`'s security
+warning reports the pass rate and where the remaining mismatches fall.
+
+[RFC 4158]: https://datatracker.ietf.org/doc/html/rfc4158
+[RFC 5280]: https://datatracker.ietf.org/doc/html/rfc5280
+[RFC 5914]: https://datatracker.ietf.org/doc/html/rfc5914
+[RFC 5937]: https://datatracker.ietf.org/doc/html/rfc5937
+[RFC 6960]: https://datatracker.ietf.org/doc/html/rfc6960
+[RFC 8954]: https://datatracker.ietf.org/doc/html/rfc8954
+[RFC 9618]: https://datatracker.ietf.org/doc/html/rfc9618
+[FIPS 204]: https://csrc.nist.gov/pubs/fips/204/final
+[FIPS 205]: https://csrc.nist.gov/pubs/fips/205/final
+[x509-limbo]: https://github.com/C2SP/x509-limbo
+[PKITS]: https://csrc.nist.gov/projects/pki-testing
 
 ## License
 
-All crates licensed under either of
+All crates licensed under either of the following, at your option: 
 
 - [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 - [MIT license](http://opensource.org/licenses/MIT)
-
-at your option.
 
 ### Contribution
 
@@ -29,21 +62,3 @@ Unless you explicitly state otherwise, any contribution intentionally submitted
 for inclusion in the work by you, as defined in the Apache-2.0 license, shall be
 dual licensed as above, without any additional terms or conditions.
 
-[//]: # "badges"
-[deps-image]: https://deps.rs/repo/github/RustCrypto/formats/status.svg
-[deps-link]: https://deps.rs/repo/github/RustCrypto/formats
-
-[//]: # "links"
-[itu x.660]: https://www.itu.int/rec/T-REC-X.660
-[itu x.690]: https://www.itu.int/rec/T-REC-X.690
-[rfc 4716]: https://datatracker.ietf.org/doc/html/rfc4253
-[rfc 5208]: https://datatracker.ietf.org/doc/html/rfc5208
-[rfc 5280 section 4.1]: https://datatracker.ietf.org/doc/html/rfc5280#section-4.1
-[rfc 5280]: https://datatracker.ietf.org/doc/html/rfc5280
-[rfc 5652]: https://datatracker.ietf.org/doc/html/rfc5652
-[rfc 5958]: https://datatracker.ietf.org/doc/html/rfc5958
-[rfc 8017]: https://datatracker.ietf.org/doc/html/rfc8017
-[rfc 8018]: https://datatracker.ietf.org/doc/html/rfc8018
-[rfc 8933]: https://datatracker.ietf.org/doc/html/rfc8933
-[rfc 8446 section 3]: https://datatracker.ietf.org/doc/html/rfc8446#section-3
-[sec1: elliptic curve cryptography]: https://www.secg.org/sec1-v2.pdf

--- a/certval/Cargo.toml
+++ b/certval/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "certval"
-version = "0.1.4"
+version = "0.2.0-pre"
 description = """
 Pure Rust implementation of X.509 Public Key Infrastructure Certificate validation as described in [RFC 5280] and
 as augmented by [RFC 5937], including support for certification path building and revocation status determination.
 """
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/carl-wallace/rust-pki"
-categories = ["cryptography", "pki", "no-std"]
-keywords = ["crypto", "x.509", "OCSP"]
+categories = ["cryptography", "no-std", "encoding"]
+keywords = ["x509", "pki", "ocsp", "crl", "certificate"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.85"
@@ -28,7 +28,7 @@ spki = { version = "0.8.0", default-features = false, features = ["alloc"] }
 pem-rfc7468 = { version="1.0.0", features = ["alloc"]}
 signature = { version = "3.0.0" }
 
-pkiprocmacros = { path = "../pkiprocmacros"}
+pkiprocmacros = { path = "../pkiprocmacros", version = "0.1.2" }
 
 ecdsa = {version = "0.17.0", default-features = false, features = ["der"]}
 p256 = {version = "0.14.0", default-features = false, features = ["ecdsa"]}

--- a/certval/README.md
+++ b/certval/README.md
@@ -8,7 +8,7 @@ as augmented by [RFC 5937]. Support for certification path building and revocati
 
 ASN.1 encoders and decoders and cryptographic support are primarily provided by various [RustCrypto] libraries.
 
-A change log is available at the root of the certval project.
+A change log is available at the root of the `certval` project.
 
 ## Crate Feature Flags
 
@@ -18,38 +18,52 @@ The certval library provides seven feature gates that enable varying levels of s
 - `revocation` augments the `default-features = false` feature by adding support for processing CRLs and OCSP responses that are provided by the caller, such as may have been obtained by stapling to a higher level protocol.
 - `std` augments the `default-features = false` feature by adding support for obtaining artifacts via the file system and addition of support for multi-threaded use.
 - `revocation,std` augments the `std` feature by adding support for processing CRLs and OCSP responses that are provided by the caller or obtained via the file system.
-- `remote` is the default. It replaces and augments the `revocation,std` features by adding support for retrieving certificates via URIs expressed in SIA and AIA extensions, for retrieving CRLs via URIs expressed in CRL DP extensions, and for interacting with OCSP responders via URIs expressed in AIA extensions.
-- `pqc` adds support for dilithium, falcon and sphincsplus using algorithm implementations from the [pqcrypto](https://github.com/rustpq/pqcrypto) project and object identifiers from the [IETF 115 PQC hackathon](https://github.com/IETF-Hackathon/pqc-certificates).
+- `remote` is enabled by default (the default feature set is `remote` plus `webpki`). It replaces and augments the `revocation,std` features by adding support for retrieving certificates via URIs expressed in SIA and AIA extensions, for retrieving CRLs via URIs expressed in CRL DP extensions, and for interacting with OCSP responders via URIs expressed in AIA extensions.
+- `pqc` adds support for ML-DSA (FIPS 204), including the hash-ML-DSA-with-SHA-512 variants, and SLH-DSA (FIPS 205), using the [ml-dsa](https://crates.io/crates/ml-dsa) and [slh-dsa](https://crates.io/crates/slh-dsa) implementations, plus composite ML-DSA signatures. Object identifiers for the standardized algorithms come from `const_oid`'s FIPS 204 and FIPS 205 tables; the composite and pre-standardization identifiers are declared in certval's own `pqc_oids` module.
 - `webpki` adds support for instantiating TaSource instances using trust anchors from the [webpki-roots](https://crates.io/crates/webpki-roots) crate
 - `rsa` enables use of the RSA algorithm. RSA support is not enabled by default.
 - `eddsa` enables use of the Ed25519 algorithm. Ed25519 support is not enabled by default.
 
 ## Sample Usage
 
-The [PITTv3](../pittv3/index.html) application uses the certval library and can serve as sample code for usage of the library.
+The suite of [PITTv3](../pittv3/index.html) applications uses the `certval` library and can serve as sample code for usage in command
+line, desktop, and WASM contexts.
 
-## Status
+## ⚠️ Security Warning
 
-tl;dr: not ready to use.
+The implementation contained in this crate has never been independently audited.
 
-This is a work-in-progress implementation which is at an early stage of
-development.
+It has been tested against the following test suites, both of which run in CI:
 
-## Minimum Supported Rust Version
+- **x509-limbo** — 9,737 cases, of which 9,698 reach the expected result: **99.60%**. The 39
+  mismatches fall in two namespaces, `webpki::` (22) and `rfc5280::` (17); every other namespace is
+  clean, `cve::` included. The `webpki::` cases are Web PKI-specific behavior this crate does not
+  implement, being a path validator rather than a TLS verifier; the `rfc5280::` ones remain to be
+  triaged. The harness is `support/x509-limbo-tests`, and CI regenerates its results file and fails
+  on any diff, so a change in conformance cannot land unremarked.
+- **NIST PKITS** — sections 4.1 through 4.14 and 4.16, in seventeen editions: the original RSA-2048
+  material, a P-256 re-issue, and fifteen post-quantum re-issues (ML-DSA-44/65/87 and twelve SLH-DSA
+  parameter sets). Editions that carry no CRLs skip the revocation cases (§4.4, plus seven named
+  cases in §4.7 and §4.14); the harness asserts that every case it did not explicitly skip reached
+  the end of validation, so a run cannot quietly no-op.
+
+Neither suite is a substitute for an audit.
+
+## Minimum Supported Rust Version (MSRV) Policy
 
 This crate requires **Rust 1.85** at a minimum.
 
-The MSRV may change in the future, but it will be accompanied by a minor
-version bump.
+MSRV increases are not considered breaking changes and can happen in patch releases.
+
+The crate MSRV accounts for all supported targets and crate feature combinations, excluding
+explicitly unstable features.
 
 ## License
 
-Licensed under either of:
+All crates licensed under either of the following, at your option:
 
 - [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 - [MIT license](http://opensource.org/licenses/MIT)
-
-at your option.
 
 ### Contribution
 
@@ -60,7 +74,7 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (badges)
 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/pittv3-gui-lib/Cargo.toml
+++ b/pittv3-gui-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "pittv3_gui_lib"
-version = "0.1.3"
+name = "pittv3-gui-lib"
+version = "0.2.0-pre"
 description = """
 Shared user interface components for GUI frontends to the PKI Interoperability Test Tool v3 (PITTv3),
 which can be used to build and validate certification paths using different sets of trust anchors,
@@ -18,7 +18,7 @@ rust-version = "1.88"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pittv3_lib = { path = "../pittv3-lib", default-features = false }
+pittv3-lib = { path = "../pittv3-lib", default-features = false }
 certval = { path = "../certval", default-features = false }
 x509-cert = { version = "0.3.0", default-features = false }
 # For the fold half of a retrieving run in retrieval.rs: an authority information access URI
@@ -64,11 +64,11 @@ log4rs = {version = "1.4.0", default-features = false, optional = true}
 # Default is set to be the least encompassing (i.e., for WASM).
 [features]
 default = []
-revocation = ["certval/revocation", "pittv3_lib/revocation"]
-std = ["revocation", "certval/std", "pittv3_lib/std", "dep:home"]
-remote = ["certval/remote", "pittv3_lib/remote", "revocation", "std"]
-pqc = ["certval/pqc", "pittv3_lib/pqc"]
-webpki = ["certval/webpki", "pittv3_lib/webpki"]
+revocation = ["certval/revocation", "pittv3-lib/revocation"]
+std = ["revocation", "certval/std", "pittv3-lib/std", "dep:home"]
+remote = ["certval/remote", "pittv3-lib/remote", "revocation", "std"]
+pqc = ["certval/pqc", "pittv3-lib/pqc"]
+webpki = ["certval/webpki", "pittv3-lib/webpki"]
 gui_desktop = ["std", "dep:log4rs", "dep:anyhow", "dep:futures-channel"]
 
 [package.metadata.docs.rs]

--- a/pittv3-gui/Cargo.toml
+++ b/pittv3-gui/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pittv3-gui"
-version = "0.1.3"
+version = "0.2.0-pre"
 description = """
 Desktop GUI frontend for the PKI Interoperability Test Tool v3 (PITTv3), which can be used to build
 and validate certification paths using different sets of trust anchors, intermediate CA certificates
@@ -20,8 +20,8 @@ rust-version = "1.88"
 # Unlike the CLI, the desktop GUI is not feature-gated: it always builds with the most encompassing
 # feature set (i.e., remote, webpki). WASM frontends get their own crate with a trimmed feature set.
 [dependencies]
-pittv3_lib = { path = "../pittv3-lib", default-features = false, features = ["eddsa", "pqc", "remote", "rsa", "webpki"] }
-pittv3_gui_lib = { path = "../pittv3-gui-lib", default-features = false, features = ["pqc", "remote", "webpki", "gui_desktop"] }
+pittv3-lib = { path = "../pittv3-lib", default-features = false, features = ["eddsa", "pqc", "remote", "rsa", "webpki"] }
+pittv3-gui-lib = { path = "../pittv3-gui-lib", default-features = false, features = ["pqc", "remote", "webpki", "gui_desktop"] }
 
 # Trust material for the built-in store selector (see src/stores.rs). Unlike the browser
 # frontend, which fetches its stores by URL and so takes these as build-dependencies, a desktop
@@ -48,7 +48,7 @@ serde_json = "1.0.150"
 tokio = { version = "1.52.3", features = ["rt", "time"] }
 
 # Only the store tests load what src/stores.rs writes back, to confirm it is what options_std will
-# read; the app itself reaches certval through pittv3_lib.
+# read; the app itself reaches certval through pittv3-lib.
 [dev-dependencies]
 certval = { path = "../certval", default-features = false, features = ["std"] }
 tempfile = "3.27.0"

--- a/pittv3-gui/README.md
+++ b/pittv3-gui/README.md
@@ -2,7 +2,6 @@
 
 This crate provides a desktop GUI frontend for the PKI Interoperability Test Tool v3 (PITTv3),
 offering a similar set of actions as the `pittv3` command line utility. The form mirrors the
-command line options: values are assembled into a
-[`Pittv3Args`](https://docs.rs/pittv3_lib/latest/pittv3_lib/args/struct.Pittv3Args.html) instance
-and processed exactly as the CLI would process them. Argument values are saved to the pittv3.cfg
+command line options: values are assembled into a `pittv3_lib::args::Pittv3Args` instance and
+processed exactly as the CLI would process them. Argument values are saved to the pittv3.cfg
 file in the .pittv3 folder beneath the user's home directory upon each run and restored at startup.

--- a/pittv3-lib/Cargo.toml
+++ b/pittv3-lib/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "pittv3_lib"
-version = "0.1.3"
+name = "pittv3-lib"
+version = "0.2.0-pre"
 description = """
 Library underpinning the PKI Interoperability Test Tool v3 (PITTv3), which can be used to build and
 validate certification paths using different sets of trust anchors, intermediate CA certificates and
@@ -10,8 +10,8 @@ the PITTv3 CLI and GUI frontends.
 authors = [""]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/carl-wallace/rust-pki"
-categories = ["cryptography", "pki", "no-std"]
-keywords = ["crypto", "x.509", "OCSP"]
+categories = ["cryptography", "no-std", "encoding"]
+keywords = ["x509", "pki", "ocsp", "crl", "certificate"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.85"

--- a/pittv3-lib/README.md
+++ b/pittv3-lib/README.md
@@ -6,8 +6,8 @@ Interoperability Test Tool v3 (PITTv3). It exists so that different frontends, i
 
 The [`Pittv3Args`](args::Pittv3Args) structure is a plain data structure with no command line
 parsing dependencies, allowing frontends to populate it directly. The various `options_*` modules
-provide the top-level processing entry points relative to the feature set in use, mirroring the
-feature gates of the `certval` crate:
+provide the top-level processing entry points relative to the feature set in use. The feature gates
+mirror those of the `certval` crate, with two of this crate's own:
 
 - no-default-features provides full path validation without file system support, network or thread safety (and no revocation support)
 - `revocation` adds support for verifying CRLs and OCSP responses presented to the library
@@ -15,3 +15,10 @@ feature gates of the `certval` crate:
 - `remote` adds support for dynamic path building, CRL fetching and OCSP
 - `std_app` provides std support for frontends while building certval with no-default-features
 - `webpki` adds a means of initializing a TaSource from the webpki-roots crate
+- `pqc` adds ML-DSA (FIPS 204) and SLH-DSA (FIPS 205) support, plus composite ML-DSA
+- `rsa` enables use of the RSA algorithm, which is not enabled by default
+- `eddsa` enables use of the Ed25519 algorithm, which is not enabled by default
+- `sha1_sig` registers a verification callback for `sha1WithRsaEncryption`, which the RustCrypto
+  libraries certval builds on do not implement; it implies `rsa`
+
+`std_app` and `sha1_sig` are this crate's own; the rest are passed through to `certval`.

--- a/pittv3-relay/Cargo.toml
+++ b/pittv3-relay/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
-name = "pittv3_relay"
-version = "0.1.3"
+name = "pittv3-relay"
+version = "0.2.0-pre"
 description = """
 Policy-enforcing byte relay used by frontends to the PKI Interoperability Test Tool v3 (PITTv3) that
 cannot reach PKI repositories themselves, i.e., browsers. It retrieves certificates, CRLs and OCSP

--- a/pittv3-service/Cargo.toml
+++ b/pittv3-service/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pittv3-service"
-version = "0.1.3"
+version = "0.2.0-pre"
 description = """
 Web service frontend for the PKI Interoperability Test Tool v3 (PITTv3). It serves the browser
 application, relays the PKI retrievals a browser cannot make itself, and validates certification
@@ -38,14 +38,14 @@ builtin-stores = [
 # revocation *processing*, and deliberately without `remote`. The service validates by calling the
 # same synchronous path pittv3-wasm calls, so the two tiers cannot disagree about a certificate --
 # they are not different code. Leaving `remote` off also means certval never opens a socket of its
-# own: every retrieval the service makes goes through pittv3_relay, where the network policy and the
+# own: every retrieval the service makes goes through pittv3-relay, where the network policy and the
 # budgets live. Note that `std` would substitute certval's asynchronous check_revocation for the
 # synchronous one the shared path is written against, so it stays off for correctness as well.
 [dependencies]
 certval = { path = "../certval", default-features = false, features = ["eddsa", "pqc", "revocation", "rsa"] }
-pittv3_lib = { path = "../pittv3-lib", default-features = false, features = ["eddsa", "pqc", "revocation", "rsa"] }
-pittv3_gui_lib = { path = "../pittv3-gui-lib", default-features = false, features = ["pqc", "revocation"] }
-pittv3_relay = { path = "../pittv3-relay" }
+pittv3-lib = { path = "../pittv3-lib", default-features = false, features = ["eddsa", "pqc", "revocation", "rsa"] }
+pittv3-gui-lib = { path = "../pittv3-gui-lib", default-features = false, features = ["pqc", "revocation"] }
+pittv3-relay = { path = "../pittv3-relay" }
 
 actix-files = "0.6.9"
 actix-web = "4.13.0"

--- a/pittv3-service/README.md
+++ b/pittv3-service/README.md
@@ -8,7 +8,7 @@ an origin.
 
 The endpoints are:
 
-- `POST /api/fetch` retrieves one artifact through `pittv3_relay`, which enforces the network policy
+- `POST /api/fetch` retrieves one artifact through `pittv3-relay`, which enforces the network policy
   and the per-retrieval budgets. The service does not look at what comes back.
 - `POST /api/tls` completes a TLS handshake with a named host and returns the certificates it
   presented, plus any OCSP response it stapled. A browser holds the certificate of every site it
@@ -17,8 +17,10 @@ The endpoints are:
   here. The handshake accepts any certificate — the chain someone is asking about is often one a
   verifier would reject, and judging it is what `/api/validate` and the browser are for — while the
   peer's handshake signature is verified, so the chain returned belongs to the party that answered.
-  Turn it off with `allow_tls_peek` for a deployment whose relay is meant to reach PKI repositories
-  and nothing else.
+  Turn it off with `--no-tls-peek` (the `allow_tls_peek` key in a configuration file) for a
+  deployment whose relay is meant to reach PKI repositories and nothing else. `--no-validation`
+  likewise refuses `POST /api/validate`, for a deployment that wants certificates never to leave the
+  browser.
 - `POST /api/validate` validates the certificates in the request and returns a `ValidationReport`,
   the same structure the CLI writes and the GUIs display.
 - `GET /api/stores` lists the trust stores the service holds, in the shape the browser

--- a/pittv3-wasm/Cargo.toml
+++ b/pittv3-wasm/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pittv3-wasm"
-version = "0.1.3"
+version = "0.2.0-pre"
 description = """
 Browser-based frontend for the PKI Interoperability Test Tool v3 (PITTv3) that performs
 certification path validation in a WASM context, including validation of certificates signed
@@ -26,11 +26,11 @@ rust-version = "1.88"
 # (a synchronous fn, unlike the async one std builds) compiled in, so revocation data supplied
 # alongside the certificates can be honored. Nothing fetches it yet, so runs leave the check off by
 # default -- see `run_settings` in main.rs. Listed on all three crates rather than relying on
-# pittv3_gui_lib's feature to fan out, so each line states what that crate is built with.
+# pittv3-gui-lib's feature to fan out, so each line states what that crate is built with.
 [dependencies]
 certval = { path = "../certval", default-features = false, features = ["eddsa", "pqc", "revocation", "rsa"] }
-pittv3_lib = { path = "../pittv3-lib", default-features = false, features = ["eddsa", "pqc", "revocation", "rsa"] }
-pittv3_gui_lib = { path = "../pittv3-gui-lib", default-features = false, features = ["pqc", "revocation"] }
+pittv3-lib = { path = "../pittv3-lib", default-features = false, features = ["eddsa", "pqc", "revocation", "rsa"] }
+pittv3-gui-lib = { path = "../pittv3-gui-lib", default-features = false, features = ["pqc", "revocation"] }
 
 # The relay exchanges JSON, so a retrieved artifact arrives base64-encoded (see relay.rs).
 base64 = { version = "0.22.1", default-features = false, features = ["alloc"] }

--- a/pittv3-wasm/README.md
+++ b/pittv3-wasm/README.md
@@ -8,15 +8,17 @@ All processing occurs in the browser; certificates never leave the page.
 A hosted instance is available at <https://pittv3.redhoundsoftware.com>; no local build is required
 to try it.
 
-Trust anchor and CA certificate stores are shipped as CBOR files in `resources/`, which Trunk
-copies into `dist/` and the app fetches by relative URL when a store is selected (rather than
-embedding them, which would be paid on every page load): an ML-DSA-44 PKITS edition, the Web PKI
-(Mozilla roots and CCADB intermediates) and U.S. DoD (NIPR). The two trust-community stores are
-regenerated from their provider crates by `build.rs`; see `resources/NOTICE` for what each artifact
-is, where it came from and the terms it travels under. Trust anchors and intermediate CA
-certificates can also be uploaded and are used together with the selected built-in store (or alone
-when no store is selected) to validate certificates from other sources, e.g., artifacts produced by
-other implementations during interoperability testing. Uploads and certificates to validate
+The two trust-community stores — the Web PKI (Mozilla roots and CCADB intermediates) and U.S. DoD
+(NIPR) — are shipped as CBOR files in `resources/`, which Trunk copies into `dist/` and the app
+fetches by relative URL when the store is selected, rather than embedding them, which would be paid
+on every page load. They are regenerated from their provider crates by `build.rs`. The ML-DSA-44
+PKITS edition is different: it is small, static test collateral with no provider behind it, so it is
+compiled in from `fixtures/` alongside its two sample end entity certificates. See
+`resources/NOTICE` for what each artifact is, where it came from and the terms it travels under.
+
+Trust anchors and intermediate CA certificates can also be uploaded and are used together with the
+selected built-in store (or alone when no store is selected) to validate certificates from other
+sources, e.g., artifacts produced by other implementations during interoperability testing. Uploads and certificates to validate
 accumulate across uploads, so a set of loaded certificates can be re-validated after changing the
 trust configuration or settings. Values that govern the RFC 5280 path validation inputs, e.g., the
 initial policy set and related indicators, can be edited in the UI.

--- a/pittv3/Cargo.toml
+++ b/pittv3/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "pittv3"
-version = "0.1.3"
+version = "0.2.0-pre"
 description = """
 PKI Interoperability Test Tool v3 (PITTv3) can be used to build and validate certification paths using different sets
 of trust anchors, intermediate CA certificates and end entity certificates.
@@ -8,8 +8,8 @@ of trust anchors, intermediate CA certificates and end entity certificates.
 authors = [""]
 license = "Apache-2.0 OR MIT"
 repository = "https://github.com/carl-wallace/rust-pki"
-categories = ["cryptography", "pki", "no-std"]
-keywords = ["crypto", "x.509", "OCSP"]
+categories = ["cryptography", "no-std", "encoding"]
+keywords = ["x509", "pki", "ocsp", "crl", "certificate"]
 readme = "README.md"
 edition = "2021"
 rust-version = "1.85"
@@ -17,7 +17,7 @@ rust-version = "1.85"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-pittv3_lib = { path = "../pittv3-lib", default-features = false }
+pittv3-lib = { path = "../pittv3-lib", default-features = false }
 
 cfg-if = "1.0.4"
 clap = {version = "4.6.2", features=["std", "derive"]}
@@ -43,15 +43,15 @@ tokio-test = "0.4.5"
 # webpki can be paired with any other feature and simply adds a means of initializing a TaSource from the webpki-roots crate
 [features]
 default = ["remote", "webpki", "pqc", "rsa", "eddsa"]
-revocation = ["pittv3_lib/revocation"]
-std_app = ["pittv3_lib/std_app", "tokio", "log4rs"]
-std = ["std_app", "revocation", "pittv3_lib/std"]
-remote = ["revocation", "std", "pittv3_lib/remote"]
-pqc = ["pittv3_lib/pqc"]
-webpki = ["pittv3_lib/webpki"]
-sha1_sig = ["pittv3_lib/sha1_sig"]
-rsa = ["pittv3_lib/rsa"]
-eddsa = ["pittv3_lib/eddsa"]
+revocation = ["pittv3-lib/revocation"]
+std_app = ["pittv3-lib/std_app", "tokio", "log4rs"]
+std = ["std_app", "revocation", "pittv3-lib/std"]
+remote = ["revocation", "std", "pittv3-lib/remote"]
+pqc = ["pittv3-lib/pqc"]
+webpki = ["pittv3-lib/webpki"]
+sha1_sig = ["pittv3-lib/sha1_sig"]
+rsa = ["pittv3-lib/rsa"]
+eddsa = ["pittv3-lib/eddsa"]
 
 [package.metadata.docs.rs]
 all-features = true

--- a/pittv3/README.md
+++ b/pittv3/README.md
@@ -5,10 +5,10 @@
 
 PKI Interoperability Test Tool v3 (PITTv3) can be used to build and validate certification paths using different sets 
 of trust anchors, intermediate CA certificates and end entity certificates. It uses ASN.1 encoders and decoders and 
-cryptographic support provided by various [RustCrypto] libraries. It also serves a sample app for using the 
+cryptographic support provided by various [RustCrypto] libraries. It also serves as a sample app for using the 
 [certval](../certval/index.html) library and related RustCrypto formats libraries.
 
-A change log is available at the root of the pittv3 project.
+A change log is available at the root of the `pittv3` project.
 
 ## Using PITTv3
 
@@ -28,7 +28,7 @@ review or to the `ca-folder` for inclusion in CBOR file.
  pittv3 --cbor example.cbor --ca-folder path/to/ca_folder --ta-folder path/to/ta_folder --generate
 ```
 If intermediate CA certificates are not available but one or more end entity certificates are
-available, the `validate-all` and `dynamic-build` options ca be used with the `ta-folder` and
+available, the `validate-all` and `dynamic-build` options can be used with the `ta-folder` and
 `download-folder` options to download available intermediate CA certificates relevant to the
 validation of the end entity certificate(s) using URIs read from AIA and SIA extensions. The
 `last-modified-map` and `blocklist` can be used to improve performance of AIA and SIA retrieval
@@ -37,7 +37,7 @@ operations during generation or during dynamic certification path building.
  pittv3 -t path/to/ta_folder -e path/to/ee/certificate -d path/to/download/folder -v -y
 ```
 Intermediate CA certificates for the web PKI can be parsed from the a [CSV file made available by
-Mozilla](https://ccadb-public.secure.force.com/mozilla/MozillaIntermediateCertsCSVReport) using
+Mozilla](https://ccadb.my.salesforce-sites.com/mozilla/PublicAllIntermediateCertsWithPEMCSV) using
 the `mozilla-csv` option.
  ```
  pittv3 --mozilla-csv path/to/MozillaIntermediateCerts.csv --ca-folder path/to/ca_folder
@@ -70,10 +70,10 @@ Several diagnostic tools are provided. Of these, `list-partial-paths-for-target`
 partial certifications paths and list of associated certificates given a target certificate or
 leaf CA index. The `cbor` and `ta-folder` options are required for most diagnostic tools. As
 with validation operations, the `time-of-interest` option can be used to vary the partial paths
-returned for a target by ignoring involid certificates.
+returned for a target by ignoring invalid certificates.
 
  ```
- pittv3 -cbor example.cbor --list-partial-paths-for-target path/to/ee/certificate.der
+ pittv3 --cbor example.cbor --list-partial-paths-for-target path/to/ee/certificate.der
  ```
 
 **4) Logging**
@@ -85,8 +85,8 @@ level and higher is directed to stdout.
 
 ## Crate Feature Flags
 
-The pittv3 binary features the same five feature gates as the certval library, plus one additional.
-The seven feature gates shared with certval enable varying levels of support and are as follows:
+The pittv3 binary features the seven feature gates of the certval library, plus two of its own.
+The gates shared with certval enable varying levels of support and are as follows:
 
 - `default-features = false` provides path validation support for no-std applications without support for revocation status determination or multi-thread support.
   Trust anchors and CA certificates/partial paths are provided by a pair of CBOR files built into the app.
@@ -94,40 +94,41 @@ The seven feature gates shared with certval enable varying levels of support and
   presently demonstrated by PITTv3, i.e., no revocation information is baked in.
 - `std` augments the `default-features = false` feature by adding support for obtaining artifacts via the file system and addition of support for multi-threaded use.
 - `revocation,std` augments the `std` feature by adding support for processing CRLs and OCSP responses that are provided by the caller or obtained via the file system.
-- `remote` is the default. It replaces and augments the `revocation,std` feature by adding support for retrieving certificates via URIs expressed in SIA and AIA extensions, for retrieving CRLs via URIs
-  expressed in CRL DP extensions, and for interacting with OCSP responders via URIs expressed in AIA extensions.
-- `pqc` adds support for dilithium, falcon and sphincsplus using algorithm implementations from the [pqcrypto](https://github.com/rustpq/pqcrypto) project and object identifiers from the [IETF 115 PQC hackathon](https://github.com/IETF-Hackathon/pqc-certificates).
+- `remote` replaces and augments the `revocation,std` feature by adding support for retrieving certificates via URIs expressed in SIA and AIA extensions, for retrieving CRLs via URIs
+  expressed in CRL DP extensions, and for interacting with OCSP responders via URIs expressed in AIA extensions. It is part of the default feature set, which is `remote`, `webpki`, `pqc`, `rsa` and `eddsa` — broader than certval's own default of `remote` plus `webpki`, since the binary is meant to be handed whatever certificates a user has.
+- `pqc` adds support for ML-DSA (FIPS 204), including the hash-ML-DSA-with-SHA-512 variants, and SLH-DSA (FIPS 205), using the [ml-dsa](https://crates.io/crates/ml-dsa) and [slh-dsa](https://crates.io/crates/slh-dsa) implementations, plus composite ML-DSA signatures.
 - `webpki` adds support for instantiating TaSource instances using trust anchors from the [webpki-roots](https://crates.io/crates/webpki-roots) crate
-- `rsa` enables use of the RSA algorithm. RSA support is not enabled by default.
-- `eddsa` enables use of the Ed25519 algorithm. Ed25519 support is not enabled by default.
+- `rsa` enables use of the RSA algorithm. It is off by default in certval and on by default here.
+- `eddsa` enables use of the Ed25519 algorithm. It is off by default in certval and on by default here.
 
-The one additional feature gate is `std_app`, which builds certval as `default-features = false` but
+The first of the two additional gates is `std_app`, which builds certval as `default-features = false` but
 builds pittv3 with std support so that end entity files can be selected for validation (additional
 work could be done to broaden the capabilities of the app while using certval in no-std but for now
 it's only for selecting end entity files).
 
-## Status
+The second is `sha1_sig`, which registers an additional signature verification callback covering
+`sha1WithRsaEncryption`, an algorithm the RustCrypto libraries certval builds on do not implement.
+It implies `rsa`, and exists so that legacy material can be examined; it does not make SHA-1 a
+sound signature algorithm.
 
-tl;dr: not ready to use.
+## ⚠️ Security Warning
 
-This is a work-in-progress implementation which is at an early stage of
-development.
+PITTv3 is a diagnostic tool built on `certval`, which has never been independently audited. See the
+security warning in `certval/README.md` for the conformance suites the library is tested against —
+x509-limbo and NIST PKITS — and what they do and do not establish.
 
 ## Minimum Supported Rust Version
 
-This crate requires **Rust 1.85** at a minimum.
-
-The MSRV may change in the future, but it will be accompanied by a minor
-version bump.
+This crate requires **Rust 1.85** at a minimum, and tracks `certval`'s MSRV; see that crate's MSRV
+policy. No promise is made about when it moves — nothing resolves against this binary, so an
+increase cannot break a downstream build.
 
 ## License
 
-Licensed under either of:
+All crates licensed under either of the following, at your option:
 
 - [Apache License, Version 2.0](http://www.apache.org/licenses/LICENSE-2.0)
 - [MIT license](http://opensource.org/licenses/MIT)
-
-at your option.
 
 ### Contribution
 
@@ -138,7 +139,7 @@ dual licensed as above, without any additional terms or conditions.
 [//]: # (badges)
 
 [license-image]: https://img.shields.io/badge/license-Apache2.0/MIT-blue.svg
-[rustc-image]: https://img.shields.io/badge/rustc-1.56+-blue.svg
+[rustc-image]: https://img.shields.io/badge/rustc-1.85+-blue.svg
 
 [//]: # (links)
 

--- a/pittv3/tests/examples/wasm_settings_samples/README.md
+++ b/pittv3/tests/examples/wasm_settings_samples/README.md
@@ -3,8 +3,8 @@
 Hand-verified bundles for exercising the wasm app's **Settings** tab. Each scenario is a
 `settings.json` (certval `CertificationPathSettings` JSON — the same format the PITTv3 CLI `-s` and
 desktop app read) plus the end-entity certificate(s) to validate. Revocation is disabled in every
-settings file so results match across the wasm app (which never does revocation) and the CLI/desktop
-run offline.
+settings file so results match across the wasm app and the CLI/desktop run offline, whatever
+retrieval the app is permitted.
 
 Together they exercise: time of interest, require-explicit-policy + initial-policy-set, inhibit
 policy mapping, inhibit anyPolicy, and initial permitted/excluded name-constraint subtrees
@@ -56,9 +56,11 @@ applied.
   `x509-limbo` case `rfc5280::nc::permitted-ipv4-match` (root permits `192.0.2.0/24`, leaf SAN
   `192.0.2.1`): it validates by default, and the excluded-IP setting flips it. The leaf is valid
   1970–2969, so no TOI is needed.
-- The wasm app does **no** revocation checking (no CRL/OCSP, no AIA fetch); these scenarios exercise
-  basic path validation plus the settings knobs. The same `settings.json` files also load into the
-  CLI (`-s`) and desktop app.
+- These scenarios exercise basic path validation plus the settings knobs, and nothing they need is
+  retrieved: each store is uploaded and revocation is disabled in the settings. That is what makes
+  them reproducible in the browser-only tier, where the app fetches nothing at all, and in the
+  relayed tier, where it can. The same `settings.json` files also load into the CLI (`-s`) and
+  desktop app.
 - **Scenario 09 (URI name constraints)** validates `ValidURInameConstraintsTest34EE` (URI SAN
   `http://testserver.testcertificates.gov/…`) against the PKITS store; the excluded URI subtree
   `.testcertificates.gov` covers that host, so it flips to invalid. URI matching is now no_std in

--- a/pkiprocmacros/Cargo.toml
+++ b/pkiprocmacros/Cargo.toml
@@ -1,7 +1,13 @@
 [package]
 name = "pkiprocmacros"
 version = "0.1.2"
+description = "Procedural macros supporting the certval certification path validation library"
+license = "Apache-2.0 OR MIT"
+repository = "https://github.com/carl-wallace/rust-pki"
+categories = ["cryptography", "no-std"]
+keywords = ["x509", "pki", "macros"]
 edition = "2021"
+rust-version = "1.85"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/support/x509-limbo-tests/README.md
+++ b/support/x509-limbo-tests/README.md
@@ -1,10 +1,23 @@
-# `rustls-webpki` test harness for x509-limbo
+# certval harness for x509-limbo
 
-This directory contains a basic test harness for running the x509-limbo
-testsuite against the Rust [`rustls-webpki` crate].
+This directory holds `rust-certval-harness`, which runs the
+[x509-limbo](https://github.com/C2SP/x509-limbo) testsuite against `certval`. The testsuite itself
+is the `support/x509-limbo` submodule beside it; that submodule also carries upstream's harnesses
+for other implementations, and none of those are this one.
 
-[`rustls-webpki` crate]: https://docs.rs/rustls-webpki/latest/rustls-webpki/index.html
+## Running it
 
-## Building
+```sh
+git submodule update --init support/x509-limbo
+make -C support/x509-limbo-tests
+```
 
-Just `cargo build`.
+`cargo build` on its own only produces the binary. The `Makefile` is what hands it to the
+testsuite's own runner, which then writes the outcome of every case to `rust-certval.json`.
+
+## `rust-certval.json` is committed on purpose
+
+CI regenerates the file and runs `git diff --exit-code` on it (`.github/workflows/certval.yml`), so
+a run that leaves it dirty means certval now reaches a different conclusion somewhere in the
+testsuite — not that the build broke. Read the diff, and commit it alongside the change that caused
+it.


### PR DESCRIPTION
- Change some package names so naming is consistent, i.e., - not _
- Update stale README files
- Add license, description, keywords, Rust version, and etc. to pkiprocmacros
- Add notes on running the x509-limbo harness