### PR TITLE
Documentation addition, duplicative check removal, minor bug fix

### DIFF
--- a/certval/src/util/pdv_utilities.rs
+++ b/certval/src/util/pdv_utilities.rs
@@ -503,6 +503,13 @@ pub(crate) fn emails_from_dn(name: &Name) -> Vec<Ia5String> {
 }
 
 /// `descended_from_dn` returns true if new_name is equal to or descended from prev_name and false otherwise.
+///
+/// `min` and `max` are the `minimum` and `maximum` of the name-constraint subtree, applied to the
+/// difference in RDN count between the two names: a name fewer than `min` levels below the subtree,
+/// or more than `max` below it, does not match. Both bounds are implemented here, but `check_names`
+/// rejects any subtree carrying a nonzero minimum or a present maximum before matching begins, so
+/// in practice they arrive as 0 and None and neither excludes anything. See that check for why the
+/// rejection is broader than RFC 5280 4.2.1.10 strictly requires.
 pub(crate) fn descended_from_dn(subtree: &Name, name: &Name, min: u32, max: Option<u32>) -> bool {
     //if descendant fewer rdns then it is not a descendant
     if subtree.len() > name.len() {

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -350,6 +350,18 @@ fn name_constraint_matching_budget_exceeded(constraint_count: usize, san_len: us
 /// - Uniform resource identifiers
 ///
 /// Additional name forms may be added in the future.
+///
+/// The `minimum` and `maximum` fields of a name-constraint subtree are rejected rather than
+/// processed. RFC 5280 4.2.1.10 requires `minimum` to be zero and `maximum` to be absent, and
+/// obliges an application that meets other values to process them or reject the certificate --
+/// but only where the extension is critical and the constrained name form appears in a subsequent
+/// certificate. This implementation takes the broader reading: any subtree asserting a nonzero
+/// minimum or a present maximum fails the path, whether or not the extension is critical and
+/// whether or not that name form is ever seen. Rejecting is the sanctioned branch of that
+/// requirement, values outside it are nonconforming to begin with, and they do not occur in
+/// practice. The distinguished-name comparison behind this check does implement both bounds, but
+/// this rejection runs first, so they are consulted only for the conforming values that get past
+/// it.
 pub fn check_names(
     _pe: &PkiEnvironment,
     cps: &CertificationPathSettings,
@@ -488,7 +500,11 @@ pub fn check_names(
 
                 // RFC 5280 4.2.1.10: minimum MUST be zero and maximum MUST be absent; an
                 // application encountering other values MUST process them or reject the
-                // certificate.
+                // certificate. That obligation is narrower than what happens here -- it binds only
+                // for a critical extension whose constrained name form appears in a subsequent
+                // certificate -- and the broader reading is taken deliberately: any nonconforming
+                // value fails the path. Rejecting is the sanctioned branch, the values are not
+                // conforming to begin with, and they do not occur in practice.
                 if has_min_or_max(&nc.permitted_subtrees) || has_min_or_max(&nc.excluded_subtrees) {
                     log_error_for_ca(ca_cert, "unsupported minimum/maximum in name constraints");
                     cpr.set_validation_status(PathValidationStatus::NameConstraintsViolation);

--- a/pittv3-gui-lib/src/validate.rs
+++ b/pittv3-gui-lib/src/validate.rs
@@ -479,23 +479,6 @@ fn validate_target(
     };
     let target_summary = CertSummary::from_cert(&target);
 
-    // validate_path treats a target found in the TA store as trusted and returns success without
-    // verifying its signature (and TA store membership requires only a subjectKeyIdentifier and
-    // public key match, not an exact certificate match), so when the target is a trust anchor
-    // check its signature here to keep bad signatures and unsupported algorithms from being
-    // reported as valid
-    if pe.is_cert_a_trust_anchor(&target).is_ok() {
-        if is_self_signed(pe, &target) {
-            out.push(ok(format!(
-                "{ee_name} is a trust anchor and is self-signed"
-            )));
-        } else {
-            out.push(err(format!(
-                "{ee_name} matches a trust anchor by key but is not self-signed (bad signature or unsupported algorithm)"
-            )));
-        }
-    }
-
     out.push(info(format!(
         "Building and validating path(s) for {} ({})",
         ee_name,

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -1207,7 +1207,10 @@ pub async fn generate(
         cps.set_download_folder(download_folder.to_string());
     }
 
-    cps.set_cbor_ta_store(args.cbor_ta_store);
+    // Honor the `cbor_ta_store` when set to true (to avoid clobbering a true from a settings file)
+    if args.cbor_ta_store {
+        cps.set_cbor_ta_store(true);
+    }
 
     let graph = build_graph(pe, cps).await;
     match graph {

--- a/pittv3-lib/tests/generate_inputs.rs
+++ b/pittv3-lib/tests/generate_inputs.rs
@@ -30,10 +30,19 @@ fn example(name: &str) -> String {
 /// checking off: these tests are about which certificates reach the graph, and the PKITS fixtures
 /// carry no revocation material to answer with.
 fn settings_file(dir: &Path) -> String {
+    settings_file_named(dir, "settings.json", false)
+}
+
+/// As [`settings_file`], writing to `name` and optionally asking for a trust anchor store in the
+/// settings rather than by the flag.
+fn settings_file_named(dir: &Path, name: &str, ta_store: bool) -> String {
     let mut cps = CertificationPathSettings::new();
     cps.set_time_of_interest(TimeOfInterest::from_unix_secs(TOI).unwrap());
     cps.set_check_revocation_status(false);
-    let path = dir.join("settings.json");
+    if ta_store {
+        cps.set_cbor_ta_store(true);
+    }
+    let path = dir.join(name);
     fs::write(&path, serde_json::to_string(&cps).unwrap()).unwrap();
     path.to_str().unwrap().to_string()
 }
@@ -45,13 +54,19 @@ fn run(args: Pittv3Args) -> ValidationReport {
 /// Generates a store at `cbor` from `ca_input`, which may name a file or a folder. `ta_store` picks
 /// which kind: a trust anchor store or the usual store of intermediates and partial paths.
 fn generate(dir: &Path, ca_input: &str, cbor: &Path, ta_store: bool) {
+    generate_with_settings(ca_input, cbor, ta_store, &settings_file(dir));
+}
+
+/// As [`generate`], with the settings file named by the caller so a test can vary what the settings
+/// ask for independently of the arguments.
+fn generate_with_settings(ca_input: &str, cbor: &Path, ta_store: bool, settings: &str) {
     run(Pittv3Args {
         ta_folder: Some(example("TrustAnchorRootCertificate.crt")),
         ca_folder: Some(ca_input.to_string()),
         cbor: Some(cbor.to_str().unwrap().to_string()),
         generate: true,
         cbor_ta_store: ta_store,
-        settings: Some(settings_file(dir)),
+        settings: Some(settings.to_string()),
         time_of_interest: TOI,
         ..Default::default()
     });
@@ -189,5 +204,42 @@ fn generates_a_ca_store_from_a_folder() {
         Some(cbor.to_str().unwrap().to_string()),
     );
 
+    assert_eq!(TargetStatus::Valid, report.targets[0].status);
+}
+
+/// A settings file can turn `cbor_ta_store` on without the flag.
+///
+/// The argument is a bare flag, so its absence is the same `false` as an explicit denial and cannot
+/// be allowed to overwrite a settings value. The CA input is a single self-signed root because that
+/// makes the two outcomes tell each other apart: as a trust anchor store it yields a usable store,
+/// while a store of intermediates and partial paths has nothing to hold and no file is written at
+/// all -- so the file-existence assertion is what fails if the setting is not honored.
+#[test]
+fn a_settings_file_can_turn_on_cbor_ta_store() {
+    let dir = tempfile::tempdir().unwrap();
+    let cbor = dir.path().join("ta.cbor");
+
+    // The flag is false; only the settings file asks for a trust anchor store.
+    generate_with_settings(
+        &example("TrustAnchorRootCertificate.crt"),
+        &cbor,
+        false,
+        &settings_file_named(dir.path(), "settings-ta-store.json", true),
+    );
+
+    assert!(cbor.is_file());
+
+    // Usable as a trust anchor store, which is what distinguishes the two kinds: the same
+    // assertions the flag-driven test makes.
+    let report = validate(
+        dir.path(),
+        None,
+        Some(cbor.to_str().unwrap().to_string()),
+        Some(example("GoodCACert.crt")),
+        None,
+    );
+
+    assert_eq!(None, report.error);
+    assert_eq!(1, report.totals.valid_paths);
     assert_eq!(TargetStatus::Valid, report.targets[0].status);
 }


### PR DESCRIPTION
- remove duplicative is trust anchor check
- add comments re: election to flatly reject min/max values that are not conformant with RFC5280 in name constraints
- fix bug that prevented settings file CBOR TA store setting from taking effect