### PR TITLE
Continued work reconciling desktop and WASM UIs

### DIFF
--- a/certval/src/builder/file_utils.rs
+++ b/certval/src/builder/file_utils.rs
@@ -289,6 +289,55 @@ fn cert_or_ta_folder_to_vec(
     Ok(certsvec.len() - initial_count)
 }
 
+/// Returns the file that records URI last-modified values: the [`PS_LAST_MODIFIED_MAP_FILE`] setting
+/// when one names a file, and `last_modified_map.json` in `download_folder` otherwise.
+///
+/// The setting is documented as the way to name this file and the getter has always existed, but the
+/// callers that fetch built the path from the download folder and never consulted it -- so a value
+/// the settings form accepted, stored and redisplayed had no effect on a run. Resolving it in one
+/// place keeps the precedence from being restated per call site.
+#[cfg(feature = "std")]
+pub fn last_modified_map_file(cps: &CertificationPathSettings, download_folder: &str) -> String {
+    fetch_state_file(
+        cps.get_last_modified_map_file(),
+        download_folder,
+        "last_modified_map.json",
+    )
+}
+
+/// Returns the file listing URIs not worth retrying: the [`PS_URI_BLOCKLIST_FILE`] setting when one
+/// names a file, and `blocklist.json` in `download_folder` otherwise. See
+/// [`last_modified_map_file`] for why the resolution lives here.
+#[cfg(feature = "std")]
+pub fn uri_blocklist_file(cps: &CertificationPathSettings, download_folder: &str) -> String {
+    fetch_state_file(
+        cps.get_uri_blocklist_file(),
+        download_folder,
+        "blocklist.json",
+    )
+}
+
+/// An empty configured value is treated as absent rather than as a request to use "": the settings
+/// form writes an empty string when a field is cleared, and honoring that literally would send the
+/// reader at a path that cannot exist.
+#[cfg(feature = "std")]
+fn fetch_state_file(
+    configured: Option<String>,
+    download_folder: &str,
+    default_name: &str,
+) -> String {
+    if let Some(configured) = configured {
+        if !configured.is_empty() {
+            return configured;
+        }
+    }
+    Path::new(download_folder)
+        .join(default_name)
+        .to_str()
+        .unwrap_or_default()
+        .to_string()
+}
+
 /// `read_last_modified_map` accepts a string containing the name of a file that notionally contains JSON data that
 /// represents last modified information and returns a map of URIs to last modified times.
 ///

--- a/certval/src/builder/graph_builder.rs
+++ b/certval/src/builder/graph_builder.rs
@@ -104,20 +104,8 @@ pub async fn build_graph(pe: &PkiEnvironment, cps: &CertificationPathSettings) -
         let mut uris_count = 0;
         let max_certs = cps.get_max_aia_sia_certs();
 
