### PR TITLE
Refactor signature cache usage to be internal to PkiEnvironment

### DIFF
--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -362,10 +362,29 @@ impl PkiEnvironment {
         signature_alg: &AlgorithmIdentifierOwned, // signature algorithm
         spki: &SubjectPublicKeyInfoOwned,         // public key
     ) -> Result<()> {
+        // The key commits to the signature and the algorithm as well as the signed bytes and the
+        // verifying key: an entry must mean "THIS signature verified", not "some signature over
+        // these bytes verified once", or a certificate whose signature is swapped for garbage
+        // would hit an entry left by its legitimate twin.
+        let cache_key = if self.has_signature_cache() {
+            signature_cache_key(message_to_verify, signature, signature_alg, spki)
+        } else {
+            None
+        };
+        if let Some((m, k)) = &cache_key {
+            if self.is_signature_verified(m, k) {
+                return Ok(());
+            }
+        }
         for f in &self.verify_signature_message_callbacks {
             match f.verify_signature_message(pe, message_to_verify, signature, signature_alg, spki)
             {
-                Ok(r) => return Ok(r),
+                Ok(r) => {
+                    if let Some((m, k)) = &cache_key {
+                        self.add_verified_signature(m, k);
+                    }
+                    return Ok(r);
+                }
                 Err(Error::Unrecognized) => continue,
                 Err(e) => return Err(e),
             }
@@ -698,8 +717,10 @@ impl PkiEnvironment {
     }
 
     /// add_signature_cache adds a [`SignatureVerificationCache`] object to the list. Adding one opts
-    /// the environment into memoizing successful certificate signature verifications; with none
-    /// added, signatures are verified on every path validation as usual.
+    /// the environment into caching every signature verification it performs successfully -- graph
+    /// building and path validation, and CRL and OCSP response signatures alike, since the cache sits
+    /// in [`PkiEnvironment::verify_signature_message`] rather than at any one caller. With none
+    /// added, every signature is verified afresh each time it is presented, as usual.
     pub fn add_signature_cache(&mut self, c: Box<dyn SignatureVerificationCache + Send + Sync>) {
         self.signature_cache.push(c);
     }
@@ -710,24 +731,36 @@ impl PkiEnvironment {
     }
 
     /// has_signature_cache returns true if at least one [`SignatureVerificationCache`] is configured.
-    /// Callers use this to avoid computing cache keys when memoization is not in use.
+    ///
+    /// This reports how the environment was set up, not that caching is doing anything: a configured
+    /// cache may have reached its capacity and be dropping new entries, or be an implementation that
+    /// never reports a hit.
+    /// Callers use this to avoid computing cache keys when caching is not in use.
     pub fn has_signature_cache(&self) -> bool {
         !self.signature_cache.is_empty()
     }
 
-    /// is_signature_verified returns true if any configured [`SignatureVerificationCache`] reports the
-    /// signature over `cert_hash` by the key identified by `issuer_spki_hash` as already verified.
-    pub fn is_signature_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
+    /// Returns true if any configured [`SignatureVerificationCache`] reports the signed data
+    /// identified by `signed_data_hash`, verified by the key identified by `issuer_spki_hash`, as
+    /// already verified.
+    ///
+    /// Private on purpose. Only [`PkiEnvironment::verify_signature_message`] creates cache keys, which
+    /// is what lets an entry carry a single unambiguous meaning: were callers able to insert keys of
+    /// their own devising, one that committed to less than this one does -- the signed bytes without
+    /// the signature, say -- would be indistinguishable from a sound entry on the way back out.
+    fn is_signature_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
         self.signature_cache
             .iter()
-            .any(|c| c.is_verified(cert_hash, issuer_spki_hash))
+            .any(|c| c.is_verified(signed_data_hash, issuer_spki_hash))
     }
 
-    /// add_verified_signature records a successful signature verification in each configured
+    /// Records a successful signature verification in each configured
     /// [`SignatureVerificationCache`]. It is a no-op when no cache has been added.
-    pub fn add_verified_signature(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) {
+    ///
+    /// Private for the reason given on [`PkiEnvironment::is_signature_verified`].
+    fn add_verified_signature(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) {
         for c in &self.signature_cache {
-            c.add_verified(cert_hash, issuer_spki_hash);
+            c.add_verified(signed_data_hash, issuer_spki_hash);
         }
     }
 
@@ -887,15 +920,35 @@ impl PkiEnvironment {
 
 /// Computes the hash used to key a [`SignatureVerificationCache`] entry from a certificate DER or an
 /// issuer subject-public-key-info DER. SHA-256 uniquely identifies the input for this purpose.
-pub(crate) fn signature_cache_hash(bytes: &[u8]) -> Vec<u8> {
+fn signature_cache_key(
+    message_to_verify: &[u8],
+    signature: &[u8],
+    signature_alg: &AlgorithmIdentifierOwned,
+    spki: &SubjectPublicKeyInfoOwned,
+) -> Option<(Vec<u8>, Vec<u8>)> {
+    let alg_der = der::Encode::to_der(signature_alg).ok()?;
+    let spki_der = der::Encode::to_der(spki).ok()?;
+    let mut buf = Vec::with_capacity(message_to_verify.len() + signature.len() + alg_der.len());
+    buf.extend_from_slice(message_to_verify);
+    buf.extend_from_slice(signature);
+    buf.extend_from_slice(&alg_der);
+    Some((signature_cache_hash(&buf), signature_cache_hash(&spki_der)))
+}
+
+fn signature_cache_hash(bytes: &[u8]) -> Vec<u8> {
     use sha2::{Digest, Sha256};
     Sha256::digest(bytes).to_vec()
 }
 
 /// A bounded, thread-safe [`SignatureVerificationCache`] backed by an in-memory set. Recording stops
-/// once the cap is reached so a long-lived environment that validates many distinct certificates
-/// cannot grow it without bound; the graph builder records certificate-authority edges first, so the
-/// frequently reused entries are retained.
+/// once the cap is reached so a long-lived environment that validates many distinct signatures cannot
+/// grow it without bound.
+///
+/// Every successful verification the environment performs is recorded, including one-shot checks --
+/// a self-signature test during ingest, an end-entity signature -- that will never be asked for
+/// again. Which entries survive the cap is therefore whichever the run happened to reach first, not
+/// the ones with the most reuse. For an estate large enough to reach the cap, prefer a cache of your
+/// own with an eviction policy that suits it.
 #[cfg(feature = "std")]
 pub struct DefaultSignatureVerificationCache {
     verified: std::sync::RwLock<alloc::collections::BTreeSet<(Vec<u8>, Vec<u8>)>>,
@@ -930,17 +983,17 @@ impl Default for DefaultSignatureVerificationCache {
 
 #[cfg(feature = "std")]
 impl SignatureVerificationCache for DefaultSignatureVerificationCache {
-    fn is_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
+    fn is_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
         match self.verified.read() {
-            Ok(set) => set.contains(&(cert_hash.to_vec(), issuer_spki_hash.to_vec())),
+            Ok(set) => set.contains(&(signed_data_hash.to_vec(), issuer_spki_hash.to_vec())),
             Err(_) => false,
         }
     }
 
-    fn add_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) {
+    fn add_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) {
         if let Ok(mut set) = self.verified.write() {
             if set.len() < self.cap {
-                set.insert((cert_hash.to_vec(), issuer_spki_hash.to_vec()));
+                set.insert((signed_data_hash.to_vec(), issuer_spki_hash.to_vec()));
             }
         }
     }
@@ -950,12 +1003,12 @@ impl SignatureVerificationCache for DefaultSignatureVerificationCache {
 /// inspect it) while also handing it to a [`PkiEnvironment`] via `add_signature_cache`.
 #[cfg(feature = "std")]
 impl<T: SignatureVerificationCache + ?Sized> SignatureVerificationCache for alloc::sync::Arc<T> {
-    fn is_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
-        (**self).is_verified(cert_hash, issuer_spki_hash)
+    fn is_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
+        (**self).is_verified(signed_data_hash, issuer_spki_hash)
     }
 
-    fn add_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) {
-        (**self).add_verified(cert_hash, issuer_spki_hash)
+    fn add_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) {
+        (**self).add_verified(signed_data_hash, issuer_spki_hash)
     }
 }
 

--- a/certval/src/environment/pki_environment_traits.rs
+++ b/certval/src/environment/pki_environment_traits.rs
@@ -480,10 +480,17 @@ pub trait RevocationStatusCache {
 /// signature is verified as usual, so correctness never depends on the cache being present or
 /// populated.
 pub trait SignatureVerificationCache {
-    /// Returns true if a signature over the certificate identified by `cert_hash` by the key
-    /// identified by `issuer_spki_hash` has already been verified successfully.
-    fn is_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]) -> bool;
+    /// Returns true if the signed data identified by `signed_data_hash`, verified by the key
+    /// identified by `issuer_spki_hash`, has already been verified successfully.
+    ///
+    /// Both arguments are opaque digests minted by [`PkiEnvironment`]; an implementation stores and
+    /// compares them and must not attempt to interpret either as a certificate or derive one of its
+    /// own. The signed data is whatever was verified -- a TBSCertificate, a TBSCertList, an OCSP
+    /// tbsResponseData -- and the digest commits to the signature and signature algorithm alongside
+    /// it, so an entry means "this exact signature verified under this exact key".
+    fn is_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) -> bool;
 
-    /// Records a successful signature verification.
-    fn add_verified(&self, cert_hash: &[u8], issuer_spki_hash: &[u8]);
+    /// Records a successful signature verification. See [`SignatureVerificationCache::is_verified`]
+    /// for what the two digests mean.
+    fn add_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]);
 }

