### PR TITLE
Add on-demand artifact save to pittv3-gui

### DIFF
--- a/pittv3-gui-lib/assets/pittv3.css
+++ b/pittv3-gui-lib/assets/pittv3.css
@@ -192,8 +192,19 @@ button[type="submit"] {
 
 .results-header {
   display: flex;
+  flex-wrap: wrap;
+  align-items: center;
   gap: 0.5rem;
   margin: 0.25rem 0 0.5rem 0;
+}
+
+/* The actions keep their natural width. As flex children they shrink by default, and once the row
+   held enough of them the labels wrapped *inside* the buttons rather than the row wrapping between
+   them -- two-line buttons reading "Save / report". If the row genuinely does not fit, flex-wrap
+   above breaks it between buttons instead. */
+.results-header > * {
+  flex: 0 0 auto;
+  white-space: nowrap;
 }
 
 /* Name for an export, sized to the name rather than to the row: it sits among buttons, and the

--- a/pittv3-gui-lib/src/validate.rs
+++ b/pittv3-gui-lib/src/validate.rs
@@ -281,27 +281,11 @@ pub fn validate_prepared(
     (reports, out)
 }
 
-/// One validated path, kept so the artifacts behind it can be exported afterwards.
-///
-/// The path and the results are what an export is assembled from; the settings are the ones that
-/// path was validated under, which is not the run's settings — RFC 5937 trust anchor constraints are
-/// folded in per path — so a manifest reporting the run's would describe inputs the path was not
-/// judged against.
-///
-/// Nothing is computed to produce these. The path and results exist for the duration of the
-/// validation regardless; retaining them is declining to drop them, which is why this is a caller's
-/// choice at the call site rather than a setting a user has to know to turn on before a run they
-/// have not seen the outcome of yet.
-pub struct RetainedPath {
-    /// Name of the target this path was built for, as the caller supplied it
-    pub target_name: String,
-    /// The path as validated
-    pub path: CertificationPath,
-    /// The settings this path was validated under
-    pub cps: CertificationPathSettings,
-    /// The results recorded while validating it
-    pub cpr: CertificationPathResults,
-}
+// Re-exported rather than defined here: `pittv3_lib::std_utils` retains the same type, so an export
+// written against it works with a run this crate prepared and validated or with one the lower crate
+// carried out end to end. Kept in this module's namespace because that is where callers already
+// reach for it.
+pub use pittv3_lib::retained::RetainedPath;
 
 /// As [`validate_prepared`], additionally returning each validated path when `retain` is set, so a
 /// frontend can export the artifacts behind a result without validating a second time.

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -19,6 +19,9 @@ use pittv3_lib::der_or_pem::SINGLE_CERT_EXTENSIONS;
 #[cfg(not(target_os = "macos"))]
 use pittv3_lib::der_or_pem::TA_BUNDLE_EXTENSIONS;
 
+use std::sync::Mutex;
+
+use crate::save::{self, RetainedArtifacts, DEFAULT_EXPORT_NAME};
 use pittv3_gui_lib::gui_end_entity::EndEntityGroup;
 use pittv3_gui_lib::gui_help::HelpView;
 use pittv3_gui_lib::gui_results::{ResultsView, RunEvent};
@@ -35,7 +38,7 @@ use pittv3_gui_lib::settings_store::{default_settings_path, expand_tilde};
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
 use pittv3_lib::graph_cache;
-use pittv3_lib::options_std::options_std;
+use pittv3_lib::options_std::options_std_retaining;
 use pittv3_lib::report::ValidationReport;
 use pittv3_lib::std_utils::{
     count_ca_inputs, count_end_entity_inputs, count_revocation_inputs, count_trust_anchor_inputs,
@@ -165,6 +168,40 @@ async fn pick_file_or_folder_into(mut sig: Signal<String>) {
         .await;
     if let Some(picked) = picked {
         sig.set(picked.path().to_string_lossy().to_string());
+    }
+}
+
+/// Asks where to put an export and writes it there, reporting either outcome into the run log.
+///
+/// A save dialog rather than a fixed location: this is the user's own copy of what a run used, and
+/// the desktop's other writes -- the peek folder, a materialized store -- go under the application
+/// home precisely because nobody chose where they should live. Here somebody is choosing.
+async fn write_export(
+    suggested: String,
+    extensions: &[&str],
+    bytes: Vec<u8>,
+    mut log: Signal<Vec<String>>,
+) {
+    let Some(handle) = AsyncFileDialog::new()
+        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_file_name(&suggested)
+        .add_filter("export", extensions)
+        .save_file()
+        .await
+    else {
+        // A cancelled dialog is a decision, not a failure, and saying so would be noise.
+        return;
+    };
+    let path = handle.path().to_path_buf();
+    match std::fs::write(&path, &bytes) {
+        Ok(()) => log.write().push(format!(
+            "Saved {} byte(s) to {}",
+            bytes.len(),
+            path.display()
+        )),
+        Err(e) => log
+            .write()
+            .push(format!("Failed to write {}: {e}", path.display())),
     }
 }
 
@@ -1024,6 +1061,14 @@ pub(crate) fn App() -> Element {
     let mut s_view = use_signal(|| View::Validate);
     let mut s_running = use_signal(|| false);
     let mut s_report = use_signal(|| None::<ValidationReport>);
+    // What the last run kept, so the results view can save the artifacts behind it without
+    // validating a second time. Held outside the signal system because the run produces it on a
+    // worker thread; see `save::RetainedArtifacts`.
+    let retained: RetainedArtifacts = use_hook(|| Arc::new(Mutex::new(None)));
+    let mut s_export_name = use_signal(|| DEFAULT_EXPORT_NAME.to_string());
+    // Whether the last run left anything to save. The artifacts live behind a mutex the worker
+    // thread fills, which the rsx cannot observe, so the buttons key off this instead.
+    let mut s_can_export = use_signal(|| false);
     let mut s_uri_dialog_open = use_signal(|| false);
     let mut s_log = use_signal(Vec::<String>::new);
 
@@ -1140,126 +1185,196 @@ pub(crate) fn App() -> Element {
         });
     };
 
-    let run_command = move |_: ()| {
-        if s_running() {
-            return;
-        }
-        let args = match current_args() {
-            Ok(args) => args,
-            Err(msg) => {
-                error!("{msg}");
-                s_log.write().push(msg);
-                s_view.set(View::Results);
+    let run_command = {
+        let retained = retained.clone();
+        move |_: ()| {
+            if s_running() {
                 return;
             }
-        };
-
-        let _ = save_args(&args);
-
-        let mut logging_configured = false;
-
-        if let Some(logging_config) = &args.logging_config {
-            if let Err(e) = log4rs::init_file(logging_config, Default::default()) {
-                println!(
-                    "ERROR: failed to configure logging using {logging_config} with {e:?}. Continuing without logging."
-                );
-            } else {
-                logging_configured = true;
-            }
-        }
-
-        if !logging_configured {
-            // if there's no config, prepare one using stdout plus the channel appender that
-            // streams run output into the Results view (log4rs initialization is one-shot per
-            // process; subsequent attempts fail harmlessly and logging keeps its first shape)
-            let stdout = ConsoleAppender::builder()
-                .encoder(Box::new(PatternEncoder::new("{m}{n}")))
-                .build();
-            match Config::builder()
-                .appender(Appender::builder().build("stdout", Box::new(stdout)))
-                .appender(Appender::builder().build("channel", Box::new(ChannelAppender)))
-                .build(
-                    Root::builder()
-                        .appender("stdout")
-                        .appender("channel")
-                        .build(LevelFilter::Info),
-                ) {
-                Ok(config) => {
-                    let handle = log4rs::init_config(config);
-                    if let Err(e) = handle {
-                        println!(
-                            "ERROR: failed to configure logging for stdout with {e:?}. Continuing without logging."
-                        );
-                    }
-                }
-                Err(e) => {
-                    println!("ERROR: failed to prepare default logging configuration with {e:?}. Continuing without logging");
-                }
-            }
-        }
-
-        debug!("PITTv3 start");
-
-        s_running.set(true);
-        s_report.set(None);
-        s_log.write().clear();
-        s_view.set(View::Results);
-
-        let (tx, mut rx) = futures_channel::mpsc::unbounded::<RunEvent>();
-        let (log_tx, mut log_rx) = futures_channel::mpsc::unbounded::<String>();
-        set_log_sink(log_tx);
-
-        // execute the run on a worker thread with its own runtime; awaiting options_std on the
-        // UI executor would block the WebView for the duration of the run
-        std::thread::spawn(move || {
-            let rt = match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(rt) => rt,
-                Err(e) => {
-                    let _ = tx.unbounded_send(RunEvent::Failed(format!(
-                        "failed to start runtime for validation run: {e}"
-                    )));
+            let args = match current_args() {
+                Ok(args) => args,
+                Err(msg) => {
+                    error!("{msg}");
+                    s_log.write().push(msg);
+                    s_view.set(View::Results);
                     return;
                 }
             };
-            let report = rt.block_on(options_std(&args));
-            debug!("PITTv3 end");
-            // A report carrying an error means the run could not be carried out (e.g. a missing
-            // required input). Surface it as a failure instead of an empty Results view.
-            let event = match report.error.clone() {
-                Some(msg) => RunEvent::Failed(msg),
-                None => RunEvent::Done(Box::new(report)),
-            };
-            let _ = tx.unbounded_send(event);
-        });
 
-        // apply run events and log lines to signals from tasks on the UI executor (signals must
-        // not be written from the worker thread)
-        spawn(async move {
-            while let Some(line) = log_rx.next().await {
-                s_log.write().push(line);
+            let _ = save_args(&args);
+
+            let mut logging_configured = false;
+
+            if let Some(logging_config) = &args.logging_config {
+                if let Err(e) = log4rs::init_file(logging_config, Default::default()) {
+                    println!(
+                    "ERROR: failed to configure logging using {logging_config} with {e:?}. Continuing without logging."
+                );
+                } else {
+                    logging_configured = true;
+                }
             }
-        });
-        spawn(async move {
-            while let Some(ev) = rx.next().await {
-                match ev {
-                    RunEvent::Progress(_p) => {}
-                    RunEvent::Done(report) => {
-                        clear_log_sink();
-                        s_report.set(Some(*report));
-                        s_running.set(false);
+
+            if !logging_configured {
+                // if there's no config, prepare one using stdout plus the channel appender that
+                // streams run output into the Results view (log4rs initialization is one-shot per
+                // process; subsequent attempts fail harmlessly and logging keeps its first shape)
+                let stdout = ConsoleAppender::builder()
+                    .encoder(Box::new(PatternEncoder::new("{m}{n}")))
+                    .build();
+                match Config::builder()
+                    .appender(Appender::builder().build("stdout", Box::new(stdout)))
+                    .appender(Appender::builder().build("channel", Box::new(ChannelAppender)))
+                    .build(
+                        Root::builder()
+                            .appender("stdout")
+                            .appender("channel")
+                            .build(LevelFilter::Info),
+                    ) {
+                    Ok(config) => {
+                        let handle = log4rs::init_config(config);
+                        if let Err(e) = handle {
+                            println!(
+                            "ERROR: failed to configure logging for stdout with {e:?}. Continuing without logging."
+                        );
+                        }
                     }
-                    RunEvent::Failed(msg) => {
-                        clear_log_sink();
-                        error!("{msg}");
-                        s_log.write().push(msg);
-                        s_running.set(false);
+                    Err(e) => {
+                        println!("ERROR: failed to prepare default logging configuration with {e:?}. Continuing without logging");
                     }
                 }
             }
-        });
+
+            debug!("PITTv3 start");
+
+            s_running.set(true);
+            s_report.set(None);
+            s_log.write().clear();
+            s_view.set(View::Results);
+
+            let (tx, mut rx) = futures_channel::mpsc::unbounded::<RunEvent>();
+            let (log_tx, mut log_rx) = futures_channel::mpsc::unbounded::<String>();
+            set_log_sink(log_tx);
+            // A fresh run replaces what the previous one kept, so the buttons never offer artifacts
+            // belonging to a run that is no longer on screen.
+            if let Ok(mut held) = retained.lock() {
+                *held = None;
+            }
+            s_can_export.set(false);
+            let run_retained = retained.clone();
+            let done_retained = retained.clone();
+
+            // execute the run on a worker thread with its own runtime; awaiting options_std on the
+            // UI executor would block the WebView for the duration of the run
+            std::thread::spawn(move || {
+                let rt = match tokio::runtime::Builder::new_current_thread()
+                    .enable_all()
+                    .build()
+                {
+                    Ok(rt) => rt,
+                    Err(e) => {
+                        let _ = tx.unbounded_send(RunEvent::Failed(format!(
+                            "failed to start runtime for validation run: {e}"
+                        )));
+                        return;
+                    }
+                };
+                // Retention is asked for here and nowhere else: the desktop offers the artifacts after
+                // a run, so it keeps what the run built. The CLI passes false and pays nothing.
+                let (report, run_artifacts) = rt.block_on(options_std_retaining(&args, true));
+                if let Ok(mut held) = run_retained.lock() {
+                    *held = run_artifacts;
+                }
+                debug!("PITTv3 end");
+                // A report carrying an error means the run could not be carried out (e.g. a missing
+                // required input). Surface it as a failure instead of an empty Results view.
+                let event = match report.error.clone() {
+                    Some(msg) => RunEvent::Failed(msg),
+                    None => RunEvent::Done(Box::new(report)),
+                };
+                let _ = tx.unbounded_send(event);
+            });
+
+            // apply run events and log lines to signals from tasks on the UI executor (signals must
+            // not be written from the worker thread)
+            spawn(async move {
+                while let Some(line) = log_rx.next().await {
+                    s_log.write().push(line);
+                }
+            });
+            spawn(async move {
+                while let Some(ev) = rx.next().await {
+                    match ev {
+                        RunEvent::Progress(_p) => {}
+                        RunEvent::Done(report) => {
+                            clear_log_sink();
+                            s_report.set(Some(*report));
+                            // A run that validated nothing leaves nothing to export, which is a
+                            // different state from a run that has not happened yet -- both
+                            // disable the buttons, and neither is an error.
+                            s_can_export.set(
+                                done_retained
+                                    .lock()
+                                    .map(|held| {
+                                        held.as_ref().is_some_and(|run| !run.paths.is_empty())
+                                    })
+                                    .unwrap_or(false),
+                            );
+                            s_running.set(false);
+                        }
+                        RunEvent::Failed(msg) => {
+                            clear_log_sink();
+                            error!("{msg}");
+                            s_log.write().push(msg);
+                            s_running.set(false);
+                        }
+                    }
+                }
+            });
+        }
+    };
+
+    // Saves every retained path's artifacts as one zip -- the same archive the browser downloads,
+    // written where the user says instead of into a download.
+    let save_artifacts = {
+        let retained = retained.clone();
+        move |_: MouseEvent| {
+            let retained = retained.clone();
+            let name = save::export_name(&s_export_name());
+            spawn(async move {
+                match save::artifacts_archive(&retained, &name) {
+                    Ok(None) => s_log
+                        .write()
+                        .push("No validated paths are held from this run to save".to_string()),
+                    Err(e) => s_log
+                        .write()
+                        .push(format!("Failed to build the archive: {e}")),
+                    Ok(Some(bytes)) => {
+                        write_export(format!("{name}.zip"), &["zip"], bytes, s_log).await
+                    }
+                }
+            });
+        }
+    };
+
+    // Saves the manifests alone: every path's account of itself, without the material behind them.
+    let save_path_logs = {
+        let retained = retained.clone();
+        move |_: MouseEvent| {
+            let retained = retained.clone();
+            let name = save::export_name(&s_export_name());
+            spawn(async move {
+                match save::path_logs_text(&retained) {
+                    None => s_log
+                        .write()
+                        .push("No validated paths are held from this run to save".to_string()),
+                    Some(text) => {
+                        write_export(format!("{name}.txt"), &["txt"], text.into_bytes(), s_log)
+                            .await
+                    }
+                }
+            });
+        }
     };
 
     let selected = VIEWS.iter().position(|(v, _)| *v == s_view()).unwrap_or(0);
@@ -1714,7 +1829,33 @@ pub(crate) fn App() -> Element {
                                             spawn(save_report(r));
                                         }
                                     },
-                                    "Save"
+                                    title: "Save the structured report as JSON",
+                                    "Save report"
+                                }
+                                // Saving what a run used is offered here, beside the report, rather
+                                // than below the results: the decision is made after seeing them,
+                                // which is the difference between this and a Results Folder. Same
+                                // order and same archive as the browser.
+                                button {
+                                    r#type: "button",
+                                    disabled: !s_can_export(),
+                                    onclick: save_path_logs,
+                                    title: "Save every path's manifest as one text file",
+                                    "Save path logs"
+                                }
+                                button {
+                                    r#type: "button",
+                                    disabled: !s_can_export(),
+                                    onclick: save_artifacts,
+                                    title: "Save the certificates and revocation data behind every path, as a zip",
+                                    "Save artifacts"
+                                }
+                                input {
+                                    r#type: "text",
+                                    class: "export-name",
+                                    value: "{s_export_name}",
+                                    title: "Name for the export: the archive and the folder inside it",
+                                    oninput: move |e| s_export_name.set(e.value()),
                                 }
                                 button {
                                     r#type: "button",

--- a/pittv3-gui/src/main.rs
+++ b/pittv3-gui/src/main.rs
@@ -4,6 +4,7 @@
 
 mod gui;
 mod peek;
+mod save;
 mod stores;
 
 use dioxus::desktop::{Config, LogicalSize, WindowBuilder};

--- a/pittv3-gui/src/save.rs
+++ b/pittv3-gui/src/save.rs
@@ -1,0 +1,137 @@
+//! Saving the artifacts a validation used, after the run rather than before it.
+//!
+//! A Results Folder is the other way to get this material, and it has to be named before a run
+//! starts. These are for the person who has seen the outcome and only then wants what is behind it,
+//! which is what the browser frontend has offered since it had no filesystem to write to.
+//!
+//! **The archive is the same one the browser produces.** Both call
+//! [`pittv3_gui_lib::export::path_entries`] over the paths a run retained and
+//! [`pittv3_gui_lib::export::zip_paths`] to package them, so a bundle from the desktop and one from
+//! the browser are the same bytes for the same run. The desktop writes it where the user says
+//! instead of triggering a download; that is the whole of the difference.
+//!
+//! Validating again to produce the archive is not an option: revocation data moves, and a responder
+//! asked twice can answer differently, so the material has to come from the run being reported. That
+//! is why the run keeps it — see [`pittv3_lib::retained::RetainedRun`].
+
+use std::sync::{Arc, Mutex};
+
+use pittv3_gui_lib::export::{path_entries, paths_text, zip_paths};
+use pittv3_lib::retained::RetainedRun;
+
+/// What the last run kept, shared between the worker thread that produced it and the UI that offers
+/// to save it.
+///
+/// A mutex rather than a signal because the run happens on its own thread with its own runtime, and
+/// signals may only be written from the UI executor. Nothing contends for it: the worker stores once
+/// when the run finishes and the buttons read it afterwards.
+pub(crate) type RetainedArtifacts = Arc<Mutex<Option<RetainedRun>>>;
+
+/// Builds the per-path export entries once, so an archive and a log describe the same paths in the
+/// same order.
+///
+/// Returns an empty vector when nothing is held, which is the case before the first run and after a
+/// run that found no paths at all.
+fn build_entries(artifacts: &RetainedArtifacts) -> Vec<Vec<(String, Vec<u8>)>> {
+    let guard = match artifacts.lock() {
+        Ok(guard) => guard,
+        // A poisoned mutex means the worker panicked mid-run; the run is not reportable either way,
+        // and refusing to export is better than exporting whatever was written before the panic.
+        Err(_) => return vec![],
+    };
+    let Some(run) = guard.as_ref() else {
+        return vec![];
+    };
+    run.paths
+        .iter()
+        .map(|r| path_entries(&run.environment, &r.path, Some(&r.cps), &r.cpr))
+        .collect()
+}
+
+/// The zip of every retained path's artifacts: the certificates, the revocation data consulted, the
+/// responder certificates that make an OCSP response checkable, and a manifest per path.
+///
+/// `Ok(None)` means there was nothing to save, which the caller reports as such rather than writing
+/// an empty archive.
+pub(crate) fn artifacts_archive(
+    artifacts: &RetainedArtifacts,
+    name: &str,
+) -> Result<Option<Vec<u8>>, String> {
+    let entries = build_entries(artifacts);
+    if entries.is_empty() {
+        return Ok(None);
+    }
+    zip_paths(name, &entries).map(Some)
+}
+
+/// The manifests alone -- every path's account of itself, one after another, without the material
+/// behind them.
+///
+/// Taken from the same entries the archive is built from rather than rendered separately, so the two
+/// cannot disagree about what the run found.
+pub(crate) fn path_logs_text(artifacts: &RetainedArtifacts) -> Option<String> {
+    let entries = build_entries(artifacts);
+    let text = paths_text(&entries);
+    match text.is_empty() {
+        true => None,
+        false => Some(text),
+    }
+}
+
+/// The name an export takes when the user has not chosen one. The field is pre-populated with it,
+/// as the browser's is, so the common case needs no typing and both frontends produce a bundle under
+/// the same name for the same run.
+pub(crate) const DEFAULT_EXPORT_NAME: &str = "PITTv3Results";
+
+/// A filename stem for an export, from what the user typed or [`DEFAULT_EXPORT_NAME`] when the field
+/// has been cleared.
+///
+/// Sanitized because the value names a file and a folder inside the archive: a separator here would
+/// scatter the contents or, worse, land them somewhere other than where the save dialog said.
+pub(crate) fn export_name(typed: &str) -> String {
+    let trimmed = typed.trim();
+    let cleaned: String = trimmed
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' => '_',
+            c => c,
+        })
+        .collect();
+    match cleaned.is_empty() {
+        true => DEFAULT_EXPORT_NAME.to_string(),
+        false => cleaned,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn a_cleared_name_falls_back_to_the_one_the_field_starts_with() {
+        assert_eq!(export_name(""), DEFAULT_EXPORT_NAME);
+        assert_eq!(export_name("   "), DEFAULT_EXPORT_NAME);
+    }
+
+    /// The name reaches a filesystem path and an archive entry, so a separator in it is not a name
+    /// but an instruction about where things land.
+    #[test]
+    fn separators_are_not_carried_into_the_name() {
+        assert_eq!(export_name("../etc/passwd"), ".._etc_passwd");
+        assert_eq!(export_name("C:\\runs\\one"), "C__runs_one");
+    }
+
+    #[test]
+    fn a_typed_name_is_kept_and_trimmed() {
+        assert_eq!(export_name("  dod run 3 "), "dod run 3");
+    }
+
+    /// Nothing retained is not a failure -- it is the state before the first run, and after a run
+    /// that found no paths.
+    #[test]
+    fn nothing_retained_yields_nothing_to_save() {
+        let artifacts: RetainedArtifacts = Arc::new(Mutex::new(None));
+        assert!(artifacts_archive(&artifacts, "run").unwrap().is_none());
+        assert!(path_logs_text(&artifacts).is_none());
+    }
+}

--- a/pittv3-lib/src/lib.rs
+++ b/pittv3-lib/src/lib.rs
@@ -19,6 +19,7 @@ pub mod options_std;
 pub mod options_std_app;
 pub mod pitt_log;
 pub mod report;
+pub mod retained;
 pub mod stats;
 pub mod std_utils;
 pub mod uri_check;

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -134,6 +134,7 @@ use log::{debug, error, info};
 use crate::args::Pittv3Args;
 use crate::graph_cache;
 use crate::report::{ReportTotals, TargetReport, ValidationReport};
+use crate::retained::{RetainedPath, RetainedRun};
 use crate::stats::{PVStats, PathValidationStats, PathValidationStatsGroup};
 use crate::std_utils::*;
 
@@ -207,6 +208,37 @@ fn normalize_pem_wrap(pem: &str) -> Option<String> {
 /// report. The CLI ignores the return value (log/file output is unchanged); GUI and server
 /// frontends consume it.
 pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
+    let (report, _) = options_std_retaining(args, false).await;
+    report
+}
+
+/// As [`options_std`], additionally returning the paths a run validated and the environment it
+/// validated them against when `retain` is set.
+///
+/// This is what lets a frontend offer the artifacts behind a result *after* the run: `results_folder`
+/// answers the same need but has to be named before it starts, and validating a second time to
+/// produce an export would describe a different run, since revocation data moves.
+///
+/// `None` comes back whenever nothing was validated — the actions that generate, clean up, or run a
+/// diagnostic have no paths to keep — and whenever `retain` is false, which is the CLI's case and
+/// costs it nothing.
+pub async fn options_std_retaining(
+    args: &Pittv3Args,
+    retain: bool,
+) -> (ValidationReport, Option<RetainedRun>) {
+    let mut kept = None;
+    let report = options_std_inner(args, retain.then_some(&mut kept)).await;
+    (report, kept)
+}
+
+/// The dispatcher itself. Every action other than validation returns a report and writes nothing to
+/// `kept`, which is why "nothing was retained" needs no code in those branches: the slot the caller
+/// declared simply stays empty.
+#[cfg(feature = "std")]
+async fn options_std_inner(
+    args: &Pittv3Args,
+    kept: Option<&mut Option<RetainedRun>>,
+) -> ValidationReport {
     if args.cleanup {
         // Cleanup runs in isolation before other actions
         let mut pe = PkiEnvironment::default();
@@ -653,7 +685,7 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
         };
     } else {
         // Generate, validate certificate file, or validate certificates folder per args.
-        return generate_and_validate(args).await;
+        return generate_and_validate(args, kept).await;
     }
     ValidationReport::default()
 }
@@ -676,8 +708,17 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
 /// This function demonstrates deserializing a set of buffers and partial paths, attempting validation
 /// then downloading fresh artifacts, updating the buffers and partial paths and trying again until no
 /// further options are available.
+///
+/// When `retain` is set, every validated path is kept and returned with the environment it was
+/// validated against, so a frontend can export the artifacts behind a result once the run is over
+/// rather than having to name a results folder before it starts.
 #[cfg(feature = "std")]
-async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
+async fn generate_and_validate(
+    args: &Pittv3Args,
+    kept: Option<&mut Option<RetainedRun>>,
+) -> ValidationReport {
+    let retain = kept.is_some();
+    let mut retained: Vec<RetainedPath> = vec![];
     // The CBOR file is required (but can be an empty file if doing dynamic building only)
     let cbor_file = if let Some(cbor) = &args.cbor {
         cbor
@@ -1157,6 +1198,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
                         &validate_opts,
                         &mut fresh_uris,
                         threshold,
+                        retain.then_some(&mut retained),
                     )
                     .await;
                 }
@@ -1164,7 +1206,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         }
 
         if let Some(folder) = &args.end_entity_folder {
-            validate_cert_folder(
+            validate_cert_folder_retaining(
                 &pe,
                 &cps,
                 folder.as_str(),
@@ -1172,6 +1214,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
                 &validate_opts,
                 &mut fresh_uris,
                 threshold,
+                retain.then_some(&mut retained),
             )
             .await;
         }
@@ -1182,7 +1225,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
         // once, and sorting them into two arguments first is work the run can do instead.
         for input in &args.ee_inputs {
             if Path::new(input).is_dir() {
-                validate_cert_folder(
+                validate_cert_folder_retaining(
                     &pe,
                     &cps,
                     input.as_str(),
@@ -1190,6 +1233,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
                     &validate_opts,
                     &mut fresh_uris,
                     threshold,
+                    retain.then_some(&mut retained),
                 )
                 .await;
                 continue;
@@ -1210,6 +1254,7 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
                     &validate_opts,
                     &mut fresh_uris,
                     threshold,
+                    retain.then_some(&mut retained),
                 )
                 .await;
             }
@@ -1391,6 +1436,16 @@ async fn generate_and_validate(args: &Pittv3Args) -> ValidationReport {
             paths: path_reports,
             no_paths_hints,
             error,
+        });
+    }
+    // The environment goes back with the paths when the caller asked to retain: the certificates
+    // travel with a path but the CRLs behind a status do not, and those are recovered from the
+    // sources registered here. Certificate sources were cleared above once building finished, which
+    // an export does not need -- it names artifacts, it does not build further paths.
+    if let Some(slot) = kept {
+        *slot = Some(RetainedRun {
+            environment: pe,
+            paths: retained,
         });
     }
     report

--- a/pittv3-lib/src/retained.rs
+++ b/pittv3-lib/src/retained.rs
@@ -1,0 +1,46 @@
+//! What a run keeps so its artifacts can be exported after the fact.
+//!
+//! A results folder is written *during* a run and has to be asked for before it starts. Retention
+//! answers the other case: a person who has seen the outcome and only then wants the material
+//! behind it. Both produce the same layout — [`crate::pitt_log::log_path`] writes it to a folder
+//! and `pittv3_gui_lib::export::path_entries` composes the same files as archive entries — so what
+//! differs is when the decision is made, not what comes out.
+//!
+//! This type lives here rather than beside either producer because there are two: the frontends
+//! that prepare an environment and validate against it, and the entry points in
+//! [`crate::std_utils`] that do the whole run. A consumer written against this type works with
+//! either, which is what lets one set of export buttons outlive a change of producer.
+
+use alloc::string::String;
+
+use certval::{CertificationPath, CertificationPathResults, CertificationPathSettings};
+
+/// One validated path, kept so the artifacts behind it can be exported afterwards.
+///
+/// The path and the results are what an export is assembled from; the settings are the ones that
+/// path was validated under, which is not the run's settings — RFC 5937 trust anchor constraints are
+/// folded in per path — so a manifest reporting the run's would describe inputs the path was not
+/// judged against.
+///
+/// Nothing is computed to produce these. The path and results exist for the duration of the
+/// validation regardless; retaining them is declining to drop them, which is why this is a caller's
+/// choice at the call site rather than a setting a user has to know to turn on before a run they
+/// have not seen the outcome of yet.
+///
+/// **Paths that failed are kept too**: a failure is the case someone most wants the material for.
+///
+/// Exporting also needs the `PkiEnvironment` the run used, which is not held here — the CRLs that
+/// settled a status are recovered from whichever `CrlSource` supplied them, since the results retain
+/// only `CrlInfo` and keeping every body per position per path is what made a large distribution
+/// point cost megabytes a run. A caller that means to export therefore keeps the environment alive
+/// alongside these.
+pub struct RetainedPath {
+    /// Name of the target this path was built for, as the caller supplied it
+    pub target_name: String,
+    /// The path as validated
+    pub path: CertificationPath,
+    /// The settings this path was validated under
+    pub cps: CertificationPathSettings,
+    /// The results recorded while validating it
+    pub cpr: CertificationPathResults,
+}

--- a/pittv3-lib/src/retained.rs
+++ b/pittv3-lib/src/retained.rs
@@ -12,8 +12,11 @@
 //! either, which is what lets one set of export buttons outlive a change of producer.
 
 use alloc::string::String;
+use alloc::vec::Vec;
 
-use certval::{CertificationPath, CertificationPathResults, CertificationPathSettings};
+use certval::{
+    CertificationPath, CertificationPathResults, CertificationPathSettings, PkiEnvironment,
+};
 
 /// One validated path, kept so the artifacts behind it can be exported afterwards.
 ///
@@ -43,4 +46,20 @@ pub struct RetainedPath {
     pub cps: CertificationPathSettings,
     /// The results recorded while validating it
     pub cpr: CertificationPathResults,
+}
+
+/// Everything a run keeps so its artifacts can be exported once it is over: the paths, and the
+/// environment they were validated against.
+///
+/// The environment is here because it is half of what an export needs and the half that is easy to
+/// drop by accident. A path's certificates travel with it, but the CRLs that settled a status do
+/// not — the results record only `CrlInfo`, so the bodies are asked back from whichever `CrlSource`
+/// supplied them, and that source lives on the environment. Returning the two together is what
+/// keeps a caller from holding paths it cannot fully export.
+pub struct RetainedRun {
+    /// The environment the run was carried out against, kept alive so revocation artifacts can be
+    /// recovered from the sources registered on it
+    pub environment: PkiEnvironment,
+    /// Every path validated during the run, in the order they were reported
+    pub paths: Vec<RetainedPath>,
 }

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -678,6 +678,7 @@ fn staple_crls(path: &mut CertificationPath, crls: &[Vec<u8>]) {
 /// artifacts a run was handed and reading those per target would read the same files once for every
 /// certificate validated.
 #[cfg(feature = "std")]
+#[allow(clippy::too_many_arguments)]
 pub(crate) async fn validate_cert_file(
     pe: &PkiEnvironment,
     cps: &CertificationPathSettings,
@@ -686,6 +687,7 @@ pub(crate) async fn validate_cert_file(
     opts: &ValidateOpts,
     fresh_uris: &mut Vec<String>,
     threshold: usize,
+    retain: Option<&mut Vec<RetainedPath>>,
 ) -> Result<()> {
     // A file the walk admitted and the reader cannot deliver never becomes a target, so record why
     // here: nothing downstream sees this file again, and without it the entry reaches the report as
@@ -697,7 +699,7 @@ pub(crate) async fn validate_cert_file(
             return Err(e);
         }
     };
-    validate_cert_bytes(
+    validate_cert_bytes_retaining(
         pe,
         cps,
         cert_filename,
@@ -706,6 +708,7 @@ pub(crate) async fn validate_cert_file(
         opts,
         fresh_uris,
         threshold,
+        retain,
     )
     .await
 }
@@ -1176,7 +1179,6 @@ pub async fn validate_targets_retaining(
 
 /// validate_cert_folder recursively traverses the given `certs_folder` and invokes `validate_cert_file`
 /// for each .der, .crt or .cer file that is found.
-#[async_recursion::async_recursion]
 #[cfg(feature = "std")]
 pub async fn validate_cert_folder(
     pe: &PkiEnvironment,
@@ -1187,6 +1189,37 @@ pub async fn validate_cert_folder(
     fresh_uris: &mut Vec<String>,
     threshold: usize,
 ) {
+    validate_cert_folder_retaining(
+        pe,
+        cps,
+        certs_folder,
+        stats,
+        opts,
+        fresh_uris,
+        threshold,
+        None,
+    )
+    .await
+}
+
+/// As [`validate_cert_folder`], additionally pushing each validated path onto `retain` when one is
+/// given, so the artifacts behind a folder run can be exported without validating a second time.
+///
+/// The sink is reborrowed rather than moved on the way down: a folder holding folders recurses, and
+/// each file in each of them contributes to the one collection the caller passed in.
+#[async_recursion::async_recursion]
+#[cfg(feature = "std")]
+#[allow(clippy::too_many_arguments)]
+pub async fn validate_cert_folder_retaining(
+    pe: &PkiEnvironment,
+    cps: &CertificationPathSettings,
+    certs_folder: &str,
+    stats: &mut PathValidationStatsGroup,
+    opts: &ValidateOpts,
+    fresh_uris: &mut Vec<String>,
+    threshold: usize,
+    mut retain: Option<&mut Vec<RetainedPath>>,
+) {
     for entry in WalkDir::new(certs_folder) {
         match entry {
             Ok(e) => {
@@ -1194,8 +1227,17 @@ pub async fn validate_cert_folder(
                 if e.file_type().is_dir() {
                     if let Some(s) = path.to_str() {
                         if s != certs_folder {
-                            validate_cert_folder(pe, cps, s, stats, opts, fresh_uris, threshold)
-                                .await;
+                            validate_cert_folder_retaining(
+                                pe,
+                                cps,
+                                s,
+                                stats,
+                                opts,
+                                fresh_uris,
+                                threshold,
+                                retain.as_deref_mut(),
+                            )
+                            .await;
                         }
                     } else {
                         error!("Skipping file due to invalid Unicode in name",);
@@ -1225,6 +1267,7 @@ pub async fn validate_cert_folder(
                                         opts,
                                         fresh_uris,
                                         threshold,
+                                        retain.as_deref_mut(),
                                     )
                                     .await;
                                 }

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -23,6 +23,7 @@ use crate::{
         CertSummary, NoPathsContext, PathReport, ProgressEvent, ReportTotals, TargetReport,
         TargetStatus, ValidationReport,
     },
+    retained::RetainedPath,
     stats::{PVStats, PathValidationStats, PathValidationStatsGroup},
 };
 
@@ -755,6 +756,43 @@ pub async fn validate_cert_bytes(
     fresh_uris: &mut Vec<String>,
     threshold: usize,
 ) -> Result<()> {
+    validate_cert_bytes_retaining(
+        pe,
+        cps,
+        name,
+        target_bytes,
+        stats,
+        opts,
+        fresh_uris,
+        threshold,
+        None,
+    )
+    .await
+}
+
+/// As [`validate_cert_bytes`], additionally pushing each validated path onto `retain` when one is
+/// given, so a caller can export the artifacts behind a result without validating a second time.
+///
+/// Validating again to produce an export would describe a *different* run — revocation data moves,
+/// and a responder asked twice may answer differently — so the material has to be kept from the run
+/// being reported rather than reconstructed from it afterwards.
+///
+/// Retention is per call site rather than a setting: a results folder has to be asked for before a
+/// run, and this exists for the person who only wants the material once they have seen the outcome.
+/// A caller that means to export keeps the [`PkiEnvironment`] alive too — see
+/// [`crate::retained::RetainedPath`] for why the CRLs are not held here.
+#[allow(clippy::too_many_arguments)]
+pub async fn validate_cert_bytes_retaining(
+    pe: &PkiEnvironment,
+    cps: &CertificationPathSettings,
+    name: &str,
+    target_bytes: &[u8],
+    stats: &mut PathValidationStats,
+    opts: &ValidateOpts,
+    fresh_uris: &mut Vec<String>,
+    threshold: usize,
+    mut retain: Option<&mut Vec<RetainedPath>>,
+) -> Result<()> {
     let time_of_interest = cps.get_time_of_interest();
     let cert_filename = name;
 
@@ -923,6 +961,20 @@ pub async fn validate_cert_bytes(
             r.as_ref().err(),
             (Instant::now() - path_start).as_millis() as u64,
         ));
+        // Kept for a later export, with the settings this path was actually judged under rather than
+        // the run's -- `path_cps` carries the RFC 5937 trust anchor constraints folded in above, and
+        // a manifest reporting the run's settings would name inputs the path was not validated
+        // against. Paths that failed are kept too: a failure is the case someone most wants the
+        // material for. Cloned because `cpr` is moved into `stats` on the next line and the path
+        // belongs to the built set.
+        if let Some(retained) = retain.as_deref_mut() {
+            retained.push(RetainedPath {
+                target_name: name.to_string(),
+                path: path.clone(),
+                cps: path_cps.clone(),
+                cpr: cpr.clone(),
+            });
+        }
         stats.results.push(cpr);
         match r {
             Ok(_) => {
@@ -998,6 +1050,30 @@ pub async fn validate_targets(
     opts: &ValidateOpts,
     progress: Option<&(dyn Fn(ProgressEvent) + Send + Sync + '_)>,
 ) -> ValidationReport {
+    let (report, _) = validate_targets_retaining(pe, cps, targets, opts, progress, false).await;
+    report
+}
+
+/// As [`validate_targets`], additionally returning every validated path when `retain` is set, so a
+/// frontend can export the artifacts behind a result without validating a second time.
+///
+/// Off by default and chosen at the call site: a GUI sets it because the decision to export is made
+/// after seeing the results, while a batch run that will never export should not hold every path it
+/// built. Nothing is computed either way — the paths and results exist for the duration of the run
+/// regardless, and retaining them is declining to drop them — so the cost is holding them for the
+/// life of the caller rather than per target.
+///
+/// A caller that means to export keeps the [`PkiEnvironment`] alive alongside the returned paths:
+/// the CRLs behind a status are recovered from the sources registered on it, not held here.
+pub async fn validate_targets_retaining(
+    pe: &PkiEnvironment,
+    cps: &CertificationPathSettings,
+    targets: &[(String, Vec<u8>)],
+    opts: &ValidateOpts,
+    progress: Option<&(dyn Fn(ProgressEvent) + Send + Sync + '_)>,
+    retain: bool,
+) -> (ValidationReport, Vec<RetainedPath>) {
+    let mut retained: Vec<RetainedPath> = vec![];
     let start = Instant::now();
     let mut stats = PathValidationStatsGroup::new();
     let mut fresh_uris: Vec<String> = vec![];
@@ -1023,7 +1099,7 @@ pub async fn validate_targets(
         let prev_valid = stats_for_target.valid_paths_per_target;
         let prev_invalid = stats_for_target.invalid_paths_per_target;
 
-        let _ = validate_cert_bytes(
+        let _ = validate_cert_bytes_retaining(
             pe,
             cps,
             name.as_str(),
@@ -1032,6 +1108,7 @@ pub async fn validate_targets(
             opts,
             &mut fresh_uris,
             0,
+            retain.then_some(&mut retained),
         )
         .await;
 
@@ -1087,13 +1164,14 @@ pub async fn validate_targets(
         });
     }
 
-    ValidationReport {
+    let report = ValidationReport {
         targets: target_reports,
         totals,
         time_of_interest: cps.get_time_of_interest().as_unix_secs(),
         duration_ms: (Instant::now() - start).as_millis() as u64,
         error: None,
-    }
+    };
+    (report, retained)
 }
 
 /// validate_cert_folder recursively traverses the given `certs_folder` and invokes `validate_cert_file`

--- a/pittv3-lib/tests/retained.rs
+++ b/pittv3-lib/tests/retained.rs
@@ -1,0 +1,147 @@
+//! Integration tests for path retention: the paths a run keeps so its artifacts can be exported
+//! afterwards, and the [`RetainedPath`] they are kept as.
+//!
+//! A results folder is asked for before a run; retention is the other case, chosen after the
+//! outcome is known. These cover the entry point that offers it and the shape of what comes back.
+#![cfg(feature = "std")]
+
+use std::fs;
+use std::path::Path;
+
+use certval::*;
+use pittv3_lib::retained::RetainedPath;
+use pittv3_lib::std_utils::{validate_targets_retaining, ValidateOpts};
+
+const TOI: u64 = 1648039783;
+
+fn read_example(flavor: &str, name: &str) -> Vec<u8> {
+    let p = Path::new("../certval/tests/examples")
+        .join(flavor)
+        .join(name);
+    fs::read(&p).unwrap_or_else(|e| panic!("failed to read {}: {e}", p.display()))
+}
+
+/// Builds a PkiEnvironment with the PKITS trust anchor and Good CA from the indicated flavor
+/// folder (certs are pushed directly, i.e., no filesystem-folder machinery).
+fn build_pe(flavor: &str, cps: &CertificationPathSettings) -> PkiEnvironment {
+    let mut pe = PkiEnvironment::default();
+    pe.populate_5280_pki_environment();
+
+    let mut ta_store = TaSource::new();
+    ta_store.push(CertFile {
+        filename: "TrustAnchorRootCertificate.crt".to_string(),
+        bytes: read_example(flavor, "TrustAnchorRootCertificate.crt"),
+    });
+    ta_store.initialize().unwrap();
+    pe.add_trust_anchor_source(Box::new(ta_store));
+
+    let mut cert_source = CertSource::default();
+    cert_source.push(CertFile {
+        filename: "GoodCACert.crt".to_string(),
+        bytes: read_example(flavor, "GoodCACert.crt"),
+    });
+    cert_source.initialize(cps).unwrap();
+    cert_source.find_all_partial_paths(&pe, cps);
+    pe.add_certificate_source(Box::new(cert_source));
+
+    pe
+}
+
+fn base_settings() -> CertificationPathSettings {
+    let mut cps = CertificationPathSettings::new();
+    cps.set_time_of_interest(TimeOfInterest::from_unix_secs(TOI).unwrap());
+    cps
+}
+
+fn targets(flavor: &str) -> Vec<(String, Vec<u8>)> {
+    vec![
+        (
+            "valid".to_string(),
+            read_example(flavor, "ValidCertificatePathTest1EE.crt"),
+        ),
+        (
+            "badsig".to_string(),
+            read_example(flavor, "InvalidEESignatureTest3EE.crt"),
+        ),
+    ]
+}
+
+/// Retention is off unless the call site asks, and asking yields the paths the report describes --
+/// including the one that failed, which is the case someone most wants the material for.
+///
+/// Named through `pittv3_lib::retained::RetainedPath` on purpose: the type moved here from
+/// `pittv3-gui-lib` so that both producers can emit it, and a test that only inferred it from the
+/// return type would keep compiling if the module or its visibility changed.
+#[test]
+fn retained_paths_are_kept_only_when_asked() {
+    let flavor = "PKITS_data_p256/certs";
+    let mut cps = base_settings();
+    cps.set_check_revocation_status(false);
+    let pe = build_pe(flavor, &cps);
+    let targets = targets(flavor);
+
+    // Declining to retain costs the caller nothing and yields nothing to export from.
+    let (report, retained): (_, Vec<RetainedPath>) = tokio_test::block_on(
+        validate_targets_retaining(&pe, &cps, &targets, &ValidateOpts::default(), None, false),
+    );
+    assert!(retained.is_empty());
+    let paths_reported = report.totals.paths_found;
+    assert!(paths_reported > 0, "the run found no paths to retain");
+
+    // Retaining yields exactly the paths the report accounts for, failures included.
+    let (report, retained): (_, Vec<RetainedPath>) = tokio_test::block_on(
+        validate_targets_retaining(&pe, &cps, &targets, &ValidateOpts::default(), None, true),
+    );
+    assert_eq!(retained.len(), report.totals.paths_found);
+    assert_eq!(retained.len(), paths_reported);
+    assert!(retained.iter().any(|r| r.target_name == "valid"));
+    assert!(
+        retained.iter().any(|r| r.target_name == "badsig"),
+        "a path that failed validation is still material worth exporting"
+    );
+}
+
+/// What a retained path carries is what an export is assembled from: the path as validated, the
+/// results recorded while validating it, and the settings *that path* was judged under rather than
+/// the run's -- a manifest reporting the run's would name inputs the path was not validated
+/// against.
+#[test]
+fn a_retained_path_carries_what_an_export_needs() {
+    let flavor = "PKITS_data_p256/certs";
+    let mut cps = base_settings();
+    cps.set_check_revocation_status(false);
+    let pe = build_pe(flavor, &cps);
+
+    let (_report, retained): (_, Vec<RetainedPath>) =
+        tokio_test::block_on(validate_targets_retaining(
+            &pe,
+            &cps,
+            &targets(flavor),
+            &ValidateOpts::default(),
+            None,
+            true,
+        ));
+
+    let valid: &RetainedPath = retained
+        .iter()
+        .find(|r| r.target_name == "valid")
+        .expect("the valid target retained no path");
+
+    // The path is the one the report describes: trust anchor, Good CA, target.
+    assert_eq!(valid.path.intermediates.len(), 1);
+    assert!(valid
+        .path
+        .target
+        .decoded()
+        .tbs_certificate()
+        .subject()
+        .to_string()
+        .contains("Valid EE Certificate Test1"));
+
+    // The settings travel with the path, and are the ones it was judged under.
+    assert!(!valid.cps.0.is_empty());
+    assert_eq!(valid.cps.get_time_of_interest().as_unix_secs(), TOI);
+
+    // The results are populated, which is what a manifest renders from.
+    assert!(!valid.cpr.0.is_empty());
+}

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -1606,9 +1606,11 @@ fn App() -> Element {
                     },
                     2 => rsx! {
                         div { class: "results",
+                            h2 { "Results" }
+                            // The heading sits above the row rather than in it: sharing the line
+                            // left too little width for the actions, which then wrapped onto a
+                            // second line and stranded the name field beside Clear.
                             div { class: "results-header",
-                                h2 { "Results" }
-                                span {
                                     button {
                                         disabled: targets.read().is_empty(),
                                         onclick: save_results,
@@ -1616,17 +1618,10 @@ fn App() -> Element {
                                         "Save report"
                                     }
                                     button {
+                                        disabled: log_lines == 0,
                                         onclick: save_log,
-                                        title: "Download what the validation stack logged, as text",
-                                        "Save log ({log_lines} line(s))"
-                                    }
-                                    button {
-                                        onclick: move |_| {
-                                            log_capture::clear();
-                                            log_tick += 1;
-                                        },
-                                        title: "Discard what has been logged so far",
-                                        "Clear log"
+                                        title: "Download what the validation stack logged, as text ({log_lines} line(s))",
+                                        "Save log"
                                     }
                                     button {
                                         disabled: retained_paths.read().is_empty(),
@@ -1648,14 +1643,19 @@ fn App() -> Element {
                                         oninput: move |e| export_name.set(e.value()),
                                     }
                                     button {
+                                        // One Clear rather than two, matching the desktop: a
+                                        // separate "Clear log" was a second button doing part of
+                                        // what this one does, and the row is where that cost shows.
                                         onclick: move |_| {
                                             targets.write().clear();
                                             notes.write().clear();
                                             retained_paths.write().clear();
+                                            log_capture::clear();
+                                            log_tick += 1;
                                         },
+                                        title: "Discard the results and the log",
                                         "Clear"
                                     }
-                                }
                             }
                             if targets.read().is_empty() && notes.read().is_empty() {
                                 p { class: "hint",


### PR DESCRIPTION
- Move RetainedPath from pittv3-gui-lib to pittv3-lib, re-exported from gui_lib::validate so callers are unchanged
- Add validate_targets_retaining and validate_cert_bytes_retaining; the existing validate_targets and validate_cert_bytes delegate with retention off
- Add a test covering retention on and off
- Add RetainedRun (the paths a run kept plus the environment they were validated against) to pittv3-lib/src/retained.rs. The environment is kept because a path carries its certificates but not the CRLs behind a status, which can be recovered from the sources registered with the environment
- Thread optional retention through validate_cert_file and the new validate_cert_folder_retaining
- Add options_std_retaining.
- Add pittv3-gui/src/save.rs. Add Save artifacts and Save path logs buttons to the results view along with a name field.
- Minor adjustments to UIs to tidy up the Results group