### PR TITLE
augment default settings since a no-std build has no clock 

### DIFF
--- a/pittv3-service/src/orchestrate.rs
+++ b/pittv3-service/src/orchestrate.rs
@@ -472,17 +472,19 @@ fn check_limits(limits: &RequestLimits, input: &ValidationInput) -> Result<(), S
     Ok(())
 }
 
-/// Returns the time the run validated against, for stamping the report: the time of interest from
-/// the settings, or the current time when validity checking was left at its default.
+/// Returns the time the run validated against, for stamping the report.
+///
+/// This is the accessor `check_validity` itself consults, so the report names the value that
+/// decided the check rather than a second opinion about it. It resolves three ways: the time the
+/// settings state, `now()` when they state none and certval was built with `std`, and **0 when they
+/// state none and it was not** — the case that matters here, since a `no_std` build has no clock,
+/// the validity check is skipped, and 0 is what `ValidationReport::time_of_interest` documents as
+/// "validity checking was disabled" and what the frontends render as "disabled".
+///
+/// Substituting the current time for that 0 is what this used to do, and it reported a check that
+/// had not happened.
 fn time_of_interest(settings: &CertificationPathSettings) -> u64 {
-    let toi = settings.get_time_of_interest();
-    if !toi.is_disabled() {
-        return toi.as_unix_secs();
-    }
-    std::time::SystemTime::now()
-        .duration_since(std::time::UNIX_EPOCH)
-        .map(|d| d.as_secs())
-        .unwrap_or(0)
+    settings.get_time_of_interest().as_unix_secs()
 }
 
 #[cfg(test)]
@@ -529,12 +531,26 @@ mod tests {
         assert!(check_limits(&limits, &acceptable).is_ok());
     }
 
+    /// The stamp is whatever the accessor resolves, unaltered. Here that is 0 — certval is built
+    /// without `std` in this crate, so settings stating no time of interest resolve to a disabled
+    /// one, the validity check is skipped, and `ValidationReport::time_of_interest` documents 0 as
+    /// exactly that. The previous version replaced this 0 with the current time, which reported a
+    /// check the run had not made; a request reaching `/api/validate` no longer arrives this way
+    /// (`settings::defaults` states the time), but any other caller still can.
     #[test]
-    fn an_absent_time_of_interest_stamps_the_report_with_now() {
+    fn disabled_toi_test() {
         let mut settings = CertificationPathSettings::default();
-        assert!(time_of_interest(&settings) > 0);
+        assert_eq!(time_of_interest(&settings), 0);
 
         settings.set_time_of_interest(TimeOfInterest::from_unix_secs(1_700_000_000).unwrap());
         assert_eq!(time_of_interest(&settings), 1_700_000_000);
+    }
+
+    /// The settings a request actually runs under state a time, so the report names it rather than
+    /// reporting the run as unchecked -- the pairing of `settings::defaults` with the accessor
+    /// above, which is what keeps a stamped report and a performed check in agreement.
+    #[test]
+    fn service_supplied_toi_test() {
+        assert!(time_of_interest(&crate::settings::with_defaults(None)) > 0);
     }
 }

--- a/pittv3-service/src/routes.rs
+++ b/pittv3-service/src/routes.rs
@@ -193,7 +193,7 @@ async fn validate(
             .collect(),
         cas: body.cas.into_iter().map(|c| (c.name, c.der)).collect(),
         store_id: body.store_id,
-        settings: body.settings.unwrap_or_default(),
+        settings: crate::settings::with_defaults(body.settings),
         validate_all: body.validate_all,
     };
 

--- a/pittv3-service/src/settings.rs
+++ b/pittv3-service/src/settings.rs
@@ -1,14 +1,64 @@
-//! Sanitizing the path settings that arrive with a validation request.
+//! The settings a validation request runs under: the service's own defaults, and the sanitizing of
+//! what a client sends.
 //!
 //! `CertificationPathSettings` is the tool's own configuration structure, not a wire format. It
 //! carries folder and file names that mean nothing on the far side of an HTTP request and that a
 //! service must not act on, and it carries retrieval ceilings sized for a command-line run rather
 //! than for a shared server. Both are dealt with here, on arrival, rather than by trusting a client
 //! to have omitted them.
