### PR TITLE
Add no-std support for the signature verification cache

### DIFF
--- a/certval/Cargo.toml
+++ b/certval/Cargo.toml
@@ -57,7 +57,9 @@ reqwest = { version = "0.13.4", optional = true}
 # Lock for the revocation status cache on targets that take this crate without std, which has no
 # RwLock to offer. Cargo cannot express "revocation and not std", so a std build pulls this in and
 # does not use it; the crate is small and has no dependencies of its own.
-spin = { version = "0.9.9", optional = true, default-features = false, features = ["rwlock"] }
+# Not optional: the caches need a Sync lock in every build, and std::sync::RwLock does not exist
+# on the no_std targets. See util/lock.rs for which one is used where.
+spin = { version = "0.9.9", default-features = false, features = ["rwlock"] }
 getrandom = { version = "0.4", optional = true}
 serde_json = {version = "1.0.150", optional = true, default-features = false, features = ["alloc"] }
 walkdir = { version = "2.5.0", optional = true}
@@ -89,7 +91,10 @@ tokio = { version = "1.52.3", features = ["full", "macros", "time", "rt-multi-th
 # webpki can be paired with any other feature and simply adds a means of initializing a TaSource from the webpki-roots crate
 [features]
 default = ["remote", "webpki"]
-revocation = ["dep:spin"]
+# Gates code, not dependencies: ~30 cfg(feature = "revocation") sites across the crate. It used to
+# carry dep:spin, which moved to an unconditional dependency when the caches that need a lock stopped
+# being revocation-gated -- see util/lock.rs.
+revocation = []
 std = ["dep:walkdir", "dep:serde_json", "serde/rc", "dep:bitvec", "der/std"]
 remote = ["revocation", "std", "reqwest", "dep:getrandom"]
 pqc = ["ml-dsa", "sha3", "slh-dsa", "dep:pkcs1"]

--- a/certval/src/environment/pki_environment.rs
+++ b/certval/src/environment/pki_environment.rs
@@ -944,18 +944,19 @@ fn signature_cache_hash(bytes: &[u8]) -> Vec<u8> {
 /// once the cap is reached so a long-lived environment that validates many distinct signatures cannot
 /// grow it without bound.
 ///
+/// Available in every build: the lock behind it is `std::sync::RwLock` where `std` exists and a spin
+/// lock otherwise, so `no_std` consumers get the same cache rather than having to write one.
+///
 /// Every successful verification the environment performs is recorded, including one-shot checks --
 /// a self-signature test during ingest, an end-entity signature -- that will never be asked for
 /// again. Which entries survive the cap is therefore whichever the run happened to reach first, not
 /// the ones with the most reuse. For an estate large enough to reach the cap, prefer a cache of your
 /// own with an eviction policy that suits it.
-#[cfg(feature = "std")]
 pub struct DefaultSignatureVerificationCache {
-    verified: std::sync::RwLock<alloc::collections::BTreeSet<(Vec<u8>, Vec<u8>)>>,
+    verified: crate::util::lock::Lock<alloc::collections::BTreeSet<(Vec<u8>, Vec<u8>)>>,
     cap: usize,
 }
 
-#[cfg(feature = "std")]
 impl DefaultSignatureVerificationCache {
     /// Default maximum number of cached verifications.
     pub const DEFAULT_CAP: usize = 8192;
@@ -968,40 +969,36 @@ impl DefaultSignatureVerificationCache {
     /// Creates a cache that stops recording new entries once `cap` have accumulated.
     pub fn with_capacity(cap: usize) -> Self {
         DefaultSignatureVerificationCache {
-            verified: std::sync::RwLock::new(alloc::collections::BTreeSet::new()),
+            verified: crate::util::lock::Lock::new(alloc::collections::BTreeSet::new()),
             cap,
         }
     }
 }
 
-#[cfg(feature = "std")]
 impl Default for DefaultSignatureVerificationCache {
     fn default() -> Self {
         Self::new()
     }
 }
 
-#[cfg(feature = "std")]
 impl SignatureVerificationCache for DefaultSignatureVerificationCache {
     fn is_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
-        match self.verified.read() {
-            Ok(set) => set.contains(&(signed_data_hash.to_vec(), issuer_spki_hash.to_vec())),
-            Err(_) => false,
-        }
+        self.verified
+            .with_read(|set| set.contains(&(signed_data_hash.to_vec(), issuer_spki_hash.to_vec())))
     }
 
     fn add_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) {
-        if let Ok(mut set) = self.verified.write() {
+        self.verified.with_write(|set| {
             if set.len() < self.cap {
                 set.insert((signed_data_hash.to_vec(), issuer_spki_hash.to_vec()));
             }
-        }
+        })
     }
 }
 
 /// Delegating implementation so a caller can retain a shared handle to a cache (for example to
-/// inspect it) while also handing it to a [`PkiEnvironment`] via `add_signature_cache`.
-#[cfg(feature = "std")]
+/// inspect it) while also handing it to a [`PkiEnvironment`] via `add_signature_cache`. Needs only
+/// `alloc`, so it is available wherever the cache is.
 impl<T: SignatureVerificationCache + ?Sized> SignatureVerificationCache for alloc::sync::Arc<T> {
     fn is_verified(&self, signed_data_hash: &[u8], issuer_spki_hash: &[u8]) -> bool {
         (**self).is_verified(signed_data_hash, issuer_spki_hash)

--- a/certval/src/source/revocation_cache.rs
+++ b/certval/src/source/revocation_cache.rs
@@ -18,44 +18,7 @@ use crate::PathValidationStatus::RevocationStatusNotDetermined;
 use crate::{buffer_to_hex, PathValidationStatus, RevocationStatusCache};
 use crate::{name_to_string, PDVCertificate, SubjectNameAndKey, TimeOfInterest};
 
-#[cfg(feature = "std")]
-type LockImpl<T> = std::sync::RwLock<T>;
-#[cfg(not(feature = "std"))]
-type LockImpl<T> = spin::RwLock<T>;
-
-/// The cache is shared behind `&self` and [`RevocationStatusCache`] requires `Sync`, so interior
-/// mutability has to be a lock rather than a cell -- and `std`'s is unavailable to the targets this
-/// module now serves. The two differ in their guard types and in whether locking can fail, so both
-/// are reached through closures here and the difference stays in one place.
-struct Lock<T>(LockImpl<T>);
-
-impl<T> Lock<T> {
-    fn new(value: T) -> Self {
-        Lock(LockImpl::new(value))
-    }
-
-    // A poisoned lock is recovered rather than treated as a failure: the guarded value is a
-    // BTreeMap that a panicking writer leaves structurally intact, and the worst a stale entry can
-    // do is expire. Refusing to read would silently disable the cache for the process's remaining
-    // life, which is the more damaging failure.
-    #[cfg(feature = "std")]
-    fn with_read<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-        f(&self.0.read().unwrap_or_else(|e| e.into_inner()))
-    }
-    #[cfg(not(feature = "std"))]
-    fn with_read<R>(&self, f: impl FnOnce(&T) -> R) -> R {
-        f(&self.0.read())
-    }
-
-    #[cfg(feature = "std")]
-    fn with_write<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
-        f(&mut self.0.write().unwrap_or_else(|e| e.into_inner()))
-    }
-    #[cfg(not(feature = "std"))]
-    fn with_write<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
-        f(&mut self.0.write())
-    }
-}
+use crate::util::lock::Lock;
 
 struct StatusAndTime {
     status: PathValidationStatus, // Valid or Revoked

--- a/certval/src/util.rs
+++ b/certval/src/util.rs
@@ -4,6 +4,7 @@ pub mod crypto;
 pub mod crypto_composite;
 pub mod crypto_pqc;
 pub mod error;
+pub(crate) mod lock;
 pub mod pdv_alg_oids;
 pub mod pdv_utilities;
 pub mod pqc_oids;

--- a/certval/src/util/lock.rs
+++ b/certval/src/util/lock.rs
@@ -1,0 +1,52 @@
+//! One reader-writer lock for the caches, whichever build they are compiled into.
+//!
+//! The cache traits ([`crate::RevocationStatusCache`],
+//! [`crate::environment::pki_environment_traits::SignatureVerificationCache`]) are used behind
+//! `&self` and require `Sync`, so interior mutability has to be a lock rather than a cell -- and
+//! `std`'s is unavailable on the `no_std` targets these caches now serve. `std::sync::RwLock` is
+//! kept wherever it exists rather than using the spin lock everywhere: uncontended the two are
+//! comparable, but a spin lock burns CPU while waiting and, worse, keeps spinning when the OS
+//! preempts the thread holding it. These caches guard a `BTreeMap`/`BTreeSet` whose critical
+//! sections allocate and rebalance, and at least one consumer shares a single cache across a
+//! request-handling thread pool, so parking is the right behavior where it is available.
+//!
+//! The two implementations differ in their guard types and in whether locking can fail, so both are
+//! reached through closures and the difference stays here.
+
+#[cfg(feature = "std")]
+type LockImpl<T> = std::sync::RwLock<T>;
+#[cfg(not(feature = "std"))]
+type LockImpl<T> = spin::RwLock<T>;
+
+/// A reader-writer lock over `T`, backed by `std::sync::RwLock` where `std` is available and by
+/// `spin::RwLock` otherwise.
+pub(crate) struct Lock<T>(LockImpl<T>);
+
+impl<T> Lock<T> {
+    /// Wraps `value`.
+    pub(crate) fn new(value: T) -> Self {
+        Lock(LockImpl::new(value))
+    }
+
+    // A poisoned lock is recovered rather than treated as a failure: the guarded value is a
+    // collection that a panicking writer leaves structurally intact, and the worst a stale entry
+    // can do is expire or be a redundant verification. Refusing to read would silently disable the
+    // cache for the process's remaining life, which is the more damaging failure.
+    #[cfg(feature = "std")]
+    pub(crate) fn with_read<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        f(&self.0.read().unwrap_or_else(|e| e.into_inner()))
+    }
+    #[cfg(not(feature = "std"))]
+    pub(crate) fn with_read<R>(&self, f: impl FnOnce(&T) -> R) -> R {
+        f(&self.0.read())
+    }
+
+    #[cfg(feature = "std")]
+    pub(crate) fn with_write<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        f(&mut self.0.write().unwrap_or_else(|e| e.into_inner()))
+    }
+    #[cfg(not(feature = "std"))]
+    pub(crate) fn with_write<R>(&self, f: impl FnOnce(&mut T) -> R) -> R {
+        f(&mut self.0.write())
+    }
+}