--- a/certval/src/source/cert_source.rs
+++ b/certval/src/source/cert_source.rs
@@ -42,7 +42,7 @@ use const_oid::db::rfc5912::{
     ID_CE_AUTHORITY_KEY_IDENTIFIER, ID_CE_BASIC_CONSTRAINTS, ID_CE_NAME_CONSTRAINTS,
     ID_CE_SUBJECT_ALT_NAME, ID_CE_SUBJECT_KEY_IDENTIFIER,
 };
-use der::{Decode, Encode};
+use der::Decode;
 use spki::SubjectPublicKeyInfoOwned;
 use x509_cert::certificate::CertificateInner;
 use x509_cert::ext::pkix::name::GeneralName;
@@ -50,7 +50,6 @@ use x509_cert::name::Name;
 
 use crate::{
     compare_names,
-    environment::pki_environment::signature_cache_hash,
     environment::pki_environment_traits::*,
     general_subtree_to_string, get_leaf_rdn,
     pdv_certificate::*,
@@ -1302,16 +1301,6 @@ impl CertSource {
                                         spki,
                                     );
                                     if let Ok(_r) = r {
-                                        // Cache this trust-anchor-to-CA signature so path
-                                        // validation need not re-verify it (skipped without a cache).
-                                        if pe.has_signature_cache() {
-                                            if let Ok(spki_der) = spki.to_der() {
-                                                pe.add_verified_signature(
-                                                    &signature_cache_hash(cur_cert.as_bytes()),
-                                                    &signature_cache_hash(&spki_der),
-                                                );
-                                            }
-                                        }
                                         let new_path = vec![cur_cert_index];
                                         if new_additions.contains_key(&cur_cert_hex_skid) {
                                             if !new_additions[&cur_cert_hex_skid]
@@ -1375,21 +1364,6 @@ impl CertSource {
                                                 .subject_public_key_info(),
                                         );
                                         if let Ok(_r) = r {
-                                            // Cache this CA-to-CA signature so path validation need
-                                            // not re-verify it (skipped without a cache).
-                                            if pe.has_signature_cache() {
-                                                if let Ok(spki_der) = prospective_ca_cert
-                                                    .as_ref()
-                                                    .tbs_certificate()
-                                                    .subject_public_key_info()
-                                                    .to_der()
-                                                {
-                                                    pe.add_verified_signature(
-                                                        &signature_cache_hash(cur_cert.as_bytes()),
-                                                        &signature_cache_hash(&spki_der),
-                                                    );
-                                                }
-                                            }
                                             if !self.pub_key_in_path(cur_cert, prospective_path) {
                                                 let mut new_path = prospective_path.clone();
                                                 new_path.push(cur_cert_index);
@@ -1824,16 +1798,17 @@ fn get_certificates_test() {
 }
 
 // Building the partial-path graph records the trust-anchor-to-CA signature it verifies into a
-// configured signature cache, so path validation can later skip re-verifying it. The cache is added
-// through a retained Arc handle so the recorded edge can be inspected afterward.
+// configured signature cache, so path validation can later skip re-verifying it.
+//
+// The cache key is the environment's own business -- nothing outside `PkiEnvironment` can mint one --
+// so this asserts the observable consequence instead of the key bytes: with every verification
+// callback removed, no signature can be verified afresh, and the same edge still coming back Ok can
+// only mean it was served from the cache.
 #[cfg(all(feature = "std", feature = "rsa"))]
 #[test]
 fn build_records_verified_signatures() {
-    use crate::environment::pki_environment::{
-        signature_cache_hash, DefaultSignatureVerificationCache,
-    };
+    use crate::environment::pki_environment::DefaultSignatureVerificationCache;
     use crate::PDVTrustAnchorChoice;
-    use alloc::sync::Arc;
 
     let ta_der = include_bytes!("../../tests/examples/TrustAnchorRootCertificate.crt");
     let ca_der =
@@ -1849,10 +1824,7 @@ fn build_records_verified_signatures() {
     let mut pe = PkiEnvironment::new();
     pe.populate_5280_pki_environment();
     pe.add_trust_anchor_source(Box::new(ta_source));
-
-    // Keep a shared handle to the cache so it can be inspected after the build.
-    let cache = Arc::new(DefaultSignatureVerificationCache::new());
-    pe.add_signature_cache(Box::new(cache.clone()));
+    pe.add_signature_cache(Box::new(DefaultSignatureVerificationCache::new()));
 
     let cps = CertificationPathSettings::new();
     let mut cert_source = CertSource::new();
@@ -1863,15 +1835,38 @@ fn build_records_verified_signatures() {
     cert_source.initialize(&cps).unwrap();
     cert_source.find_all_partial_paths(&pe, &cps);
 
-    // The build verified the trust-anchor-to-CA signature, so the cache holds that edge keyed by the
-    // CA certificate hash and the trust anchor's subject-public-key-info hash.
     let ta = PDVTrustAnchorChoice::try_from(ta_der.as_slice()).unwrap();
     let ta_spki = get_subject_public_key_info_from_trust_anchor(&ta.decoded_ta);
-    let cert_hash = signature_cache_hash(ca_der);
-    let spki_hash = signature_cache_hash(&ta_spki.to_der().unwrap());
+    let defer_ca = DeferDecodeSigned::from_der(ca_der.as_slice()).unwrap();
+
+    // Negative control: the same environment minus both the callbacks and the cache cannot verify
+    // anything, which is what makes the assertion below non-vacuous.
+    let mut bare = PkiEnvironment::new();
+    bare.populate_5280_pki_environment();
+    bare.clear_verify_signature_message_callbacks();
     assert!(
-        cache.is_verified(&cert_hash, &spki_hash),
-        "graph build should record the trust-anchor-to-CA signature"
+        bare.verify_signature_message(
+            &bare,
+            &defer_ca.tbs_field,
+            defer_ca.signature.raw_bytes(),
+            &defer_ca.signature_algorithm,
+            ta_spki,
+        )
+        .is_err(),
+        "control: with no callbacks and no cache, nothing can verify"
+    );
+
+    pe.clear_verify_signature_message_callbacks();
+    assert!(
+        pe.verify_signature_message(
+            &pe,
+            &defer_ca.tbs_field,
+            defer_ca.signature.raw_bytes(),
+            &defer_ca.signature_algorithm,
+            ta_spki,
+        )
+        .is_ok(),
+        "graph build should have recorded the trust-anchor-to-CA signature"
     );
 }
 

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -14,7 +14,7 @@ use crate::{
 };
 use const_oid::db::rfc5280::ANY_POLICY;
 use const_oid::db::rfc5912::*;
-use der::{asn1::ObjectIdentifier, Decode, Encode};
+use der::{asn1::ObjectIdentifier, Decode};
 use x509_cert::anchor::TrustAnchorChoice;
 use x509_cert::ext::pkix::constraints::name::GeneralSubtrees;
 use x509_cert::ext::pkix::name::GeneralName;
@@ -1007,42 +1007,23 @@ pub fn verify_signatures(
             cpr.set_failure_index(pos as u32 + 1);
             return Err(Error::PathValidation(PathValidationStatus::EncodingError));
         }
-
-        // Skip the (expensive) signature verification when a configured signature cache reports this
-        // exact certificate-and-issuer-key pair as already verified, e.g. by the path builder. The
-        // cheap structural checks above still run, and with no cache configured this is always false,
-        // so the signature is verified as usual.
-        let verified_from_cache = pe.has_signature_cache()
-            && working_spki
-                .to_der()
-                .ok()
-                .map(|spki_der| {
-                    pe.is_signature_verified(
-                        &signature_cache_hash(cur_cert.as_bytes()),
-                        &signature_cache_hash(&spki_der),
-                    )
-                })
-                .unwrap_or(false);
-
-        if !verified_from_cache {
-            let r = pe.verify_signature_message(
-                pe,
-                &defer_cert.tbs_field,
-                cur_cert.decoded().signature().raw_bytes(),
-                cur_cert.decoded().tbs_certificate().signature(),
-                &working_spki,
+        let r = pe.verify_signature_message(
+            pe,
+            &defer_cert.tbs_field,
+            cur_cert.decoded().signature().raw_bytes(),
+            cur_cert.decoded().tbs_certificate().signature(),
+            &working_spki,
+        );
+        if let Err(e) = r {
+            log_error_for_ca(
+                cur_cert,
+                format!("signature verification error: {e:?}").as_str(),
             );
-            if let Err(e) = r {
-                log_error_for_ca(
-                    cur_cert,
-                    format!("signature verification error: {e:?}").as_str(),
-                );
-                cpr.set_validation_status(PathValidationStatus::SignatureVerificationFailure);
-                cpr.set_failure_index(pos as u32 + 1);
-                return Err(Error::PathValidation(
-                    PathValidationStatus::SignatureVerificationFailure,
-                ));
-            }
+            cpr.set_validation_status(PathValidationStatus::SignatureVerificationFailure);
+            cpr.set_failure_index(pos as u32 + 1);
+            return Err(Error::PathValidation(
+                PathValidationStatus::SignatureVerificationFailure,
+            ));
         }
 
         working_spki = cur_cert

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -774,6 +774,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
     }
 
     let mut pe = PkiEnvironment::default();
+    pe.add_signature_cache(Box::new(DefaultSignatureVerificationCache::default()));
     pe.populate_5280_pki_environment();
 
     #[cfg(feature = "sha1_sig")]
@@ -1113,6 +1114,24 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
 
             // Save the URI count before doing any validation, which will harvest new URIs
             uri_threshold = fresh_uris.len();
+        }
+
+        // Nothing arrived this pass, so there is nothing left for the loop to do. `threshold` is the
+        // size of the pool this pass started with, and a path is only returned to the caller when
+        // `above_threshold` finds an index at or above it, which no path can satisfy once the pool
+        // has stopped growing -- so this pass would find zero paths, rebuild the same graph and
+        // re-serialize it to the same bytes, and the next pass would do it again.
+        //
+        // The loop had no other way out of that. The fetch block above stops running once the URI
+        // set stops changing, and the `break` for a non-dynamic run lives inside it, so a dynamic
+        // run that has run out of URIs to chase skips the test that would have ended it and keeps
+        // going until the pass cap. Whether that shows up depends on whether some other exit fires
+        // first: a run that finds a definitive answer for every target leaves through the
+        // `all_definitive` break below, while `--validate-all`, or any run that never finds a path,
+        // stays in the loop for the full remaining passes.
+        if 0 < pass && cert_source.len() == threshold {
+            debug!("Nothing was added to the certificate pool on pass {pass}; stopping");
+            break;
         }
 
         //TODO refactor to make TaSource.tas and CertSource.certs RefCells with on demand parsing

--- a/support/x509-limbo-tests/Cargo.lock
+++ b/support/x509-limbo-tests/Cargo.lock
@@ -135,7 +135,7 @@ dependencies = [
 
 [[package]]
 name = "certval"
-version = "0.1.4"
+version = "0.2.0-pre"
 dependencies = [
  "base64ct",
  "bitvec",


### PR DESCRIPTION
Also, fix a missing early termination bug in the pittv3 builder