### PR TITLE
Refactor pittv3-lib/pittv3 interaction

### DIFF
--- a/.github/workflows/certval.yml
+++ b/.github/workflows/certval.yml
@@ -126,6 +126,28 @@ jobs:
           targets: thumbv7em-none-eabihf
       - run: cargo build -p certval --no-default-features --target thumbv7em-none-eabihf
 
+  # The six build commands the module documentation gives, run exactly as documented: from the
+  # workspace root, without -p. That is the point of the job -- with -p they resolve features for
+  # pittv3 alone and cannot regress. Without it, cargo resolves across default-members, pittv3-gui
+  # asks pittv3-lib for `remote` (which implies `std`), and pittv3-lib comes up above whatever
+  # pittv3 itself asked for. Anything in the binary that decides by its own features what
+  # pittv3-lib contains desynchronizes there, which is how three of these six stopped compiling.
+  #
+  # Cheap despite naming the frontends: only the pittv3 bin target is built, so the dioxus tree is
+  # resolved into the graph and never compiled. That keeps this leg clear of the 1.88 MSRV and the
+  # Linux system packages the other jobs exclude those crates for, hence stable only.
+  documented-builds:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      - run: cargo build --bin pittv3
+      - run: cargo build --bin pittv3 --no-default-features --features std
+      - run: cargo build --bin pittv3 --no-default-features --features revocation,std
+      - run: cargo build --bin pittv3 --no-default-features --features std_app
+      - run: cargo build --bin pittv3 --no-default-features --features revocation
+      - run: cargo build --bin pittv3 --no-default-features
+
   x509-limbo:
     runs-on: ubuntu-latest
     steps:

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5146,6 +5146,7 @@ dependencies = [
  "sha2 0.11.0",
  "spki",
  "tempfile",
+ "tokio",
  "tokio-test",
  "walkdir",
  "x509-cert",

--- a/pittv3-lib/Cargo.toml
+++ b/pittv3-lib/Cargo.toml
@@ -36,6 +36,10 @@ pem-rfc7468 = { version="1.0.0", features = ["alloc"]}
 certval = { path = "../certval", default-features = false}
 cms = { version = "0.3.0-pre.2", optional = true }
 reqwest = { version = "0.13.4", optional = true }
+# Only so `run_blocking` can drive the async `options_std` for a caller that has no runtime of its
+# own. Already present transitively under `remote` (via reqwest); named here so the `std`-without-
+# `remote` build has it too.
+tokio = { version = "1.52.3", default-features = false, features = ["rt"], optional = true }
 rsa = { version = "0.10.0-rc.18", optional = true, features = ["encoding"] }
 sha1 = {version = "0.11.0", default-features = false, features = ["oid"]}
 sha2 = {version = "0.11.0", default-features = false, features = ["oid"] }
@@ -72,7 +76,7 @@ default = ["remote", "webpki"]
 # does -- including a browser, which reaches repositories through a relay rather than an HTTP client.
 revocation = ["certval/revocation", "dep:cms"]
 std_app = ["certval/revocation"]
-std = ["std_app", "certval/std", "revocation", "walkdir", "csv"]
+std = ["std_app", "certval/std", "revocation", "walkdir", "csv", "dep:tokio"]
 remote = ["certval/remote", "revocation", "std", "dep:reqwest"]
 pqc = ["certval/pqc"]
 webpki = ["certval/webpki"]

--- a/pittv3-lib/src/lib.rs
+++ b/pittv3-lib/src/lib.rs
@@ -25,4 +25,61 @@ pub mod uri_check;
 #[cfg(feature = "sha1_sig")]
 pub mod sha1_sig;
 
+/// Runs this build's entry point, for a caller that has an async runtime.
+///
+/// Choosing the entry point belongs here, not in the binary. The three `options_*` modules gate
+/// themselves on *this crate's* features, and a binary can only test its own; cargo unifies features
+/// across a workspace build, so the two can disagree. A binary built below `std`, linked against a
+/// `pittv3-lib` that a sibling crate pulled up to `std`, would otherwise reach for an entry point
+/// that is no longer compiled.
+#[cfg(feature = "std")]
+pub async fn run(args: &Pittv3Args) -> report::ValidationReport {
+    options_std::options_std(args).await
+}
+
+/// Runs this build's entry point, for a caller that has an async runtime.
+#[cfg(all(feature = "std_app", not(feature = "std")))]
+pub async fn run(args: &Pittv3Args) -> report::ValidationReport {
+    options_std_app::options_std_app(args);
+    report::ValidationReport::default()
+}
+
+/// Runs this build's entry point, for a caller that has an async runtime.
+#[cfg(not(feature = "std_app"))]
+pub async fn run(args: &Pittv3Args) -> report::ValidationReport {
+    options_no_std::options_no_std(args);
+    report::ValidationReport::default()
+}
+
+/// Runs this build's entry point from a synchronous caller.
+///
+/// The counterpart to [`run`] for a binary built without its own async runtime. Only the `std` arm
+/// needs one, and only reachable through feature unification -- see [`run`].
+#[cfg(feature = "std")]
+pub fn run_blocking(args: &Pittv3Args) -> report::ValidationReport {
+    match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => rt.block_on(options_std::options_std(args)),
+        Err(e) => {
+            report::ValidationReport::failed(format!("failed to start an async runtime: {e}"))
+        }
+    }
+}
+
+/// Runs this build's entry point from a synchronous caller.
+#[cfg(all(feature = "std_app", not(feature = "std")))]
+pub fn run_blocking(args: &Pittv3Args) -> report::ValidationReport {
+    options_std_app::options_std_app(args);
+    report::ValidationReport::default()
+}
+
+/// Runs this build's entry point from a synchronous caller.
+#[cfg(not(feature = "std_app"))]
+pub fn run_blocking(args: &Pittv3Args) -> report::ValidationReport {
+    options_no_std::options_no_std(args);
+    report::ValidationReport::default()
+}
+
 pub use crate::args::Pittv3Args;