-        let p = Path::new(&download_folder);
-        let blp = p.join("last_modified_map.json");
-        let lmm_file = if let Some(bl) = blp.to_str() {
-            bl.to_string()
-        } else {
-            "".to_string()
-        };
-
-        let blp = p.join("blocklist.json");
-        let blocklist_file = if let Some(bl) = blp.to_str() {
-            bl.to_string()
-        } else {
-            "".to_string()
-        };
+        let lmm_file = last_modified_map_file(cps, &download_folder);
+        let blocklist_file = uri_blocklist_file(cps, &download_folder);
 
         loop {
             {

--- a/pittv3-gui-lib/assets/pittv3.css
+++ b/pittv3-gui-lib/assets/pittv3.css
@@ -258,6 +258,12 @@ button[type="submit"] {
   background: #6b7280;
 }
 
+/* Not a verdict about a certificate but a statement about the file, so it is kept off the
+   valid/invalid palette and set apart from the grey that means no path was found */
+.badge-unreadable {
+  background: #334155;
+}
+
 .results-summary {
   display: flex;
   flex-wrap: wrap;

--- a/pittv3-gui-lib/src/gui_results.rs
+++ b/pittv3-gui-lib/src/gui_results.rs
@@ -50,6 +50,7 @@ fn status_parts(status: TargetStatus) -> (&'static str, &'static str) {
         TargetStatus::Revoked => ("badge badge-revoked", "Revoked"),
         TargetStatus::Invalid => ("badge badge-invalid", "Invalid"),
         TargetStatus::NoPathsFound => ("badge badge-nopaths", "No paths found"),
+        TargetStatus::ParseError => ("badge badge-unreadable", "Not a certificate"),
     }
 }
 
@@ -307,7 +308,12 @@ pub fn TargetCard(target: TargetReport, #[props(default)] open: bool) -> Element
                 }
                 span { class: "hint", " ({path_count} path(s))" }
             }
-            if target.paths.is_empty() {
+            // An input that never became a certificate has no path to report and nothing to say
+            // about the store, so why it could not be read stands in place of both.
+            if let Some(reason) = target.error.clone() {
+                p { class: "hint", "{reason}" }
+            }
+            if target.error.is_none() && target.paths.is_empty() {
                 p { class: "hint",
                     "No certification paths were processed for this target."
                 }
@@ -341,6 +347,7 @@ fn target_status_counts(targets: &[TargetReport]) -> Vec<(&'static str, &'static
         TargetStatus::Revoked,
         TargetStatus::Invalid,
         TargetStatus::NoPathsFound,
+        TargetStatus::ParseError,
     ];
     statuses
         .iter()

--- a/pittv3-gui-lib/src/gui_rows.rs
+++ b/pittv3-gui-lib/src/gui_rows.rs
@@ -276,9 +276,12 @@ pub fn CheckboxRow(
 /// frontend's picker returned; a native multi-select adds several at once, and a frontend with no
 /// picker at all can leave the button off by passing `None`.
 ///
-/// What each entry yields is deliberately *not* shown. A folder is read when the run reads it, so a
-/// count here would be a claim about a moment that has passed; the run reports what each input
-/// actually contributed, which is the honest place for it.
+/// What the pool *contributes* is what the count reports, where a frontend can work it out: a
+/// `.p7c` of cross-certificates is six certificates and not one file, and a folder is however many
+/// certificates are in it, so the number of entries is rarely the number a run will have. A
+/// frontend passes that as `contents`; the entry count stands in until it does, and where no
+/// frontend can say. The figure describes the material as it was last read, which for a folder is a
+/// moment that has passed -- what each input actually contributed is reported by the run.
 #[component]
 pub fn PathListRow(
     label: String,
@@ -291,14 +294,23 @@ pub fn PathListRow(
     /// Shown under the rows when the pool is empty, to say what belongs here.
     #[props(default)]
     hint: String,
+    /// What the entries contribute, worded by the frontend because the noun differs by pool
+    /// ("6 trust anchors", "3 CRLs, 1 OCSP response"). Shown in place of the entry count; empty
+    /// where the frontend has nothing to say yet.
+    #[props(default)]
+    contents: String,
 ) -> Element {
     let title = tooltip(title, &name);
     let entries = sig();
     // What the pool holds, as a count. The paths themselves are the tooltip, so the whole of a
     // pool is available on hover without any of it taking room on the page.
-    let loaded = match entries.len() {
+    let entry_count = match entries.len() {
         1 => "1 entry".to_string(),
         n => format!("{n} entries"),
+    };
+    let loaded = match contents.is_empty() {
+        true => entry_count,
+        false => contents.clone(),
     };
     let listing = entries.join("\n");
     rsx! {

--- a/pittv3-gui-lib/src/validate.rs
+++ b/pittv3-gui-lib/src/validate.rs
@@ -11,7 +11,7 @@ use std::io::{Cursor, Read};
 use std::sync::Arc;
 
 use certval::*;
-use pittv3_lib::report::{CertSummary, NoPathsContext, PathReport, TargetReport};
+use pittv3_lib::report::{CertSummary, NoPathsContext, PathReport, TargetReport, TargetStatus};
 use web_time::Instant;
 
 use crate::retrieval::{MemoryCrlSource, OcspResponses};
@@ -353,6 +353,35 @@ fn no_paths_report(
         status: TargetReport::compute_status(&[], false),
         paths: vec![],
         no_paths_hints: NoPathsContext::collect(pe, target, toi, None).hints(),
+        error: None,
+    }
+}
+
+/// Reports a target for which no certification path exists because of the target itself rather than
+/// the material available to build with: the file was not a certificate, or the certificate was
+/// refused before any path was built.
+///
+/// No path was built, so none is reported and none is counted. The reason rides on the target,
+/// which is the only thing there is. Reporting it as a one-certificate path instead put an entry in
+/// the path list that was never a path, and the totals -- which count that list -- counted it, so a
+/// run over a folder of expired certificates reported paths it had never found.
+///
+/// A file that could not be read at all is reported rather than dropped: dropping it made a run
+/// report fewer targets than the folder holds, leaving a user comparing the two counts nothing to
+/// reconcile them with.
+fn no_path_reason_report(
+    ee_name: &str,
+    target: Option<CertSummary>,
+    status: TargetStatus,
+    reason: String,
+) -> TargetReport {
+    TargetReport {
+        name: ee_name.to_string(),
+        target,
+        status,
+        paths: vec![],
+        no_paths_hints: vec![],
+        error: Some(reason),
     }
 }
 
@@ -415,15 +444,33 @@ fn validate_target(
     let der = match maybe_pem(ee) {
         Ok(der) => der,
         Err(_) => {
-            out.push(err(format!("Failed to parse {ee_name} as PEM or DER")));
-            return (None, out);
+            let reason = format!("Failed to parse {ee_name} as PEM or DER");
+            out.push(err(reason.clone()));
+            return (
+                Some(no_path_reason_report(
+                    ee_name,
+                    None,
+                    TargetStatus::ParseError,
+                    reason,
+                )),
+                out,
+            );
         }
     };
     let target = match parse_cert(&der, ee_name) {
         Ok(t) => t,
         Err(e) => {
-            out.push(err(format!("Failed to parse certificate {ee_name}: {e:?}")));
-            return (None, out);
+            let reason = format!("Failed to parse certificate {ee_name}: {e:?}");
+            out.push(err(reason.clone()));
+            return (
+                Some(no_path_reason_report(
+                    ee_name,
+                    None,
+                    TargetStatus::ParseError,
+                    reason,
+                )),
+                out,
+            );
         }
     };
     let target_summary = CertSummary::from_cert(&target);
@@ -463,25 +510,13 @@ fn validate_target(
             out.push(err(format!(
                 "{ee_name}: certificate rejected during path building — {reason}"
             )));
-            let path = PathReport {
-                status: Some(*pvs),
-                error: Some(format!("{e:?}")),
-                // The target alone. Whether that lone certificate is an anchor is the environment's
-                // to answer -- a target that is itself a trust anchor looks exactly the same here --
-                // so ask rather than infer from the shape or the outcome.
-                certs: vec![target_summary.clone()],
-                no_anchor: pe.is_cert_a_trust_anchor(&target).is_err(),
-                failure_reasons: vec![reason],
-                ..Default::default()
-            };
             return (
-                Some(TargetReport {
-                    name: ee_name.to_string(),
-                    target: Some(target_summary),
-                    status: TargetReport::compute_status(std::slice::from_ref(&path), true),
-                    paths: vec![path],
-                    no_paths_hints: vec![],
-                }),
+                Some(no_path_reason_report(
+                    ee_name,
+                    Some(target_summary),
+                    TargetStatus::Invalid,
+                    reason,
+                )),
                 out,
             );
         }
@@ -582,6 +617,16 @@ fn validate_target(
                     i + 1,
                     cert_count
                 )));
+                // A revoked end entity is the same certificate on every candidate path, so the
+                // first path to report it has settled the target and the rest cost a signature
+                // check and a revocation lookup to reach the same answer. Stop for the same reason
+                // and under the same condition as a successful path does above: the run has what it
+                // came for, unless validate_all asked to see every path regardless.
+                let revoked =
+                    e == Error::PathValidation(PathValidationStatus::CertificateRevokedEndEntity);
+                if revoked && !validate_all {
+                    break;
+                }
             }
         }
     }
@@ -606,6 +651,7 @@ fn validate_target(
             status,
             paths: path_reports,
             no_paths_hints: vec![],
+            error: None,
         }),
         out,
     )

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -2,6 +2,10 @@
 
 use dioxus::prelude::*;
 
+use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::Arc;
+use std::time::Duration;
+
 use futures_util::StreamExt;
 use home::home_dir;
 use log::{debug, error, LevelFilter};
@@ -33,6 +37,9 @@ use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
 use pittv3_lib::graph_cache;
 use pittv3_lib::options_std::options_std;
 use pittv3_lib::report::ValidationReport;
+use pittv3_lib::std_utils::{
+    count_ca_inputs, count_end_entity_inputs, count_revocation_inputs, count_trust_anchor_inputs,
+};
 use pittv3_lib::uri_check::{check_uris_from_bytes, UriCheckReport};
 
 use crate::peek;
@@ -323,6 +330,96 @@ fn dedup_pool(v: Vec<String>) -> Vec<String> {
     out
 }
 
+/// What the four input pools on the Validate view contribute, as against how many entries they
+/// hold. A `.p7c` of cross-certificates is six certificates and a folder is however many are in it,
+/// so an entry count answers a question nobody asked: the number worth showing is the number the
+/// run will have. The browser frontend reports its uploads the same way.
+///
+/// Worked out by the loaders the run itself uses, which means reading every file named. That is
+/// what keeps it off the UI thread: see [`spawn_pool_count`].
+#[derive(Clone, Debug, Default, PartialEq, Eq)]
+struct PoolCounts {
+    trust_anchors: usize,
+    ca_certificates: usize,
+    crls: usize,
+    ocsp_responses: usize,
+    end_entities: usize,
+}
+
+/// `n` followed by the noun, plural unless there is one of them.
+fn plural(n: usize, noun: &str) -> String {
+    match n {
+        1 => format!("1 {noun}"),
+        n => format!("{n} {noun}s"),
+    }
+}
+
+/// The revocation pool's count, which is two counts: a CRL and an OCSP response are not the same
+/// thing to a run, and the pool takes both because a file says for itself which it is.
+///
+/// A kind that contributed nothing is left out rather than shown as a zero — a pool of CRLs is the
+/// ordinary case and "0 OCSP responses" beside it is noise. Both being empty is worth saying, since
+/// the entries are there on the row and something has to account for them.
+fn revocation_contents(counts: &PoolCounts) -> String {
+    let mut parts = vec![];
+    if counts.crls > 0 {
+        parts.push(plural(counts.crls, "CRL"));
+    }
+    if counts.ocsp_responses > 0 {
+        parts.push(plural(counts.ocsp_responses, "OCSP response"));
+    }
+    match parts.is_empty() {
+        true => "0 revocation artifacts".to_string(),
+        false => parts.join(", "),
+    }
+}
+
+/// The paths a count is about, as the worker thread needs them: owned, since it outlives the render
+/// that read the signals, and carrying the time the material is judged at, which decides the answer
+/// as surely as the paths do.
+struct PoolInputs {
+    ta: Vec<String>,
+    ca: Vec<String>,
+    rev: Vec<String>,
+    ee: Vec<String>,
+    time_of_interest: u64,
+}
+
+/// Counts what the four pools contribute, on a worker thread, and sends the result back tagged with
+/// `generation`.
+///
+/// On a thread rather than in a memo because counting is the loading: a pool naming a folder of a
+/// few thousand certificates, or a CBOR store of them, would otherwise stall the WebView on the
+/// keystroke that named it — the same reason a run does not happen on the UI executor either.
+///
+/// The pause at the top is a debounce with the wait already paid for. Every edit to a pool, and
+/// every keystroke in the time of interest field, asks for a fresh count; a thread that wakes to
+/// find `latest` moved past its own generation has been superseded before it read anything, and
+/// stops without touching the disk.
+fn spawn_pool_count(
+    inputs: PoolInputs,
+    generation: usize,
+    latest: Arc<AtomicUsize>,
+    tx: futures_channel::mpsc::UnboundedSender<(usize, PoolCounts)>,
+) {
+    std::thread::spawn(move || {
+        std::thread::sleep(Duration::from_millis(250));
+        if generation != latest.load(Ordering::SeqCst) {
+            return;
+        }
+        let toi = inputs.time_of_interest;
+        let (crls, ocsp_responses) = count_revocation_inputs(inputs.rev.iter().map(String::as_str));
+        let counts = PoolCounts {
+            trust_anchors: count_trust_anchor_inputs(inputs.ta.iter().map(String::as_str), toi),
+            ca_certificates: count_ca_inputs(inputs.ca.iter().map(String::as_str), toi),
+            crls,
+            ocsp_responses,
+            end_entities: count_end_entity_inputs(inputs.ee.iter().map(String::as_str)),
+        };
+        let _ = tx.unbounded_send((generation, counts));
+    });
+}
+
 /// Returns the value of `sig` as a usize, or None if the value is empty or cannot be parsed
 fn usize_or_none(sig: Signal<String>) -> Option<usize> {
     match string_or_none(sig) {
@@ -416,6 +513,10 @@ fn PoolRow(
     extensions: &'static [&'static str],
     #[props(default)] title: String,
     #[props(default)] hint: String,
+    /// What the entries contribute, from [`PoolCounts`]. Empty until the first count comes back,
+    /// which is when the row falls back to reporting entries.
+    #[props(default)]
+    contents: String,
 ) -> Element {
     #[cfg(target_os = "macos")]
     {
@@ -427,6 +528,7 @@ fn PoolRow(
                 sig,
                 title,
                 hint,
+                contents,
                 on_add: move |_| {
                     spawn(pick_files_or_folders_into(sig));
                 },
@@ -442,6 +544,7 @@ fn PoolRow(
             sig,
             title,
             hint,
+            contents,
             on_add: move |_| {
                 spawn(pick_files_into(sig, filter_name, extensions));
             },
@@ -826,6 +929,51 @@ pub(crate) fn App() -> Element {
     let mut s_graph_export = use_signal(String::new);
     let s_ta_cbor = use_signal(|| saved_or_empty(&sa.ta_cbor));
     let s_time_of_interest = use_signal(|| get_now_as_unix_epoch().to_string());
+
+    // What those pools hold, kept current beside them. Recounted whenever a pool changes and
+    // whenever the time of interest does, because loading drops material not valid at that time and
+    // so the count is an answer as of a moment.
+    //
+    // Two generations of the same counter: `counts_seq` is bumped by the effect that asks for a
+    // count and read by both the worker (before it starts, as a debounce) and the task that applies
+    // the result (before it writes, so a slow count over a folder cannot overwrite a fast one over
+    // the empty pool that replaced it).
+    let mut s_pool_counts = use_signal(PoolCounts::default);
+    let counts_seq = use_hook(|| Arc::new(AtomicUsize::new(0)));
+    let counts_tx = use_hook(|| {
+        let (tx, mut rx) = futures_channel::mpsc::unbounded::<(usize, PoolCounts)>();
+        let seq = counts_seq.clone();
+        // Signals are written here, on the UI executor, and never from the worker thread.
+        spawn(async move {
+            while let Some((generation, counts)) = rx.next().await {
+                if generation == seq.load(Ordering::SeqCst) {
+                    s_pool_counts.set(counts);
+                }
+            }
+        });
+        tx
+    });
+    use_effect({
+        let counts_seq = counts_seq.clone();
+        let counts_tx = counts_tx.clone();
+        move || {
+            let generation = counts_seq.fetch_add(1, Ordering::SeqCst) + 1;
+            spawn_pool_count(
+                PoolInputs {
+                    ta: pool(s_ta_inputs),
+                    ca: pool(s_ca_inputs),
+                    rev: pool(s_rev_inputs),
+                    ee: pool(s_ee_inputs),
+                    time_of_interest: s_time_of_interest()
+                        .parse::<u64>()
+                        .unwrap_or_else(|_| get_now_as_unix_epoch()),
+                },
+                generation,
+                counts_seq.clone(),
+                counts_tx.clone(),
+            );
+        }
+    });
     let s_logging_config = use_signal(|| sa.logging_config.clone().unwrap_or_default());
     let s_error_folder = use_signal(|| sa.error_folder.clone().unwrap_or_default());
     let s_download_folder = use_signal(|| sa.download_folder.clone().unwrap_or_default());
@@ -1130,10 +1278,11 @@ pub(crate) fn App() -> Element {
             {
                 match s_view() {
                     View::Validate => {
-                        // Named for what the run will do, and counting what it will judge -- the
-                        // same filter the arguments apply, so the number on the button is the
-                        // number of targets, not the number of rows in the pool.
-                        let targets = pool(s_ee_inputs).len();
+                        // Named for what the run will do, and counting what it will judge: a
+                        // folder in the pool is one entry and as many targets as it holds, so the
+                        // number on the button comes from the same count as the row above rather
+                        // than from the length of the pool.
+                        let targets = s_pool_counts().end_entities;
                         let validate_label = match targets {
                             0 => "Validate using the current store and settings".to_string(),
                             1 => "Validate 1 certificate using the current store and settings"
@@ -1181,6 +1330,10 @@ pub(crate) fn App() -> Element {
                                         sig: s_ta_inputs,
                                         filter_name: "Trust anchor, bundle or CBOR store",
                                         extensions: TA_POOL_EXTENSIONS,
+                                        contents: plural(
+                                            s_pool_counts().trust_anchors,
+                                            "trust anchor",
+                                        ),
                                     }
                                     // Shown whatever dynamic build is set to. This pool is `--ca`,
                                     // which `load_ca_inputs` folds into the graph on the first pass
@@ -1194,6 +1347,10 @@ pub(crate) fn App() -> Element {
                                         sig: s_ca_inputs,
                                         filter_name: "CA certificate, bundle or CBOR store",
                                         extensions: TA_POOL_EXTENSIONS,
+                                        contents: plural(
+                                            s_pool_counts().ca_certificates,
+                                            "certificate",
+                                        ),
                                     }
                                 }
                             }
@@ -1211,6 +1368,7 @@ pub(crate) fn App() -> Element {
                                         sig: s_rev_inputs,
                                         filter_name: "CRL or OCSP response",
                                         extensions: REV_POOL_EXTENSIONS,
+                                        contents: revocation_contents(&s_pool_counts()),
                                     }
                                     FolderRow { label: "CRL Folder (index)", name: "crl-folder", sig: s_crl_folder }
                                 }
@@ -1224,6 +1382,10 @@ pub(crate) fn App() -> Element {
                                             sig: s_ee_inputs,
                                             filter_name: "Certificate File",
                                             extensions: SINGLE_CERT_EXTENSIONS,
+                                            contents: plural(
+                                                s_pool_counts().end_entities,
+                                                "certificate",
+                                            ),
                                         }
                                     },
                                     peek_host: s_peek_host,

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -421,12 +421,10 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
 
             #[cfg(feature = "remote")]
             {
-                let p = Path::new(&download_folder);
-                let blp = p.join("last_modified_map.json");
-                let lmm_file = blp.to_str().unwrap_or_default();
-
-                let blp = p.join("blocklist.json");
-                let blocklist_file = blp.to_str().unwrap_or_default();
+                let lmm_file = last_modified_map_file(&cps, &download_folder);
+                let lmm_file = lmm_file.as_str();
+                let blocklist_file = uri_blocklist_file(&cps, &download_folder);
+                let blocklist_file = blocklist_file.as_str();
 
                 if let Some(download_folder) = &args.download_folder {
                     //let mut buffers: Vec<CertFile> = vec![];
@@ -1002,12 +1000,10 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         if uri_threshold != fresh_uris.len() {
             #[cfg(feature = "remote")]
             if args.dynamic_build {
-                let p = Path::new(&download_folder);
-                let blp = p.join("last_modified_map.json");
-                let lmm_file = blp.to_str().unwrap_or_default();
-
-                let blp = p.join("blocklist.json");
-                let blocklist_file = blp.to_str().unwrap_or_default();
+                let lmm_file = last_modified_map_file(&cps, &download_folder);
+                let lmm_file = lmm_file.as_str();
+                let blocklist_file = uri_blocklist_file(&cps, &download_folder);
+                let blocklist_file = blocklist_file.as_str();
 
                 // read the last modified map and blocklist once
                 let mut lmm = read_last_modified_map(lmm_file);

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -1301,6 +1301,9 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         info!("\t * Invalid paths found: {}", s.invalid_paths_per_target);
 
         // Say why the count is zero where the count is reported, not only in the structured report
+        if let Some((_status, reason)) = &s.no_path_reason {
+            info!("\t * No certification path was found because of the target itself: {reason}");
+        }
         if 0 == s.paths_per_target {
             for hint in &s.no_paths_hints {
                 info!("\t * {hint}");
@@ -1354,7 +1357,15 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
     for (name, s) in stats.iter_mut() {
         let paths_found = s.paths_per_target > 0;
         let path_reports = core::mem::take(&mut s.path_reports);
-        let status = TargetReport::compute_status(&path_reports, paths_found);
+        // A target that never yielded a path is reported as why rather than rolled up from path
+        // results it has none of
+        let (status, error) = match s.no_path_reason.take() {
+            Some((status, reason)) => (status, Some(reason)),
+            None => (
+                TargetReport::compute_status(&path_reports, paths_found),
+                None,
+            ),
+        };
         let target_summary = s
             .target_summary
             .clone()
@@ -1379,6 +1390,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
             status,
             paths: path_reports,
             no_paths_hints,
+            error,
         });
     }
     report

--- a/pittv3-lib/src/report.rs
+++ b/pittv3-lib/src/report.rs
@@ -304,6 +304,12 @@ pub enum TargetStatus {
     Invalid,
     /// No certification paths could be found for the target
     NoPathsFound,
+    /// The input was admitted as a certificate and could not be read as one, so no target existed
+    /// to build a path for. Distinct from [`NoPathsFound`](TargetStatus::NoPathsFound), which says
+    /// the store held no issuer for a certificate that was read: nothing about the store or the
+    /// settings bears on this outcome, and reporting it as an absence of paths sent users looking
+    /// at trust material over a file that was never a certificate.
+    ParseError,
 }
 
 /// Results from validating all certification paths processed for one target certificate.
@@ -323,6 +329,12 @@ pub struct TargetReport {
     /// See [`NoPathsContext`].
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     pub no_paths_hints: Vec<String>,
+    /// Why the input yielded no target, when the status is
+    /// [`ParseError`](TargetStatus::ParseError). Absent otherwise. The status says a certificate
+    /// could not be read; this says what went wrong reading it, which is the whole of what a run
+    /// can offer about a file it could not decode.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub error: Option<String>,
 }
 
 /// What the path builder had to work with, used to explain a zero-path outcome.
@@ -940,6 +952,7 @@ mod tests {
                     duration_ms: 12,
                 }],
                 no_paths_hints: vec![],
+                error: None,
             }],
             totals: ReportTotals {
                 targets: 1,
@@ -1255,6 +1268,7 @@ mod tests {
             status: TargetStatus::Valid,
             paths,
             no_paths_hints: vec![],
+            error: None,
         };
 
         let one = target(vec![path(8), path(19)]);

--- a/pittv3-lib/src/stats.rs
+++ b/pittv3-lib/src/stats.rs
@@ -3,7 +3,7 @@
 use alloc::collections::{BTreeMap, BTreeSet};
 use certval::CertificationPathResults;
 
-use crate::report::{CertSummary, PathReport};
+use crate::report::{CertSummary, PathReport, TargetStatus};
 
 /// `PathValidationStats` enables collection of some basic statistics related to path validation.
 pub struct PathValidationStats {
@@ -31,6 +31,16 @@ pub struct PathValidationStats {
     /// before the report is assembled. Cleared as soon as a path is found, so a diagnosis from an
     /// early pass of the dynamic-building loop does not survive a later pass that succeeds.
     pub no_paths_hints: Vec<String>,
+    /// Why no certification path was found for this target, when the reason is the target itself
+    /// rather than the material available to build with: the file was not a certificate, or the
+    /// certificate was refused before any path was built. Carries the status to report it as and
+    /// the reason to show.
+    ///
+    /// Recorded where the read, the parse or the build refuses, all of which happen before any path
+    /// exists, so an entry carrying this has no paths and contributes none to the totals. The
+    /// reason belongs on the target for the same reason: nothing was found, so there is nothing for
+    /// it to hang off.
+    pub no_path_reason: Option<(TargetStatus, String)>,
     /// Fingerprints of the certification paths already reported for this target, one per path, over
     /// the trust anchor followed by the intermediates in order followed by the target.
     ///
@@ -67,6 +77,7 @@ impl PathValidationStats {
             path_reports: vec![],
             target_summary: None,
             no_paths_hints: vec![],
+            no_path_reason: None,
             reported_chains: BTreeSet::new(),
         }
     }

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -21,7 +21,7 @@ use crate::{
     args::Pittv3Args,
     report::{
         CertSummary, NoPathsContext, PathReport, ProgressEvent, ReportTotals, TargetReport,
-        ValidationReport,
+        TargetStatus, ValidationReport,
     },
     stats::{PVStats, PathValidationStats, PathValidationStatsGroup},
 };
@@ -303,6 +303,128 @@ pub fn load_trust_anchors(
     Ok(Some(ta_store))
 }
 
+/// How many trust anchors the entries in a trust anchor input pool would contribute.
+///
+/// Answers the question the pool's own length cannot: an entry may be a folder, a bundle carrying
+/// several anchors, or a CBOR store, so the number of entries and the number of anchors a run will
+/// have are different numbers, and it is the second one a caller looks at the pool to learn.
+///
+/// The inputs are loaded exactly as [`load_trust_anchors`] loads them and the size of the result is
+/// read off, so this is the number the run will use rather than an estimate of it -- including the
+/// deduplication `push` performs, which a per-entry sum would miss.
+///
+/// An input that cannot be read contributes nothing rather than failing. This describes a set of
+/// inputs while it is still being assembled; the run is where a trust anchor that will not load is
+/// an error, and it says so there.
+///
+/// `time_of_interest` is epoch seconds rather than a [`TimeOfInterest`] so that a frontend reaching
+/// certval only through this crate can ask -- the desktop GUI is one. It matters to the answer:
+/// loading drops an anchor not valid at that time, so a count is a count *as of* a moment. A value
+/// that is not a time leaves validity unchecked, which counts the material rather than nothing.
+#[cfg(feature = "std")]
+pub fn count_trust_anchor_inputs<'a>(
+    paths: impl IntoIterator<Item = &'a str>,
+    time_of_interest: u64,
+) -> usize {
+    let toi = counting_time_of_interest(time_of_interest);
+    let pe = PkiEnvironment::default();
+    let mut ta_store = TaSource::new();
+    for path in paths {
+        if let Err(e) = push_trust_anchor_input(&pe, path, &mut ta_store, toi) {
+            debug!("Counting no trust anchors from {path}: {e}");
+        }
+    }
+    ta_store.len()
+}
+
+/// The time the counting functions judge validity against, from the epoch seconds a frontend holds.
+///
+/// A value certval will not take as a time disables the check rather than substituting one: the
+/// alternative is counting against *some other* moment, and a count that quietly answers a
+/// different question than it was asked is worse than one that checks nothing.
+#[cfg(feature = "std")]
+fn counting_time_of_interest(time_of_interest: u64) -> TimeOfInterest {
+    match TimeOfInterest::from_unix_secs(time_of_interest) {
+        Ok(toi) => toi,
+        Err(_e) => TimeOfInterest::disabled(),
+    }
+}
+
+/// How many certificates the entries in a CA input pool would contribute, the CA-side counterpart
+/// of [`count_trust_anchor_inputs`] and built the same way, by running [`load_ca_inputs`] over a
+/// store of its own.
+///
+/// A CBOR store named on its own is adopted whole, so what comes back for one is the store's own
+/// size; combined with anything else only its certificates count, which is again what the run does
+/// with the same inputs.
+#[cfg(feature = "std")]
+pub fn count_ca_inputs<'a>(
+    paths: impl IntoIterator<Item = &'a str>,
+    time_of_interest: u64,
+) -> usize {
+    let pe = PkiEnvironment::default();
+    let mut cert_source = CertSource::new();
+    load_ca_inputs(
+        &pe,
+        paths,
+        &mut cert_source,
+        counting_time_of_interest(time_of_interest),
+    )
+    .certs
+}
+
+/// How many targets the entries in an end entity input pool would yield.
+///
+/// A folder entry is traversed for the certificates in it, exactly as `validate_cert_folder` does
+/// and by the same extension filter, so a folder counts as the targets it holds rather than as one.
+/// A file entry counts as one target whatever it holds: unlike the trust anchor and CA inputs, an
+/// end entity file is decoded as a single certificate and a bundle named here is not fanned out.
+///
+/// Repeats collapse, because the run keys its per-target statistics by file name and a file named
+/// twice is validated once.
+#[cfg(feature = "std")]
+pub fn count_end_entity_inputs<'a>(paths: impl IntoIterator<Item = &'a str>) -> usize {
+    let mut targets: Vec<String> = vec![];
+    let mut count = |name: String| {
+        if !targets.contains(&name) {
+            targets.push(name);
+        }
+    };
+
+    for path in paths {
+        if !Path::new(path).is_dir() {
+            count(path.to_string());
+            continue;
+        }
+        for entry in WalkDir::new(path).into_iter().filter_map(|e| e.ok()) {
+            if entry.file_type().is_dir() {
+                continue;
+            }
+            let ext = entry.path().extension().and_then(OsStr::to_str);
+            let is_certificate = ext.is_some_and(|ext| SINGLE_CERT_EXTENSIONS.contains(&ext));
+            let Some(name) = entry.path().to_str() else {
+                continue;
+            };
+            if is_certificate {
+                count(name.to_string());
+            }
+        }
+    }
+    targets.len()
+}
+
+/// How many CRLs and how many OCSP responses, in that order, the entries in a revocation input pool
+/// would supply.
+///
+/// Reads the artifacts and discards them, since which kind a file holds is decided from its bytes
+/// (see [`load_revocation_inputs`]) and there is no cheaper way to ask. A folder entry is traversed,
+/// so it counts as what is in it.
+#[cfg(all(feature = "std", feature = "revocation"))]
+pub fn count_revocation_inputs<'a>(paths: impl IntoIterator<Item = &'a str>) -> (usize, usize) {
+    let inputs = load_revocation_inputs(paths);
+    (inputs.crls.len(), inputs.ocsp_responses.len())
+}
+
 /// `ValidateOpts` conveys the options that govern processing of a single validation target,
 /// decoupling the core validation logic from [`Pittv3Args`] so that non-CLI callers (GUI, web
 /// server) need not fabricate a full argument structure (and never see filesystem paths unless
@@ -564,7 +686,16 @@ pub(crate) async fn validate_cert_file(
     fresh_uris: &mut Vec<String>,
     threshold: usize,
 ) -> Result<()> {
-    let target_bytes = get_file_as_byte_vec_pem(Path::new(&cert_filename))?;
+    // A file the walk admitted and the reader cannot deliver never becomes a target, so record why
+    // here: nothing downstream sees this file again, and without it the entry reaches the report as
+    // an unexplained absence of paths.
+    let target_bytes = match get_file_as_byte_vec_pem(Path::new(&cert_filename)) {
+        Ok(bytes) => bytes,
+        Err(e) => {
+            stats.no_path_reason = Some((TargetStatus::ParseError, format!("{e:?}")));
+            return Err(e);
+        }
+    };
     validate_cert_bytes(
         pe,
         cps,
@@ -627,7 +758,19 @@ pub async fn validate_cert_bytes(
     let time_of_interest = cps.get_time_of_interest();
     let cert_filename = name;
 
-    let target_cert = parse_cert(target_bytes, cert_filename)?;
+    // An input reaches here because something claimed it was a certificate -- the walk admits a file
+    // by its extension, and a caller naming bytes directly is making the same claim. When it is not
+    // one, that is the whole of what happened to it: no path was sought, so no store and no setting
+    // is implicated, and saying "no paths found" pointed users at trust material over a file that
+    // was never a certificate.
+    let target_cert = match parse_cert(target_bytes, cert_filename) {
+        Ok(target_cert) => target_cert,
+        Err(e) => {
+            error!("Failed to parse a certificate from {cert_filename}: {e:?}");
+            stats.no_path_reason = Some((TargetStatus::ParseError, format!("{e:?}")));
+            return Err(e);
+        }
+    };
     info!("Start building and validating path(s) for {cert_filename}");
 
     let start2 = Instant::now();
@@ -655,6 +798,18 @@ pub async fn validate_cert_bytes(
     let r = pe.get_paths_for_target(&target_cert, &mut paths, threshold, time_of_interest);
     if let Err(e) = r {
         error!("Failed to find certification paths for target with error {e:?}");
+        // A PathValidation error means a check rejected the target itself while the path was being
+        // built (e.g. it is not valid at the time of interest) -- a rejection of the certificate,
+        // not an absence of candidate issuers. No path exists either way, so this contributes no
+        // paths; what it contributes is the reason, which belongs on the target. Reporting it as
+        // the neutral "no paths found" instead reads like a store or configuration problem when
+        // nothing about either is wrong. Every other error keeps the no-paths-found outcome.
+        if let Error::PathValidation(pvs) = &e {
+            let reason = format!("{pvs:?}");
+            error!("{cert_filename}: certificate rejected during path building - {reason}");
+            stats.no_path_reason = Some((TargetStatus::Invalid, reason));
+            return Err(e);
+        }
         stats.no_paths_hints = diagnose(pe);
         return Err(Error::Unrecognized);
     }
@@ -678,25 +833,36 @@ pub async fn validate_cert_bytes(
     let mut reported = 0usize;
     let mut suppressed = 0usize;
 
-    for (i, path) in paths.iter_mut().enumerate() {
-        // The dynamic-building loop calls back in once per pass, and the builder can offer a path an
-        // earlier pass already returned. Skip it before validating rather than after: a repeat costs
-        // a signature check and a revocation round trip, and reporting it a second time is what made
-        // one target's five paths read as ten.
-        //
-        // Logged at debug on every suppression on purpose. Deduplicating here is a backstop over
-        // whatever the builder's own `threshold` did, so silence would hide the builder handing back
-        // paths it was asked to withhold; a run that suppresses nothing says the threshold held.
-        let chain = chain_fingerprint(path);
-
-        if !stats.reported_chains.insert(chain) {
+    // Every path the builder returned is recorded here, before any of them is validated, rather
+    // than as each one is reached.
+    //
+    // The dynamic-building loop calls back in once per pass and the builder can offer a path an
+    // earlier pass already returned; having recorded it is what lets the repeat be skipped, which
+    // is worth doing before validating rather than after, since a repeat costs a signature check
+    // and a revocation round trip. Recording a path where it is validated misses every path the
+    // loop never reaches -- it stops at the first success unless validate_all is set, and always at
+    // a revoked end entity -- so those went unrecorded, were offered again on the next pass,
+    // suppressed nothing, and were counted a second time. Over eight revoked targets one run
+    // counted twenty paths twice that way, which is what made it report more paths found than the
+    // same material yielded in the browser, whose totals come from the reports themselves.
+    //
+    // Logged at debug on every suppression on purpose. Deduplicating here is a backstop over
+    // whatever the builder's own `threshold` did, so silence would hide the builder handing back
+    // paths it was asked to withhold; a run that suppresses nothing says the threshold held.
+    let mut to_validate = Vec::with_capacity(paths.len());
+    for (i, path) in paths.iter().enumerate() {
+        if stats.reported_chains.insert(chain_fingerprint(path)) {
+            to_validate.push(i);
+        } else {
             debug!(
                 "Suppressing a certification path already reported for {cert_filename} (offered again with threshold {threshold})"
             );
             suppressed += 1;
-            continue;
         }
+    }
 
+    for i in to_validate {
+        let path = &mut paths[i];
         info!(
             "Validating {} certificate path for {}",
             (path.intermediates.len() + 2),
@@ -771,11 +937,16 @@ pub async fn validate_cert_bytes(
                 stats.invalid_paths_per_target += 1;
 
                 log_path(pe, &opts.error_folder, path, i, None, None);
-                if e == Error::PathValidation(PathValidationStatus::CertificateRevokedEndEntity) {
-                    info!("Failed to validate {cert_filename} with {e:?}");
+                info!("Failed to validate {cert_filename} with {e:?}");
+                // A revoked end entity is the same certificate on every candidate path, so the
+                // first path to report it has settled the target and the rest cost a signature
+                // check and a revocation lookup to reach the same answer. Stop for the same reason
+                // and under the same condition as a successful path does: the run has what it came
+                // for, unless validate_all asked to see every path regardless.
+                let revoked =
+                    e == Error::PathValidation(PathValidationStatus::CertificateRevokedEndEntity);
+                if revoked && !opts.validate_all {
                     break;
-                } else {
-                    info!("Failed to validate {cert_filename} with {e:?}");
                 }
             }
         }
@@ -866,7 +1037,15 @@ pub async fn validate_targets(
 
         let paths_found = stats_for_target.paths_per_target - prev_paths;
         let path_reports = core::mem::take(&mut stats_for_target.path_reports);
-        let status = TargetReport::compute_status(&path_reports, paths_found > 0);
+        // A target that never yielded a path is reported as why rather than rolled up from path
+        // results it has none of
+        let (status, error) = match stats_for_target.no_path_reason.take() {
+            Some((status, reason)) => (status, Some(reason)),
+            None => (
+                TargetReport::compute_status(&path_reports, paths_found > 0),
+                None,
+            ),
+        };
 
         if let Some(progress) = progress {
             progress(ProgressEvent::PathsFound {
@@ -904,6 +1083,7 @@ pub async fn validate_targets(
             status,
             paths: path_reports,
             no_paths_hints,
+            error,
         });
     }
 

--- a/pittv3-lib/tests/input_counts.rs
+++ b/pittv3-lib/tests/input_counts.rs
@@ -1,0 +1,200 @@
+//! Integration tests for the input-pool counting functions — what a frontend shows beside a pool.
+//!
+//! A pool's own length is the wrong number, and misleadingly so: one `.p7c` of cross-certificates is
+//! six certificates, a folder is however many are in it, and a CBOR store is however many it
+//! carries. A row reporting entries reads "1" for all three. Both frontends had this bug; these
+//! tests pin the answer for the one that reports on *paths* rather than on bytes it already holds,
+//! which is what makes the answer a matter of reading the disk.
+//!
+//! The counts come from the loaders the run uses, so what is really pinned here is that the number
+//! shown before a run is the number the run will have.
+#![cfg(feature = "std")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use certval::*;
+use pittv3_lib::std_utils::{
+    count_ca_inputs, count_end_entity_inputs, count_revocation_inputs, count_trust_anchor_inputs,
+    load_ca_inputs,
+};
+
+/// A time at which the PKITS fixtures are valid
+const TOI: u64 = 1648039783;
+
+const FLAVOR: &str = "../certval/tests/examples/PKITS_data_p256/certs";
+
+/// A `.p7c` of six cross-certificates issued to the Federal Bridge CA G4 — the shape that started
+/// this: a single file every count based on files reports as one.
+const BUNDLE: &str = "../certval/tests/examples/caCertsIssuedTofbcag4.p7c";
+
+/// 2021-05-01, when all six certificates in [`BUNDLE`] are valid. Four of them expired in 2023 and a
+/// fifth in 2024, which is the point of [`BUNDLE_LATER`] below rather than an obstacle here.
+const BUNDLE_TOI: u64 = 1619827200;
+
+/// 2026-01-01, by which one of the six is still valid. Fixed rather than "now" so the test asserts a
+/// number instead of describing the calendar.
+const BUNDLE_LATER: u64 = 1767225600;
+
+/// The captured path from the revocation fixtures: two CRLs, two OCSP responses, three certificates
+/// and a manifest, in one folder.
+const CAPTURED: &str = "../certval/tests/examples/harvard.edu";
+
+/// Four intermediates, enough that a folder counting as one entry is visibly the wrong answer.
+const CHAIN: &[&str] = &[
+    "requireExplicitPolicy10CACert.crt",
+    "requireExplicitPolicy10subCACert.crt",
+    "requireExplicitPolicy10subsubCACert.crt",
+    "requireExplicitPolicy10subsubsubCACert.crt",
+];
+
+fn example(name: &str) -> PathBuf {
+    Path::new(FLAVOR).join(name)
+}
+
+fn example_str(name: &str) -> String {
+    example(name).to_str().unwrap().to_string()
+}
+
+/// Copies `names` into a fresh folder under `dir` and returns its path, standing in for a folder a
+/// user points the tool at.
+fn folder_with(dir: &Path, label: &str, names: &[&str]) -> String {
+    let folder = dir.join(label);
+    fs::create_dir_all(&folder).unwrap();
+    for name in names {
+        fs::copy(example(name), folder.join(name)).unwrap();
+    }
+    folder.to_str().unwrap().to_string()
+}
+
+/// The bug as it was reported: a bundle is counted as the certificates in it, not as the one file it
+/// arrived in. Both pools fan a file out, so both are asserted against the same material.
+#[test]
+fn a_bundle_counts_as_the_certificates_in_it() {
+    assert_eq!(6, count_ca_inputs([BUNDLE], BUNDLE_TOI));
+    assert_eq!(6, count_trust_anchor_inputs([BUNDLE], BUNDLE_TOI));
+}
+
+/// A count is an answer as of a moment, because loading drops material not valid at the time of
+/// interest. Same file, same pool, five of the six expired: one.
+#[test]
+fn a_count_is_as_of_the_time_of_interest() {
+    assert_eq!(1, count_ca_inputs([BUNDLE], BUNDLE_LATER));
+    assert_eq!(1, count_trust_anchor_inputs([BUNDLE], BUNDLE_LATER));
+}
+
+/// A time certval will not take disables the check rather than standing in for it, so the material
+/// is counted rather than nothing. Without this the fallback would be a silent zero, which reads as
+/// "these inputs are empty" — the opposite of what happened.
+#[test]
+fn an_impossible_time_leaves_validity_unchecked() {
+    assert_eq!(6, count_ca_inputs([BUNDLE], u64::MAX));
+    assert_eq!(6, count_trust_anchor_inputs([BUNDLE], u64::MAX));
+}
+
+/// A folder counts as what is in it, and entries of different shapes add up: the whole point of a
+/// pool is that a set is assembled from material in whatever form it arrived.
+#[test]
+fn a_folder_counts_as_its_contents() {
+    let dir = tempfile::tempdir().unwrap();
+    let folder = folder_with(dir.path(), "chain", &CHAIN[..3]);
+
+    assert_eq!(3, count_ca_inputs([folder.as_str()], TOI));
+    assert_eq!(
+        4,
+        count_ca_inputs([folder.as_str(), example_str(CHAIN[3]).as_str()], TOI),
+        "a folder of three and a file beside it"
+    );
+}
+
+/// Repeats collapse, because the loaders deduplicate: a certificate named twice is carried once and
+/// counting it twice would promise a run material it does not have. A per-entry sum would miss this.
+#[test]
+fn material_named_twice_counts_once() {
+    let dir = tempfile::tempdir().unwrap();
+    let folder = folder_with(dir.path(), "chain", CHAIN);
+    let also = example_str(CHAIN[0]);
+
+    assert_eq!(4, count_ca_inputs([folder.as_str(), also.as_str()], TOI));
+    assert_eq!(
+        4,
+        count_trust_anchor_inputs([folder.as_str(), also.as_str()], TOI)
+    );
+}
+
+/// A CBOR store counts as the certificates it carries. This is the shape where an entry count is
+/// furthest from the truth — a store of a thousand certificates is one file — and it is a shape the
+/// app itself writes, so a user gets one by exporting.
+#[test]
+fn a_store_counts_as_its_certificates() {
+    let dir = tempfile::tempdir().unwrap();
+    let chain: Vec<String> = CHAIN.iter().map(|n| example_str(n)).collect();
+    let mut source = CertSource::new();
+    load_ca_inputs(
+        &PkiEnvironment::default(),
+        chain.iter().map(String::as_str),
+        &mut source,
+        TimeOfInterest::from_unix_secs(TOI).unwrap(),
+    );
+    let store = dir.path().join("ca.cbor");
+    fs::write(
+        &store,
+        source
+            .serialize(CertificationPathBuilderFormats::Cbor)
+            .unwrap(),
+    )
+    .unwrap();
+
+    assert_eq!(CHAIN.len(), count_ca_inputs([store.to_str().unwrap()], TOI));
+}
+
+/// An entry that cannot be read contributes nothing and costs the others nothing. A count is shown
+/// beside inputs a user is still assembling, so a typo among them must not blank the row — the run
+/// is where an input that will not load has consequences, and it reports them there.
+#[test]
+fn an_unreadable_entry_counts_as_nothing() {
+    let good = example_str(CHAIN[0]);
+
+    assert_eq!(1, count_ca_inputs(["does/not/exist", good.as_str()], TOI));
+    assert_eq!(
+        1,
+        count_trust_anchor_inputs(["does/not/exist", good.as_str()], TOI)
+    );
+}
+
+/// The end entity pool counts *targets*, which is the same question asked of different material: a
+/// folder is traversed for the certificates in it, so the number is what the run will judge and what
+/// the Validate button promises.
+#[test]
+fn an_end_entity_folder_counts_as_its_targets() {
+    let dir = tempfile::tempdir().unwrap();
+    let folder = folder_with(dir.path(), "targets", &CHAIN[..2]);
+    fs::write(Path::new(&folder).join("notes.txt"), "not a certificate").unwrap();
+
+    assert_eq!(
+        2,
+        count_end_entity_inputs([folder.as_str()]),
+        "the text file is not a target"
+    );
+    assert_eq!(
+        3,
+        count_end_entity_inputs([folder.as_str(), example_str(CHAIN[2]).as_str()])
+    );
+}
+
+/// A file named twice is one target, matching the run: per-target statistics are keyed by file name,
+/// so the second naming is the same target and is validated once.
+#[test]
+fn an_end_entity_named_twice_counts_once() {
+    let one = example_str(CHAIN[0]);
+
+    assert_eq!(1, count_end_entity_inputs([one.as_str(), one.as_str()]));
+}
+
+/// The revocation pool counts two things, because a CRL and an OCSP response are not the same thing
+/// to a run. Which a file holds comes from its bytes, so a folder of mixed material sorts itself —
+/// the certificates and the manifest in the captured folder are neither and count as neither.
+#[test]
+fn revocation_inputs_count_by_kind() {
+    assert_eq!((2, 2), count_revocation_inputs([CAPTURED]));
+}

--- a/pittv3-lib/tests/rejected_target.rs
+++ b/pittv3-lib/tests/rejected_target.rs
@@ -1,0 +1,176 @@
+//! Integration tests for the two ways an input yields no certification path without the store
+//! having anything to do with it.
+//!
+//! A check that fails while the path is being built -- the target is not valid at the time of
+//! interest, say -- is a rejection of the certificate, not an absence of candidate issuers. A file
+//! that is not a certificate is not even that. Both were reported as "no paths found", which reads
+//! like the store or the configuration is wrong when nothing about either is. These tests pin each
+//! outcome to its own status, carrying its own reason.
+#![cfg(feature = "std")]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+
+use certval::*;
+use pittv3_lib::args::Pittv3Args;
+use pittv3_lib::options_std::options_std;
+use pittv3_lib::report::{TargetStatus, ValidationReport};
+
+/// A time at which the PKITS fixtures are valid
+const TOI: u64 = 1648039783;
+
+/// Long after the PKITS fixtures expire
+const TOI_AFTER_EXPIRY: u64 = 4102444800;
+
+const FLAVOR: &str = "../certval/tests/examples/PKITS_data_p256/certs";
+
+fn example(name: &str) -> PathBuf {
+    Path::new(FLAVOR).join(name)
+}
+
+fn folder_with(dir: &Path, names: &[&str]) -> String {
+    fs::create_dir_all(dir).unwrap();
+    for name in names {
+        fs::copy(example(name), dir.join(name)).unwrap();
+    }
+    dir.to_str().unwrap().to_string()
+}
+
+/// Writes the settings file a run reads. Revocation checking is off: these tests are about what the
+/// path builder does with the target, and the fixtures carry no revocation material to answer with.
+fn settings_file(dir: &Path, toi: u64) -> String {
+    let mut cps = CertificationPathSettings::new();
+    cps.set_time_of_interest(TimeOfInterest::from_unix_secs(toi).unwrap());
+    cps.set_check_revocation_status(false);
+    let path = dir.join("settings.json");
+    fs::write(&path, serde_json::to_string(&cps).unwrap()).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+fn validate(dir: &Path, toi: u64) -> ValidationReport {
+    let ta_folder = folder_with(&dir.join("ta"), &["TrustAnchorRootCertificate.crt"]);
+    let ca_folder = folder_with(&dir.join("ca"), &["GoodCACert.crt"]);
+    let args = Pittv3Args {
+        ta_folder: Some(ta_folder),
+        ca_folder: Some(ca_folder),
+        end_entity_file: Some(
+            example("ValidCertificatePathTest1EE.crt")
+                .to_str()
+                .unwrap()
+                .to_string(),
+        ),
+        settings: Some(settings_file(dir, toi)),
+        time_of_interest: toi,
+        ..Default::default()
+    };
+    tokio_test::block_on(options_std(&args))
+}
+
+/// Runs a validation over a folder of targets rather than a single file, which is how a file that
+/// is not a certificate reaches the run at all: the walk admits by extension.
+fn validate_folder(dir: &Path, ee_folder: &Path) -> ValidationReport {
+    let ta_folder = folder_with(&dir.join("ta"), &["TrustAnchorRootCertificate.crt"]);
+    let ca_folder = folder_with(&dir.join("ca"), &["GoodCACert.crt"]);
+    let args = Pittv3Args {
+        ta_folder: Some(ta_folder),
+        ca_folder: Some(ca_folder),
+        end_entity_folder: Some(ee_folder.to_str().unwrap().to_string()),
+        settings: Some(settings_file(dir, TOI)),
+        time_of_interest: TOI,
+        ..Default::default()
+    };
+    tokio_test::block_on(options_std(&args))
+}
+
+/// The control: the same inputs at a time the fixtures are valid produce a path.
+#[test]
+fn valid_at_time_of_interest_finds_a_path() {
+    let dir = tempfile::tempdir().unwrap();
+    let report = validate(dir.path(), TOI);
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+}
+
+/// The same inputs at a time the target has expired: the certificate is rejected, so the report has
+/// to say that rather than report the neutral absence of paths.
+#[test]
+fn expired_target_is_invalid_not_no_paths_found() {
+    let dir = tempfile::tempdir().unwrap();
+    let report = validate(dir.path(), TOI_AFTER_EXPIRY);
+
+    let target = &report.targets[0];
+    assert_eq!(TargetStatus::Invalid, target.status);
+    // The reason rides on the target, because no path was built for it to hang off
+    assert!(
+        target
+            .error
+            .as_deref()
+            .is_some_and(|e| e.contains("InvalidNotAfterDate")),
+        "reason: {:?}",
+        target.error
+    );
+    // Nothing about the store is at fault, so the store is not blamed
+    assert!(
+        target.no_paths_hints.is_empty(),
+        "hints: {:?}",
+        target.no_paths_hints
+    );
+    // No path was built, so none is reported and none is counted. Reporting the rejection as a
+    // one-certificate path put an entry in the path list that was never a path, and every total
+    // that counts that list then counted it.
+    assert!(target.paths.is_empty(), "paths: {:?}", target.paths);
+    assert_eq!(0, report.totals.paths_found);
+    assert_eq!(0, report.totals.valid_paths);
+    assert_eq!(0, report.totals.invalid_paths);
+}
+
+/// A file named like a certificate and holding something else. The PIV credentials that turned this
+/// up ship CHUID data as `.crt`, which the walk admits and the parser then rejects; the run filed
+/// them under no-paths-found, which reads as a complaint about the store for input that was never a
+/// certificate at all.
+#[test]
+fn a_file_that_is_not_a_certificate_says_so() {
+    let dir = tempfile::tempdir().unwrap();
+    let ee_dir = dir.path().join("ee");
+    fs::create_dir_all(&ee_dir).unwrap();
+    fs::copy(
+        example("ValidCertificatePathTest1EE.crt"),
+        ee_dir.join("ValidCertificatePathTest1EE.crt"),
+    )
+    .unwrap();
+    // APPLICATION [13], primitive -- the outer tag PIV CHUID data carries, and not a SEQUENCE
+    fs::write(
+        ee_dir.join("chuid.crt"),
+        [0x4d, 0x04, 0x01, 0x02, 0x03, 0x04],
+    )
+    .unwrap();
+
+    let report = validate_folder(dir.path(), &ee_dir);
+
+    // Both files are reported: one that is dropped silently leaves a user comparing the folder with
+    // the run and nothing to reconcile the two counts with
+    assert_eq!(2, report.targets.len());
+
+    let certificate = report
+        .targets
+        .iter()
+        .find(|t| t.name.ends_with("ValidCertificatePathTest1EE.crt"))
+        .unwrap();
+    assert_eq!(TargetStatus::Valid, certificate.status);
+    assert_eq!(None, certificate.error);
+
+    let not_a_certificate = report
+        .targets
+        .iter()
+        .find(|t| t.name.ends_with("chuid.crt"))
+        .unwrap();
+    assert_eq!(TargetStatus::ParseError, not_a_certificate.status);
+    // The status says a certificate could not be read; the error says what went wrong reading it
+    assert!(
+        not_a_certificate.error.is_some(),
+        "no reason carried: {not_a_certificate:?}"
+    );
+    // Nothing about the store bears on it, so the store is not blamed and no path is claimed
+    assert!(not_a_certificate.no_paths_hints.is_empty());
+    assert!(not_a_certificate.paths.is_empty());
+    assert_eq!(None, not_a_certificate.target);
+}

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -12,8 +12,8 @@ use dioxus::prelude::*;
 use web_time::{Instant, SystemTime, UNIX_EPOCH};
 
 use certval::{
-    CertSource, CertificationPathSettings, PkiEnvironment, RevocationCache, TaSource,
-    TimeOfInterest, CERT_BUNDLE_EXTENSIONS, TA_BUNDLE_EXTENSIONS,
+    CertFile, CertSource, CertVector, CertificationPathSettings, PkiEnvironment, RevocationCache,
+    TaSource, TimeOfInterest, CERT_BUNDLE_EXTENSIONS, TA_BUNDLE_EXTENSIONS,
 };
 use pittv3_gui_lib::gui_end_entity::EndEntityGroup;
 use pittv3_gui_lib::gui_results::ResultsView;
@@ -353,25 +353,55 @@ fn App() -> Element {
 
     // What an upload actually contributes, which is certificates and not files: since the 08-24
     // fan-out one `.p7c` of cross-certificates carries several, and reporting the file count made
-    // the label read "1 trust anchor(s)" for six. Mirrors prepare_validation's dispatch so the
-    // number shown is the number that will be used.
+    // the label read "1 trust anchor(s)" for six.
+    //
+    // Counted by pushing into a store rather than by summing what each file parses to, because
+    // `push` drops a certificate the store already holds and a per-file sum cannot: the "issued by"
+    // and "issued to" bundles for a cross-certified pair each carry the same cross-certificate, so
+    // nominating both parsed 17 certificates where the run had 16. The filenames here are the
+    // upload's own rather than prepare_validation's numbering, which changes nothing -- `CertFile`
+    // equality is over the bytes alone.
     let loaded_ta_count = use_memo(move || {
-        uploaded_tas()
-            .iter()
-            .map(|(_, bytes)| match TaSource::new_from_cbor(bytes) {
-                Ok(src) => src.get_tas().len(),
-                Err(_) => certs_in(bytes).map(|c| c.len()).unwrap_or(0),
-            })
-            .sum::<usize>()
+        let mut ta_store = TaSource::new();
+        for (name, bytes) in uploaded_tas().iter() {
+            // A `.cbor` trust-anchor store merges all of its anchors; new_from_cbor rejects
+            // anything else, so certificates and bundles fall through to the parse below
+            if let Ok(src) = TaSource::new_from_cbor(bytes) {
+                for cf in src.get_tas() {
+                    ta_store.push(cf);
+                }
+                continue;
+            }
+            if let Ok(ders) = certs_in(bytes) {
+                for der in ders {
+                    ta_store.push(CertFile {
+                        filename: name.clone(),
+                        bytes: der,
+                    });
+                }
+            }
+        }
+        ta_store.len()
     });
     let loaded_ca_count = use_memo(move || {
-        uploaded_cas()
-            .iter()
-            .map(|(_, bytes)| match CertSource::new_from_cbor(bytes) {
-                Ok(src) => src.get_buffers().len(),
-                Err(_) => certs_in(bytes).map(|c| c.len()).unwrap_or(0),
-            })
-            .sum::<usize>()
+        let mut cert_source = CertSource::new();
+        for (name, bytes) in uploaded_cas().iter() {
+            if let Ok(src) = CertSource::new_from_cbor(bytes) {
+                for cf in src.get_buffers() {
+                    cert_source.push(cf);
+                }
+                continue;
+            }
+            if let Ok(ders) = certs_in(bytes) {
+                for der in ders {
+                    cert_source.push(CertFile {
+                        filename: name.clone(),
+                        bytes: der,
+                    });
+                }
+            }
+        }
+        cert_source.len()
     });
     let mut loaded_ees = use_signal(Vec::<(String, Vec<u8>)>::new);
     // Which of the two ways of naming an end entity certificate the form is offering. Not a


### PR DESCRIPTION
- honor the last-modified map and URI blocklist settings (which may yet go away)
- count what an input pool contributes, i.e. a .p7c of cross-certificates may contribute
six certificates instead of 1 file. Likewise for folders.
- report a target the builder rejects outright as invalid, i.e., expired, carrying the
reason rather than as no paths found.
- add TargetStatus::ParseError for a file admitted as a certificate that cannot
be read as one, with the reason on a new TargetReport.error.
- associate the above reasons with the target instead of as a one-certificate path.
A target that found no path contributes nothing to the path counts.
- fingerprint chains before validation to avoid early termination miss
- honor validate-all when a revoked end entity ends the loop, in both UIs