--- a/pittv3-gui-lib/src/validate.rs
+++ b/pittv3-gui-lib/src/validate.rs
@@ -223,6 +223,10 @@ pub fn prepare_validation(
     // --- prepare the environment ONCE ---
     let mut pe = PkiEnvironment::default();
     pe.populate_5280_pki_environment();
+    // The graph and the paths built over it re-present the same CA signatures many times;
+    // caching them is sound because a hit means this exact signature already verified under
+    // this exact key.
+    pe.add_signature_cache(Box::new(DefaultSignatureVerificationCache::new()));
     pe.add_trust_anchor_source(Box::new(ta_store));
     // Registered empty and always, rather than only when the frontend has CRLs: the source is
     // shared by clone, so a frontend that retrieves one later adds it to the same contents this
@@ -775,6 +779,10 @@ pub fn validate_hackathon_zip(
 
     let mut pe = PkiEnvironment::default();
     pe.populate_5280_pki_environment();
+    // The graph and the paths built over it re-present the same CA signatures many times;
+    // caching them is sound because a hit means this exact signature already verified under
+    // this exact key.
+    pe.add_signature_cache(Box::new(DefaultSignatureVerificationCache::new()));
     pe.add_trust_anchor_source(Box::new(ta_store));
     // path building for TA-issued targets happens in the certificate source, so one must be
     // registered even though the R5 format carries no intermediate CA certificates

--- a/pittv3-lib/src/options_no_std.rs
+++ b/pittv3-lib/src/options_no_std.rs
@@ -83,6 +83,10 @@ pub fn options_no_std(args: &Pittv3Args) {
 
     let mut pe = PkiEnvironment::default();
     pe.populate_5280_pki_environment();
+    // The graph and the paths built over it re-present the same CA signatures many times;
+    // caching them is sound because a hit means this exact signature already verified under
+    // this exact key.
+    pe.add_signature_cache(Box::new(DefaultSignatureVerificationCache::new()));
     pe.add_trust_anchor_source(Box::new(ta_store.clone()));
     pe.add_certificate_source(Box::new(cert_source.clone()));
 

--- a/pittv3-lib/src/options_std_app.rs
+++ b/pittv3-lib/src/options_std_app.rs
@@ -107,6 +107,10 @@ pub fn options_std_app(args: &Pittv3Args) {
 
     let mut pe = PkiEnvironment::default();
     pe.populate_5280_pki_environment();
+    // The graph and the paths built over it re-present the same CA signatures many times;
+    // caching them is sound because a hit means this exact signature already verified under
+    // this exact key.
+    pe.add_signature_cache(Box::new(DefaultSignatureVerificationCache::new()));
     pe.add_trust_anchor_source(Box::new(ta_store.clone()));
     pe.add_certificate_source(Box::new(cert_source.clone()));
 


### PR DESCRIPTION
- std retains std::sync::RwLock use. no-std uses spin::RwLock. spin is now an unconditional dependency.
- Move and reuse the Lock type used by the revocation status cache
- Remove the feature gate on the Arc blanket impl, which needs only alloc.
- Register the cache in the pittv3 environments that build paths