--- a/pittv3/src/cliargs.rs
+++ b/pittv3/src/cliargs.rs
@@ -260,6 +260,7 @@ pub struct Pittv3CliArgs {
 
 impl From<Pittv3CliArgs> for Pittv3Args {
     fn from(v: Pittv3CliArgs) -> Self {
+        #[allow(clippy::needless_update)]
         Pittv3Args {
             #[cfg(feature = "std")]
             ta_folder: v.ta_folder,
@@ -331,6 +332,10 @@ impl From<Pittv3CliArgs> for Pittv3Args {
             issuer: v.issuer,
             #[cfg(feature = "remote")]
             no_auto_discover: v.no_auto_discover,
+            // pittv3-lib's feature set is a superset of ours -- ours forward to it and cargo only
+            // ever adds -- so it can carry fields this initializer does not name. Let those default
+            // rather than tracking a shape we cannot see.
+            ..Default::default()
         }
     }
 }

--- a/pittv3/src/main.rs
+++ b/pittv3/src/main.rs
@@ -24,16 +24,6 @@ use log4rs::encode::pattern::PatternEncoder;
 extern crate cfg_if;
 
 cfg_if! {
-    if #[cfg(feature = "std")] {
-        use pittv3_lib::options_std::*;
-    } else if #[cfg(feature = "std_app")] {
-        use pittv3_lib::options_std_app::*;
-    } else if #[cfg(not(feature = "std_app"))] {
-        use pittv3_lib::options_no_std::*;
-    }
-}
-
-cfg_if! {
     if #[cfg(feature = "std_app")] {
         /// Point of entry for PITTv3 application.
         #[tokio::main]
@@ -75,18 +65,13 @@ cfg_if! {
             }
             debug!("PITTv3 start");
 
-            // process options available under std, revocation,std and remote features
-            #[cfg(feature = "std")]
-            {
-                let report = options_std(&args).await;
-                if let Some(e) = &report.error {
-                    eprintln!("error: {e}");
-                    std::process::exit(1);
-                }
+            // Which entry point this resolves to is pittv3-lib's decision, not ours: its modules
+            // gate on its own features, which cargo may have unified above the ones we asked for.
+            let report = pittv3_lib::run(&args).await;
+            if let Some(e) = &report.error {
+                eprintln!("error: {e}");
+                std::process::exit(1);
             }
-
-            #[cfg(not(feature = "std"))]
-            options_std_app(&args);
 
             debug!("PITTv3 end");
         }
@@ -98,8 +83,8 @@ cfg_if! {
 
             debug!("PITTv3 start");
 
-            // process options available under no-default features and revocation feature
-            options_no_std(&args);
+            // See the note in the other main: pittv3-lib picks its own entry point.
+            let _report = pittv3_lib::run_blocking(&args);
 
             debug!("PITTv3 end");
         }


### PR DESCRIPTION
- Add `pittv3_lib::run` and `pittv3_lib::run_blocking` to always be present and governed by pittv3-lib's features. Use `ValidationReport::default()` for instances that returned (). This pushes some of what had been done with cfg-if in pittv3 into pittv3-lib.
- Add CI builds to follow the build commands included in documentation