+//!
+//! What a request *omits* is settled here too, and by this service rather than by its dependencies.
+//! certval is built here without `std`, which is a build with no clock — `SystemTime` does not
+//! exist in `no_std` — so `TimeOfInterest` has nothing to default to and the time a run validates
+//! against is the caller's to supply. This service is that caller. Leaving it unstated is not a
+//! narrower check but no check: `check_validity` returns `Ok(())` when the time of interest is
+//! disabled, so an omitted value meant a certificate's validity period was never consulted.
+//! [`defaults`] states what a run means instead of leaving an obligation unmet.
 
 use certval::*;
 
 use crate::config::ServiceConfig;
+
+/// The settings a request runs under before anything the client sent is applied.
+///
+/// Written as a profile rather than as one fix, so the next value a `no_std` build leaves to its
+/// caller does not have to be discovered the way this one was — by an expired certificate coming
+/// back valid.
+///
+/// **Time of interest: now.** A `no_std` build has no clock, so certval cannot supply this and does
+/// not pretend to; the time a run validates against is the caller's to state, and `check_validity`
+/// returns `Ok(())` when none was. Leaving it unstated is therefore not a wider validity window but
+/// the absence of the check. The browser frontend states the same value for the same reason
+/// (`pittv3-wasm`'s `run_settings`), which is what keeps a served run and a page run answering
+/// alike.
+pub fn defaults() -> CertificationPathSettings {
+    let mut settings = CertificationPathSettings::default();
+    if let Ok(toi) = TimeOfInterest::from_unix_secs(now_as_unix_secs()) {
+        settings.set_time_of_interest(toi);
+    }
+    settings
+}
+
+/// Applies `requested` over the service's [`defaults`], returning what the run should use.
+///
+/// An overlay rather than a replacement: a client that states one preference is saying what it
+/// wants *differently*, not asking every other value to revert to unstated. Without this, sending
+/// any settings at all would reintroduce the unstated time of interest that sending none used to
+/// produce.
+pub fn with_defaults(requested: Option<CertificationPathSettings>) -> CertificationPathSettings {
+    let mut settings = defaults();
+    if let Some(requested) = requested {
+        settings.0.extend(requested.0);
+    }
+    settings
+}
+
+fn now_as_unix_secs() -> u64 {
+    std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .map(|d| d.as_secs())
+        .unwrap_or(0)
+}
 
 /// Settings naming a location in the filesystem. A client cannot see the service's filesystem and
 /// has no business steering it there, so these are removed outright rather than validated.
@@ -100,6 +150,50 @@ mod tests {
             cps.0.insert(k.to_string(), v);
         }
         cps
+    }
+
+    /// A run has to validate against a time, and in a build with no clock that time arrives from
+    /// here or not at all. An unstated one is not a wider window: `check_validity` returns without
+    /// consulting a validity period.
+    #[test]
+    fn a_request_that_states_no_settings_still_validates_against_a_time() {
+        let bare = CertificationPathSettings::default();
+        assert!(
+            bare.get_time_of_interest().is_disabled(),
+            "the premise of this test is that the bare default states no time"
+        );
+
+        let settings = with_defaults(None);
+        assert!(!settings.get_time_of_interest().is_disabled());
+    }
+
+    /// Stating one preference says what a run should do differently; it does not withdraw the rest.
+    /// Replacing rather than overlaying would have put the unstated time of interest back for every
+    /// caller who sent any settings at all.
+    #[test]
+    fn stated_settings_ride_on_top_of_the_defaults_rather_than_replacing_them() {
+        let requested = settings_with(vec![(
+            PS_CHECK_REVOCATION_STATUS,
+            CertificationPathProcessingTypes::Bool(false),
+        )]);
+
+        let settings = with_defaults(Some(requested));
+        assert!(!settings.get_check_revocation_status());
+        assert!(!settings.get_time_of_interest().is_disabled());
+    }
+
+    /// The defaults are a floor, not a ceiling: a caller asking about a certificate as of some past
+    /// date gets that date, which is the whole point of the setting.
+    #[test]
+    fn a_stated_time_of_interest_wins() {
+        let mut requested = CertificationPathSettings::new();
+        requested.set_time_of_interest(TimeOfInterest::from_unix_secs(1_647_264_981).unwrap());
+
+        let settings = with_defaults(Some(requested));
+        assert_eq!(
+            settings.get_time_of_interest().as_unix_secs(),
+            1_647_264_981
+        );
     }
 
     #[test]

