### PR TITLE
--capi-ca-rw changes and cargo doc warnings fixes

### DIFF
--- a/certval/src/builder/uri_utils.rs
+++ b/certval/src/builder/uri_utils.rs
@@ -107,21 +107,20 @@ pub(crate) async fn read_capped_body(
 /// A file containing the certificate is written to a location that uses the filename parameter as
 /// a base to which an index is added before saving via [`save_cert`]. Certificates that are not
 /// valid at the indicated time of interest are discarded as well.
+///
+/// `filename` is `None` when the caller named no folder to keep downloads in; see [`save_cert`].
+/// The certificates still reach `buffers`.
 #[cfg(feature = "remote")]
 fn save_certs_from_p7(
     pe: &PkiEnvironment,
-    filename: &Path,
+    filename: Option<&Path>,
     bytes: &[u8],
     target: &str,
     buffers: &mut dyn CertVector,
     time_of_interest: TimeOfInterest,
 ) -> bool {
     let mut at_least_one_saved = false;
-    let filename = if let Some(fname) = filename.to_str() {
-        fname
-    } else {
-        return false;
-    };
+    let filename = filename.and_then(|f| f.to_str());
 
     match ContentInfo::from_der(bytes) {
         Ok(ci) => {
@@ -131,13 +130,17 @@ fn save_certs_from_p7(
                     Ok(sd) => {
                         for (i, c) in sd.certificates.iter().enumerate() {
                             for a in c.0.iter() {
-                                let f = format!("{filename}_{i}.der");
-                                #[allow(irrefutable_let_patterns)]
-                                let Ok(pb) = PathBuf::from_str(&f);
+                                // One name per certificate in the message, or none at all when
+                                // there is nowhere to write them.
+                                let pb = filename.map(|f| {
+                                    #[allow(irrefutable_let_patterns)]
+                                    let Ok(pb) = PathBuf::from_str(&format!("{f}_{i}.der"));
+                                    pb
+                                });
                                 if let Ok(enccert) = a.to_der() {
                                     if save_cert(
                                         pe,
-                                        &pb,
+                                        pb.as_deref(),
                                         enccert.as_slice(),
                                         target,
                                         buffers,
@@ -163,23 +166,25 @@ fn save_certs_from_p7(
 }
 
 /// `save_cert` takes a buffer that notionally contains a certificate. if the certificate can be parsed,
-/// and it is not present in `buffers`, then it is appended to `buffers` and written to `filename`. The
-/// attempt to write a file is "best effort". If it fails, life goes on.
+/// and it is not present in `buffers`, then it is appended to `buffers` and, when `filename` names
+/// somewhere to put it, written there. The attempt to write a file is "best effort". If it fails,
+/// life goes on.
+///
+/// `filename` is `None` when the caller named no folder to keep downloads in. The certificate still
+/// reaches `buffers`, which is what the run builds paths from; only the copy on disk is skipped.
+/// This is a distinct case from a write that fails, and has to be, because the path built from an
+/// empty folder is a bare relative name that would drop files into the process's working directory.
 #[cfg(feature = "remote")]
 fn save_cert(
     pe: &PkiEnvironment,
-    filename: &Path,
+    filename: Option<&Path>,
     bytes: &[u8],
     target: &str,
     buffers: &mut dyn CertVector,
     time_of_interest: TimeOfInterest,
 ) -> bool {
     let mut saved = false;
-    let filename = if let Some(fname) = filename.to_str() {
-        fname
-    } else {
-        return false;
-    };
+    let filename = filename.and_then(|f| f.to_str());
 
     let r = CertificateInner::from_der(bytes);
     match r {
@@ -207,15 +212,17 @@ fn save_cert(
                 buffers.push(cf);
                 saved = true;
 
-                match File::create(filename) {
-                    Ok(mut dest) => {
-                        let r = dest.write_all(bytes);
-                        if let Err(e) = r {
-                            error!("Failed to copy {target} with {e:?}");
+                if let Some(filename) = filename {
+                    match File::create(filename) {
+                        Ok(mut dest) => {
+                            let r = dest.write_all(bytes);
+                            if let Err(e) = r {
+                                error!("Failed to copy {target} with {e:?}");
+                            }
                         }
-                    }
-                    Err(e) => {
-                        error!("Failed to save {filename} with error: {e}");
+                        Err(e) => {
+                            error!("Failed to save {filename} with error: {e}");
+                        }
                     }
                 }
             } else {
@@ -250,8 +257,15 @@ pub async fn fetch_to_buffer(
     time_of_interest: TimeOfInterest,
     max_bytes: u64,
 ) -> Result<()> {
-    // Downloaded artifacts are saved for future use, create a path object for that folder
-    let path = Path::new(folder);
+    // Downloaded artifacts are saved for future use, create a path object for that folder. An empty
+    // folder means the caller has nowhere to keep them -- a run writing fetched certificates to a
+    // CAPI store rather than to disk, for one -- and is not the same as a folder that turns out to
+    // be unwritable: joining a name onto an empty path yields a bare relative name, which would
+    // scatter downloads through the process's working directory.
+    let path = match folder.is_empty() {
+        true => None,
+        false => Some(Path::new(folder)),
+    };
 
     let client = match shared_http_client() {
         Some(client) => client,
@@ -328,7 +342,7 @@ pub async fn fetch_to_buffer(
                     continue;
                 }
 
-                let fname = path.join(fname_from_response);
+                let fname = path.map(|p| p.join(fname_from_response));
 
                 match read_capped_body(response, max_bytes, target).await {
                     Ok(bytes) => {
@@ -338,7 +352,7 @@ pub async fn fetch_to_buffer(
                         if "application/pkcs7-mime" == content_type {
                             save_certs_from_p7(
                                 pe,
-                                &fname,
+                                fname.as_deref(),
                                 bytes.as_ref(),
                                 target,
                                 buffers,
@@ -347,7 +361,7 @@ pub async fn fetch_to_buffer(
                         } else if "application/x-x509-ca-cert" == content_type {
                             save_cert(
                                 pe,
-                                &fname,
+                                fname.as_deref(),
                                 bytes.as_ref(),
                                 target,
                                 buffers,
@@ -359,7 +373,7 @@ pub async fn fetch_to_buffer(
                                 Ok(_) => {
                                     save_cert(
                                         pe,
-                                        &fname,
+                                        fname.as_deref(),
                                         bytes.as_ref(),
                                         target,
                                         buffers,
@@ -369,7 +383,7 @@ pub async fn fetch_to_buffer(
                                 Err(_) => {
                                     save_certs_from_p7(
                                         pe,
-                                        &fname,
+                                        fname.as_deref(),
                                         bytes.as_ref(),
                                         target,
                                         buffers,

--- a/certval/src/revocation.rs
+++ b/certval/src/revocation.rs
@@ -6,7 +6,9 @@
 //!
 //! As shown in the example below, revocation status determination is performed after validating a certification path
 //! via [`PkiEnvironment::validate_path`](crate::PkiEnvironment::validate_path).
-//! For convenience, [`check_revocation`](crate::check_revocation()) implements the [`ValidatePath`](crate::ValidatePath) type.
+//! For convenience, the `check_revocation` function (present under `std`) implements the
+//! [`ValidatePath`](crate::ValidatePath) type. It is not linked here because the name also belongs
+//! to the module holding it, which is present whether or not `std` is.
 //!
 //! ```no_run
 //! #[tokio::test]

--- a/certval/src/revocation/check_revocation.rs
+++ b/certval/src/revocation/check_revocation.rs
@@ -285,13 +285,13 @@ pub async fn check_revocation(
 
 /// Determines revocation status from data the caller has already supplied, retrieving nothing.
 ///
-/// This is steps 1 through 4 of the ladder documented on [`check_revocation`], with the same
+/// This is steps 1 through 4 of the ladder documented on `check_revocation`, with the same
 /// short-circuit on revocation and the same accumulation of undetermined statuses: the environment's
 /// revocation status cache, the OCSP no-check extension, an OCSP response or CRL stapled into the
 /// path, and any registered [`CrlSource`](crate::CrlSource). Nothing is fetched, so a status that
 /// only a responder or a CRL DP could settle stays undetermined.
 ///
-/// This is available whenever `revocation` is, unlike [`check_revocation`], which exists only under
+/// This is available whenever `revocation` is, unlike `check_revocation`, which exists only under
 /// `std` and is asynchronous. That is a hazard for a caller that cannot see what it got: a crate can
 /// `cfg` on its own features but never on a dependency's, so feature unification decides both
 /// whether the function is there at all and whether it must be awaited, and the mismatch surfaces as
@@ -300,7 +300,7 @@ pub async fn check_revocation(
 /// stop caring which flavor of certval it was linked against.
 ///
 /// Returns `Ok` when the status of every certificate was determined and none was revoked, and
-/// otherwise the same errors [`check_revocation`] returns.
+/// otherwise the same errors `check_revocation` returns.
 pub fn check_revocation_local(
     pe: &PkiEnvironment,
     cps: &CertificationPathSettings,

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -328,7 +328,7 @@ pub static PS_CHECK_CRLDP_LDAP: &str = "psCheckCrlDpLdap";
 
 /// `PS_RETAIN_EXPIRED_KEPT_CRLS` is used to retrieve a boolean value from a [`CertificationPathSettings`]
 /// object. The default value is false. It governs only the opt-in in-memory kept-CRL cache (see
-/// [`CrlSourceFolders::with_options`](crate::source::CrlSourceFolders::with_options)). When false,
+/// `CrlSourceFolders::with_options`, which needs `revocation` and `std`). When false,
 /// a kept CRL whose `nextUpdate` has passed the time of interest is evicted on the next insert to
 /// bound memory. When true, expired kept CRLs are retained so a later validation at an earlier time
 /// of interest (retroactive / long-term-validation checks) can still be answered from them.

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -768,9 +768,11 @@ async fn generate_and_validate(
     // A writable CAPI store is somewhere to put fetched certificates, so it answers this
     // requirement the same way a folder does. `fetch_to_buffer` skips the copy on disk when no
     // folder was named; the certificates still reach the pool the run builds from.
-    #[cfg(all(windows, feature = "capi"))]
+    // Gated on `remote` as well, because `download_folder` above is: without it there is no
+    // fetching, so nothing needs anywhere to be put and the guard below is not compiled either.
+    #[cfg(all(feature = "remote", windows, feature = "capi"))]
     let have_somewhere_to_put_them = !download_folder.is_empty() || args.capi_ca_store_rw.is_some();
-    #[cfg(not(all(windows, feature = "capi")))]
+    #[cfg(all(feature = "remote", not(all(windows, feature = "capi"))))]
     let have_somewhere_to_put_them = !download_folder.is_empty();
 
     #[cfg(feature = "remote")]

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -765,10 +765,18 @@ async fn generate_and_validate(
         .or_else(|| cps.get_download_folder())
         .unwrap_or_else(|| ca_folder.clone());
 
+    // A writable CAPI store is somewhere to put fetched certificates, so it answers this
+    // requirement the same way a folder does. `fetch_to_buffer` skips the copy on disk when no
+    // folder was named; the certificates still reach the pool the run builds from.
+    #[cfg(all(windows, feature = "capi"))]
+    let have_somewhere_to_put_them = !download_folder.is_empty() || args.capi_ca_store_rw.is_some();
+    #[cfg(not(all(windows, feature = "capi")))]
+    let have_somewhere_to_put_them = !download_folder.is_empty();
+
     #[cfg(feature = "remote")]
-    if args.dynamic_build && download_folder.is_empty() {
+    if args.dynamic_build && !have_somewhere_to_put_them {
         return ValidationReport::failed(
-            "a CA folder or download folder is required when dynamic build is enabled",
+            "a CA folder, download folder or writable CAPI store is required when dynamic build is enabled",
         );
     }
 

--- a/pittv3-lib/src/report.rs
+++ b/pittv3-lib/src/report.rs
@@ -590,7 +590,7 @@ impl ValidationReport {
     ///
     /// This is for a frontend whose targets accumulate across interactions rather than arriving
     /// from a single run: the totals have to be recomputed whenever the set changes, and there are
-    /// no certval run statistics to read them from — unlike [`crate::options_std`], which
+    /// no certval run statistics to read them from — unlike `options_std`, which
     /// accumulates the same counts from `paths_per_target` and friends as it goes.
     ///
     /// `duration_ms` is the sum of what the paths themselves report. There is no one run here to

--- a/pittv3-lib/src/retained.rs
+++ b/pittv3-lib/src/retained.rs
@@ -2,13 +2,13 @@
 //!
 //! A results folder is written *during* a run and has to be asked for before it starts. Retention
 //! answers the other case: a person who has seen the outcome and only then wants the material
-//! behind it. Both produce the same layout — [`crate::pitt_log::log_path`] writes it to a folder
+//! behind it. Both produce the same layout — `pitt_log::log_path` writes it to a folder
 //! and `pittv3_gui_lib::export::path_entries` composes the same files as archive entries — so what
 //! differs is when the decision is made, not what comes out.
 //!
 //! This type lives here rather than beside either producer because there are two: the frontends
 //! that prepare an environment and validate against it, and the entry points in
-//! [`crate::std_utils`] that do the whole run. A consumer written against this type works with
+//! `std_utils` that do the whole run. A consumer written against this type works with
 //! either, which is what lets one set of export buttons outlive a change of producer.
 
 use alloc::string::String;


### PR DESCRIPTION
- changes to allow --capi-ca-rw to work as a cert sink when downloads folder not specified (had been requiring downloads or CA folder always)
 - fix a few rustdoc warnings