--- a/pittv3-service/tools/validate_api.py
+++ b/pittv3-service/tools/validate_api.py
@@ -1,0 +1,317 @@
+#!/usr/bin/env python3
+"""Exercises `POST /api/validate` from outside the service.
+
+The endpoint is the middle ground left behind when a full hosted PITTv3 was decided against: the
+browser application validates in the page and never posts here, so a script is the client. That
+makes this the only thing that drives `orchestrate::validate` end to end, and the only way a
+breakpoint in the service's validation path fires without a request hand-assembled in curl.
+
+Certificates travel as base64 because JSON has no bytes. DER and PEM are both accepted -- the
+service decodes either -- so files are read as bytes and encoded as they are.
+
+    # what the service holds
+    validate_api.py --stores
+
+    # one certificate against a store the service names
+    validate_api.py --store-id dod_nipr_prod ee.der
+
+    # against anchors and intermediates carried in the request instead
+    validate_api.py --ta root.der --ca intermediate.der ee.der
+
+    # every path for each target, not just the first that validates
+    validate_api.py --store-id webpki --validate-all ee.der
+
+    # the whole report rather than a summary
+    validate_api.py --store-id fpki --json ee.der
+
+    # take a live host's chain and validate what it presented, in one call
+    validate_api.py --peek letsencrypt.org --store-id webpki_tls
+
+    # retrieve one artifact through the relay, without validating anything
+    validate_api.py --fetch http://crl.example.com/ca.crl
+
+Run a service to point it at, or name a deployed one with --base:
+
+    cargo run -p pittv3-service -- --bind 127.0.0.1:8080
+
+Exit status is 0 when every target validated, 1 when any did not, and 2 when the request itself
+failed -- so a caller can gate on the verdict without reading the report.
+"""
+
+import argparse
+import base64
+import json
+import sys
+import urllib.error
+import urllib.request
+from pathlib import Path
+
+DEFAULT_BASE = "http://127.0.0.1:8080"
+
+
+def post(base, path, body, timeout):
+    """Posts JSON and returns the parsed response.
+
+    A refusal carries an `error` string and a status this script reports rather than translates:
+    404 means the route is off (`--no-validation`), and a 4xx from the policy is a decision the
+    service made about the request, not a failure to reach it.
+    """
+    request = urllib.request.Request(
+        f"{base}{path}",
+        data=json.dumps(body).encode(),
+        headers={"Content-Type": "application/json"},
+        method="POST",
+    )
+    try:
+        with urllib.request.urlopen(request, timeout=timeout) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as e:
+        detail = e.read().decode(errors="replace")
+        try:
+            detail = json.loads(detail).get("error", detail)
+        except json.JSONDecodeError:
+            pass
+        raise SystemExit(f"{path}: HTTP {e.code}: {detail}")
+    except urllib.error.URLError as e:
+        raise SystemExit(f"{path}: could not reach {base}: {e.reason}")
+
+
+def get(base, path, timeout):
+    try:
+        with urllib.request.urlopen(f"{base}{path}", timeout=timeout) as response:
+            return json.loads(response.read())
+    except urllib.error.HTTPError as e:
+        raise SystemExit(f"{path}: HTTP {e.code}")
+    except urllib.error.URLError as e:
+        raise SystemExit(f"{path}: could not reach {base}: {e.reason}")
+
+
+def named(paths):
+    """Reads each file into the `{name, der}` pair the endpoint takes.
+
+    The name is the client's label and is what appears in the report, so the file name is used --
+    it is what the person running this has in hand when reading the results.
+    """
+    certificates = []
+    for path in paths:
+        p = Path(path)
+        if not p.is_file():
+            raise SystemExit(f"{path}: not a file")
+        certificates.append(
+            {"name": p.name, "der": base64.b64encode(p.read_bytes()).decode()}
+        )
+    return certificates
+
+
+def peeked_certificates(base, host, timeout):
+    """Takes a host's chain through `/api/tls` and returns it as `NamedCertificate` values.
+
+    The server sends its own certificate first and its issuers after, so the first becomes the
+    target and the rest become CA input. Nothing here enforces that order -- a server that does not
+    follow it is the kind of finding this exists to surface -- so the names carry the position, and
+    a chain that came back in another order shows up as a target that finds no path rather than as
+    a silent reordering.
+    """
+    response = post(base, "/api/tls", {"uri": host}, timeout)
+    certificates = response.get("certificates", [])
+    if not certificates:
+        raise SystemExit(f"{host}: the handshake completed but presented no certificate")
+
+    label = f"{response['host']}:{response['port']}"
+    print(
+        f"{label} presented {len(certificates)} certificate(s) over "
+        f"{response.get('protocol') or 'an unreported protocol'}"
+        + (", with a stapled OCSP response" if response.get("stapled_ocsp") else "")
+    )
+    named_certs = [
+        {"name": f"{label}[{i}]", "der": der} for i, der in enumerate(certificates)
+    ]
+    return named_certs[0], named_certs[1:], response.get("stapled_ocsp")
+
+
+def verdict(report, accepted):
+    """True when every target reached one of the `accepted` statuses.
+
+    Separate from the printing because `--json` prints the report instead of a summary and still
+    has to exit on the same reading of it.
+    """
+    targets = report.get("targets", [])
+    return bool(targets) and all(t.get("status") in accepted for t in targets)
+
+
+def summarize(report):
+    """Prints a target-per-line summary.
+
+    A target that yielded no path carries its reason on `error` rather than a path list, so that
+    case is printed as what it is instead of as zero valid paths.
+    """
+    totals = report.get("totals", {})
+    print(
+        f"{totals.get('targets', 0)} target(s), {totals.get('paths_found', 0)} path(s), "
+        f"{totals.get('valid_paths', 0)} valid, {totals.get('invalid_paths', 0)} invalid "
+        f"in {report.get('duration_ms', 0)} ms"
+    )
+
+    for note in report.get("notes", []):
+        print(f"  note: {note}")
+
+    for target in report.get("targets", []):
+        status = target.get("status")
+        paths = target.get("paths", [])
+        valid = sum(
+            1 for p in paths if p.get("error") is None and p.get("status") == "Valid"
+        )
+        if target.get("error"):
+            print(f"  {target.get('name')}: {status} -- {target['error']}")
+            continue
+        print(f"  {target.get('name')}: {status} ({valid}/{len(paths)} path(s) valid)")
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Calls POST /api/validate on a running pittv3-service.",
+        epilog="Exit status: 0 all targets valid, 1 some not, 2 the request failed.",
+    )
+    parser.add_argument("targets", nargs="*", help="certificate files to validate")
+    parser.add_argument(
+        "--base", default=DEFAULT_BASE, help=f"service base URI (default {DEFAULT_BASE})"
+    )
+    parser.add_argument(
+        "--store-id",
+        help="identifier of a store the service holds; see --stores for what it offers",
+    )
+    parser.add_argument(
+        "--ta",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help="trust anchor to carry in the request, repeatable",
+    )
+    parser.add_argument(
+        "--ca",
+        action="append",
+        default=[],
+        metavar="FILE",
+        help="intermediate to carry in the request, repeatable",
+    )
+    parser.add_argument(
+        "--settings",
+        metavar="FILE",
+        help="JSON CertificationPathSettings for the run; the service sanitizes what it will not honor",
+    )
+    parser.add_argument(
+        "--validate-all",
+        action="store_true",
+        help="validate every path found rather than stopping at the first that validates",
+    )
+    parser.add_argument(
+        "--allow-undetermined",
+        action="store_true",
+        help="count ValidExceptRevocationUndetermined as success; for a service run with "
+        "--no-revocation-fetch, or a run whose revocation data was not supplied",
+    )
+    parser.add_argument(
+        "--peek",
+        metavar="HOST",
+        help="take the chain HOST presents over TLS and validate it, instead of reading files; "
+        "the certificate the server sends first is the target and the rest are CA input",
+    )
+    parser.add_argument(
+        "--fetch",
+        metavar="URI",
+        help="retrieve one artifact through the relay and report what came back, then exit",
+    )
+    parser.add_argument(
+        "--stores", action="store_true", help="list the stores the service holds and exit"
+    )
+    parser.add_argument(
+        "--json", action="store_true", help="print the whole report instead of a summary"
+    )
+    parser.add_argument(
+        "--timeout",
+        type=float,
+        default=120.0,
+        help="seconds to wait; a run that retrieves can be slow (default 120)",
+    )
+    args = parser.parse_args()
+
+    base = args.base.rstrip("/")
+
+    if args.stores:
+        for store in get(base, "/api/stores", args.timeout):
+            # A store carrying trust anchors alone offers no ca_url, and asking for one is a 404
+            # rather than an empty artifact -- worth showing here so that is not a surprise.
+            halves = "ta+ca" if store.get("ca_url") else "ta only"
+            print(
+                f"{store['id']:<20} {store.get('label', '')}  "
+                f"[{store.get('provenance')}, {halves}]"
+            )
+        return 0
+
+    if args.fetch:
+        got = post(base, "/api/fetch", {"uri": args.fetch}, args.timeout)
+        body = base64.b64decode(got["body"])
+        print(
+            f"{got['status']} {got.get('content_type') or 'no content type'} "
+            f"{len(body)} bytes from {got['final_uri']}"
+            + (f" (last modified {got['last_modified']})" if got.get("last_modified") else "")
+        )
+        # A repository's own 4xx is reported, not translated: the relay reached it and this is what
+        # it said. Only a refusal to make the request at all comes back as an error.
+        return 0 if got["status"] < 400 else 1
+
+    if args.peek and args.targets:
+        parser.error("--peek supplies the certificates; do not also name files")
+    if not args.peek and not args.targets:
+        parser.error(
+            "name at least one certificate to validate, or pass --peek, --fetch or --stores"
+        )
+    if not args.store_id and not args.ta:
+        parser.error(
+            "a run needs anchors: pass --store-id, or --ta, or both (a store plus extra anchors)"
+        )
+
+    if args.peek:
+        target, chain, _stapled = peeked_certificates(base, args.peek, args.timeout)
+        targets, cas = [target], chain + named(args.ca)
+    else:
+        targets, cas = named(args.targets), named(args.ca)
+
+    body = {
+        "targets": targets,
+        "trust_anchors": named(args.ta),
+        "cas": cas,
+        "validate_all": args.validate_all,
+    }
+    if args.store_id:
+        body["store_id"] = args.store_id
+    if args.settings:
+        body["settings"] = json.loads(Path(args.settings).read_text())
+
+    report = post(base, "/api/validate", body, args.timeout)
+
+    # The service reports a run that could not start as an error on the report itself, which is not
+    # the same as a run whose targets came back invalid.
+    if report.get("error"):
+        print(f"the run did not complete: {report['error']}", file=sys.stderr)
+        return 2
+
+    if args.json:
+        print(json.dumps(report, indent=2))
+    else:
+        summarize(report)
+
+    accepted = {"Valid"}
+    if args.allow_undetermined:
+        accepted.add("ValidExceptRevocationUndetermined")
+    return 0 if verdict(report, accepted) else 1
+
+
+if __name__ == "__main__":
+    try:
+        sys.exit(main())
+    except SystemExit as e:
+        if isinstance(e.code, str):
+            print(e.code, file=sys.stderr)
+            sys.exit(2)
+        raise


### PR DESCRIPTION
- by necessity, no-std builds default to not checking validity unless the caller supplies a time of interest. this commit changes the service to provide "now". 
- adds python script to exercise the sample service api (which is what surfaced the issue noted above).