### PR TITLE
Various log and artifact export changes

### DIFF
--- a/pittv3-gui-lib/src/export.rs
+++ b/pittv3-gui-lib/src/export.rs
@@ -27,6 +27,57 @@ pub type ExportEntry = (String, Vec<u8>);
 /// the concatenated log and the archived manifests are necessarily the same text.
 pub const MANIFEST_NAME: &str = "manifest.txt";
 
+/// The name an export takes when the user has not chosen one. The field is pre-populated with it in
+/// both frontends, so the common case needs no typing.
+pub const DEFAULT_EXPORT_NAME: &str = "PITTv3Results";
+
+/// A filename stem for an export: what the user typed, sanitized, with a UTC timestamp appended.
+///
+/// **Sanitized** because the value names a file *and* a folder inside the archive, so a separator in
+/// it is not a name but an instruction about where things land.
+///
+/// **Stamped** because bundles are saved repeatedly -- a second run, the same run after a settings
+/// change -- and a fixed name leaves the operating system to disambiguate, which it does by
+/// appending `(1)`, `(2)`. Those say nothing about which bundle is which, and they order by when the
+/// file was saved rather than when the run happened. The base name is left as the user gave it and
+/// the stamp is appended, so a name still says what the run was as well as when it was.
+///
+/// The stamp is **UTC**, matching the times the manifests inside the archive report, and following
+/// the decision already recorded on `epoch_to_datetime_local`: a browser showing local time while
+/// the desktop showed UTC made one artifact read two ways. Colons are omitted rather than escaped --
+/// they are not legal in a Windows filename.
+///
+/// `secs` is the caller's rather than read here, so one save action stamps its archive and its path
+/// log identically even if it straddles a second, and so the formatting is testable without a clock.
+pub fn stamped_export_name(typed: &str, secs: u64) -> String {
+    let cleaned: String = typed
+        .trim()
+        .chars()
+        .map(|c| match c {
+            '/' | '\\' | ':' => '_',
+            c => c,
+        })
+        .collect();
+    let base = match cleaned.is_empty() {
+        true => DEFAULT_EXPORT_NAME,
+        false => cleaned.as_str(),
+    };
+    match x509_cert::der::DateTime::from_unix_duration(core::time::Duration::from_secs(secs)) {
+        Ok(dt) => format!(
+            "{base}-{:04}{:02}{:02}T{:02}{:02}{:02}Z",
+            dt.year(),
+            dt.month(),
+            dt.day(),
+            dt.hour(),
+            dt.minutes(),
+            dt.seconds()
+        ),
+        // A clock that yields nothing usable is not a reason to refuse to save. The unstamped name
+        // still works; it just leaves collisions to the operating system, as before.
+        Err(_) => base.to_string(),
+    }
+}
+
 /// The files describing one certification path.
 ///
 /// Certificates are numbered by hop with the trust anchor at zero, matching what a results-folder
@@ -182,6 +233,44 @@ pub fn paths_text(paths: &[Vec<ExportEntry>]) -> String {
 #[cfg(test)]
 mod tests {
     use super::*;
+
+    /// A fixed instant, so this pins the format rather than agreeing with whatever the clock said.
+    /// 2026-09-02T13:45:07Z.
+    const WHEN: u64 = 1_788_356_707;
+
+    #[test]
+    fn a_name_carries_the_base_and_a_utc_stamp() {
+        assert_eq!(
+            stamped_export_name("dod run 3", WHEN),
+            "dod run 3-20260902T134507Z"
+        );
+        // cleared field falls back to the name the field starts with, stamped the same way
+        assert_eq!(
+            stamped_export_name("   ", WHEN),
+            "PITTv3Results-20260902T134507Z"
+        );
+    }
+
+    /// The name reaches a filesystem path and an archive entry, so a separator in it is not a name
+    /// but an instruction about where things land. Colons go too: illegal in a Windows filename,
+    /// which is also why the stamp has none.
+    #[test]
+    fn separators_are_not_carried_into_the_name() {
+        assert!(stamped_export_name("../etc/passwd", WHEN).starts_with(".._etc_passwd-"));
+        assert!(stamped_export_name("C:\\runs\\one", WHEN).starts_with("C__runs_one-"));
+        let stamped = stamped_export_name("anything", WHEN);
+        assert!(!stamped.contains(':'), "{stamped}");
+        assert!(!stamped.contains('/'), "{stamped}");
+    }
+
+    /// Two saves of two different runs must not collide -- the whole point of stamping.
+    #[test]
+    fn different_moments_give_different_names() {
+        assert_ne!(
+            stamped_export_name("run", WHEN),
+            stamped_export_name("run", WHEN + 1)
+        );
+    }
 
     /// The archive puts every path under the caller's name, numbered from one, so extracting it
     /// leaves a single directory rather than loose numbered folders.

--- a/pittv3-gui-lib/src/gui_utils.rs
+++ b/pittv3-gui-lib/src/gui_utils.rs
@@ -167,3 +167,89 @@ impl Append for ChannelAppender {
 
     fn flush(&self) {}
 }
+
+/// Which dialog is asking, so the two kinds do not share one remembered folder.
+///
+/// A save dialog opening where a CA certificate was last picked from is worse than opening at home:
+/// it is confidently wrong rather than merely unhelpful. Reading material and writing results are
+/// different errands and people keep them in different places.
+#[cfg(feature = "std")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub enum DialogPurpose {
+    /// Choosing existing material to read
+    Open,
+    /// Choosing where to write an export
+    Save,
+}
+
+/// Folders the file dialogs last used, kept between sessions.
+///
+/// Held in its own file rather than in `pittv3.cfg`, deliberately: that file is a serialized
+/// [`Pittv3Args`], the CLI's argument type, and where a dialog last pointed is not an argument to a
+/// run. Adding it there would put a field in the command line's own type that the command line has
+/// no use for.
+#[cfg(feature = "std")]
+#[derive(Default, serde::Deserialize, serde::Serialize)]
+struct DialogState {
+    /// Last folder material was read from
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_open_dir: Option<String>,
+    /// Last folder an export was written to
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    last_save_dir: Option<String>,
+}
+
+#[cfg(feature = "std")]
+fn dialog_state_path() -> Option<std::path::PathBuf> {
+    Some(app_home()?.join("dialogs.json"))
+}
+
+#[cfg(feature = "std")]
+fn read_dialog_state() -> DialogState {
+    // Every failure here means "no remembered folder", which is the first-run state and not worth
+    // reporting: the dialog opens at home, as it always did.
+    dialog_state_path()
+        .and_then(|path| File::open(path).ok())
+        .and_then(|file| serde_json::from_reader(&file).ok())
+        .unwrap_or_default()
+}
+
+/// The folder a dialog of this kind should open at, or `None` when none has been remembered yet.
+///
+/// A remembered folder that no longer exists is treated as unremembered — a removable drive or a
+/// deleted directory should send the dialog home rather than somewhere it cannot go.
+#[cfg(feature = "std")]
+pub fn last_dialog_dir(purpose: DialogPurpose) -> Option<std::path::PathBuf> {
+    let state = read_dialog_state();
+    let remembered = match purpose {
+        DialogPurpose::Open => state.last_open_dir,
+        DialogPurpose::Save => state.last_save_dir,
+    }?;
+    let path = std::path::PathBuf::from(remembered);
+    path.is_dir().then_some(path)
+}
+
+/// Records the folder a dialog of this kind just used. Best-effort: failing to remember is not
+/// something to interrupt a save over, so it is logged and dropped.
+#[cfg(feature = "std")]
+pub fn remember_dialog_dir(purpose: DialogPurpose, dir: &std::path::Path) {
+    let Some(dir) = dir.to_str() else {
+        return;
+    };
+    let mut state = read_dialog_state();
+    match purpose {
+        DialogPurpose::Open => state.last_open_dir = Some(dir.to_string()),
+        DialogPurpose::Save => state.last_save_dir = Some(dir.to_string()),
+    }
+    let Some(path) = dialog_state_path() else {
+        return;
+    };
+    match serde_json::to_string(&state) {
+        Ok(json) => {
+            if let Err(e) = fs::write(path, json) {
+                error!("Unable to record the folder the dialog used: {e}");
+            }
+        }
+        Err(e) => error!("Unable to encode the folder the dialog used: {e}"),
+    }
+}

--- a/pittv3-gui-lib/src/settings_store.rs
+++ b/pittv3-gui-lib/src/settings_store.rs
@@ -55,6 +55,69 @@ pub fn default_settings_path() -> Option<String> {
     Some(app_home()?.join("settings.json").to_str()?.to_string())
 }
 
+/// A saved value if there is a usable one, otherwise the default.
+///
+/// An empty saved value falls through to the default rather than being taken at face value. That is
+/// what a text field holds when it has never been filled in, so treating it as a deliberate "no
+/// folder" would deny the default to exactly the first-run case it exists for. The consequence
+/// worth knowing: a field the user *clears* is honoured for that run — the run form sends `None` —
+/// but the default returns the next time the application starts.
+#[cfg(feature = "std")]
+pub fn saved_or_default(saved: Option<String>, default: impl FnOnce() -> Option<String>) -> String {
+    saved
+        .filter(|value| !value.is_empty())
+        .or_else(default)
+        .unwrap_or_default()
+}
+
+/// A folder beneath [`app_home`], created if absent. `None` when there is no home directory, or
+/// when the path will not round-trip through a `String` — the argument and settings types the
+/// folder feeds are string-typed, so a path that cannot be one is no use here.
+#[cfg(feature = "std")]
+fn app_home_folder(name: &str) -> Option<String> {
+    let folder = app_home()?.join(name);
+    if !folder.exists() {
+        let _ = std::fs::create_dir_all(&folder);
+    }
+    Some(folder.to_str()?.to_string())
+}
+
+/// Default folder for CA certificates, `cas` in [`app_home`].
+///
+/// Dynamic building needs somewhere to put what it fetches, and with nowhere named the run is
+/// refused outright — so on a machine that has never been configured, the first thing the
+/// application does is decline to work, over a folder no new user could have known to nominate.
+/// These defaults exist to answer that.
+///
+/// **They are offered to the folder fields rather than resolved behind them**, so what the run will
+/// use is on screen and can be changed or cleared. That matters most for the arguments that treat
+/// the CA folder as an output: `--cleanup` moves or deletes certificates from it and
+/// `--mozilla-csv` writes a report into it, and neither should ever act on a location the person
+/// running it cannot see.
+#[cfg(feature = "std")]
+pub fn default_ca_folder() -> Option<String> {
+    app_home_folder("cas")
+}
+
+/// Default folder for downloaded certificates, `downloads` in [`app_home`]. See
+/// [`default_ca_folder`] for why these are offered rather than resolved.
+#[cfg(feature = "std")]
+pub fn default_download_folder() -> Option<String> {
+    app_home_folder("downloads")
+}
+
+/// Default CRL index folder, `crls` in [`app_home`]. See [`default_ca_folder`] for why these are
+/// offered rather than resolved.
+///
+/// Naming one also gives a run somewhere to keep the CRLs it fetches: without a folder no
+/// `CrlSource` is registered at all, so a CRL retrieved from a distribution point is used for its
+/// determination and then dropped, and anything asking the environment for it afterwards — an
+/// artifact export, above all — finds nothing.
+#[cfg(feature = "std")]
+pub fn default_crl_folder() -> Option<String> {
+    app_home_folder("crls")
+}
+
 /// Resolves a leading `~` in `path` against the user's home directory, returning any other path
 /// unchanged.
 ///
@@ -148,6 +211,26 @@ mod tests {
             expand_tilde("backup/~settings.json"),
             "backup/~settings.json"
         );
+    }
+
+    /// Deliberately exercised with a stub default rather than the real ones: calling those would
+    /// make directories in whoever's home is running the suite.
+    #[test]
+    fn an_empty_saved_value_falls_through_to_the_default() {
+        let default = || Some("/default/cas".to_string());
+
+        assert_eq!(saved_or_default(None, default), "/default/cas");
+        assert_eq!(
+            saved_or_default(Some(String::new()), default),
+            "/default/cas"
+        );
+        // a saved value wins, and is not second-guessed
+        assert_eq!(
+            saved_or_default(Some("/chosen".to_string()), default),
+            "/chosen"
+        );
+        // no default to offer is still not an error -- the caller's guard reports it
+        assert_eq!(saved_or_default(None, || None), "");
     }
 
     #[test]

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -21,10 +21,12 @@ use pittv3_lib::der_or_pem::TA_BUNDLE_EXTENSIONS;
 
 use std::sync::Mutex;
 
-use crate::save::{self, RetainedArtifacts, DEFAULT_EXPORT_NAME};
+use crate::save::{self, RetainedArtifacts};
+use pittv3_gui_lib::export::{stamped_export_name, DEFAULT_EXPORT_NAME};
 use pittv3_gui_lib::gui_end_entity::EndEntityGroup;
 use pittv3_gui_lib::gui_help::HelpView;
 use pittv3_gui_lib::gui_results::{ResultsView, RunEvent};
+use pittv3_gui_lib::gui_rows::now_as_unix_epoch;
 use pittv3_gui_lib::gui_rows::{
     BrowseRow, CheckboxCell, CheckboxRow, PathListRow, TextRow, TimeRow,
 };
@@ -32,9 +34,13 @@ use pittv3_gui_lib::gui_settings::EditSettingsFile;
 use pittv3_gui_lib::gui_shell::AppShell;
 use pittv3_gui_lib::gui_uri_check::UriCheckResults;
 use pittv3_gui_lib::gui_utils::{
-    clear_log_sink, read_saved_args, save_args, set_log_sink, ChannelAppender,
+    clear_log_sink, last_dialog_dir, read_saved_args, remember_dialog_dir, save_args, set_log_sink,
+    ChannelAppender, DialogPurpose,
 };
-use pittv3_gui_lib::settings_store::{default_settings_path, expand_tilde};
+use pittv3_gui_lib::settings_store::{
+    default_ca_folder, default_crl_folder, default_download_folder, default_settings_path,
+    expand_tilde, saved_or_default,
+};
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
 use pittv3_lib::graph_cache;
@@ -48,13 +54,26 @@ use pittv3_lib::uri_check::{check_uris_from_bytes, UriCheckReport};
 use crate::peek;
 use crate::stores;
 
+/// Records where a dialog just went, from what it returned: a folder is itself the location, a file
+/// is its parent.
+fn remember_pick(purpose: DialogPurpose, path: &std::path::Path) {
+    let dir = match path.is_dir() {
+        true => Some(path),
+        false => path.parent(),
+    };
+    if let Some(dir) = dir {
+        remember_dialog_dir(purpose, dir);
+    }
+}
+
 /// Presents a folder selection dialog and assigns the selection, if any, to `sig`
 async fn pick_folder_into(mut sig: Signal<String>) {
     let folder = AsyncFileDialog::new()
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Open))
         .pick_folder()
         .await;
     if let Some(folder) = folder {
+        remember_pick(DialogPurpose::Open, folder.path());
         sig.set(folder.path().to_string_lossy().to_string());
     }
 }
@@ -64,12 +83,13 @@ async fn pick_folder_into(mut sig: Signal<String>) {
 /// failure this app has already been bitten by once (see the tilde expansion in `settings_store`).
 async fn export_store_into(index: usize, mut status: Signal<String>) {
     let folder = AsyncFileDialog::new()
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Save))
         .pick_folder()
         .await;
     let Some(folder) = folder else {
         return;
     };
+    remember_pick(DialogPurpose::Save, folder.path());
     match stores::export(index, folder.path()) {
         Ok(e) => {
             let cas = if e.ca_store {
@@ -121,13 +141,14 @@ async fn export_environment_into(args: Pittv3Args, mut status: Signal<String>) {
     let anchors = graph_cache::cached_anchors(&fingerprint);
 
     let folder = AsyncFileDialog::new()
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Save))
         .pick_folder()
         .await;
     let Some(folder) = folder else {
         return;
     };
 
+    remember_pick(DialogPurpose::Save, folder.path());
     let ca_path = folder.path().join("ca.cbor");
     if let Err(e) = std::fs::write(&ca_path, &graph) {
         error!("Failed to write {}: {e}", ca_path.display());
@@ -163,10 +184,11 @@ async fn export_environment_into(args: Pittv3Args, mut status: Signal<String>) {
 #[cfg(target_os = "macos")]
 async fn pick_file_or_folder_into(mut sig: Signal<String>) {
     let picked = AsyncFileDialog::new()
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Open))
         .pick_file_or_folder()
         .await;
     if let Some(picked) = picked {
+        remember_pick(DialogPurpose::Open, picked.path());
         sig.set(picked.path().to_string_lossy().to_string());
     }
 }
@@ -176,6 +198,12 @@ async fn pick_file_or_folder_into(mut sig: Signal<String>) {
 /// A save dialog rather than a fixed location: this is the user's own copy of what a run used, and
 /// the desktop's other writes -- the peek folder, a materialized store -- go under the application
 /// home precisely because nobody chose where they should live. Here somebody is choosing.
+/// Where a file dialog should open: the folder that kind of dialog last used, falling back to the
+/// user's home as it always did when nothing has been remembered yet.
+fn dialog_dir(purpose: DialogPurpose) -> std::path::PathBuf {
+    last_dialog_dir(purpose).unwrap_or_else(|| home_dir().unwrap_or("/".into()))
+}
+
 async fn write_export(
     suggested: String,
     extensions: &[&str],
@@ -183,7 +211,7 @@ async fn write_export(
     mut log: Signal<Vec<String>>,
 ) {
     let Some(handle) = AsyncFileDialog::new()
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Save))
         .set_file_name(&suggested)
         .add_filter("export", extensions)
         .save_file()
@@ -194,11 +222,18 @@ async fn write_export(
     };
     let path = handle.path().to_path_buf();
     match std::fs::write(&path, &bytes) {
-        Ok(()) => log.write().push(format!(
-            "Saved {} byte(s) to {}",
-            bytes.len(),
-            path.display()
-        )),
+        Ok(()) => {
+            // Remembered on success only, and only the folder: a failed write says nothing about
+            // where the user meant to put things.
+            if let Some(parent) = path.parent() {
+                remember_dialog_dir(DialogPurpose::Save, parent);
+            }
+            log.write().push(format!(
+                "Saved {} byte(s) to {}",
+                bytes.len(),
+                path.display()
+            ))
+        }
         Err(e) => log
             .write()
             .push(format!("Failed to write {}: {e}", path.display())),
@@ -223,10 +258,13 @@ fn extend_pool(mut sig: Signal<Vec<String>>, picked: Vec<String>) {
 #[cfg(target_os = "macos")]
 async fn pick_files_or_folders_into(sig: Signal<Vec<String>>) {
     let picked = AsyncFileDialog::new()
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Open))
         .pick_files_or_folders()
         .await;
     if let Some(picked) = picked {
+        if let Some(first) = picked.first() {
+            remember_pick(DialogPurpose::Open, first.path());
+        }
         extend_pool(
             sig,
             picked
@@ -241,10 +279,13 @@ async fn pick_files_or_folders_into(sig: Signal<Vec<String>>) {
 #[cfg(not(target_os = "macos"))]
 async fn pick_folders_into(sig: Signal<Vec<String>>) {
     let picked = AsyncFileDialog::new()
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Open))
         .pick_folders()
         .await;
     if let Some(picked) = picked {
+        if let Some(first) = picked.first() {
+            remember_pick(DialogPurpose::Open, first.path());
+        }
         extend_pool(
             sig,
             picked
@@ -269,10 +310,13 @@ async fn pick_files_into(
     let picked = AsyncFileDialog::new()
         .add_filter(filter_name, extensions)
         .add_filter("All Files", &["*"])
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Open))
         .pick_files()
         .await;
     if let Some(picked) = picked {
+        if let Some(first) = picked.first() {
+            remember_pick(DialogPurpose::Open, first.path());
+        }
         extend_pool(
             sig,
             picked
@@ -298,10 +342,11 @@ async fn pick_file_into(
         // browser's revocation inputs on 2026-08-20: what a file contains decides whether it is
         // usable, and every one of these readers already says so when handed something it cannot use.
         .add_filter("All Files", &["*"])
-        .set_directory(home_dir().unwrap_or("/".into()))
+        .set_directory(dialog_dir(DialogPurpose::Open))
         .pick_file()
         .await;
     if let Some(file) = file {
+        remember_pick(DialogPurpose::Open, file.path());
         sig.set(file.path().to_string_lossy().to_string());
     }
 }
@@ -309,17 +354,21 @@ async fn pick_file_into(
 /// Serializes the validation report to pretty JSON and writes it to a user-chosen file.
 async fn save_report(report: ValidationReport) {
     let file = AsyncFileDialog::new()
+        .set_directory(dialog_dir(DialogPurpose::Save))
         .add_filter("JSON", &["json"])
         .set_file_name("pittv3-results.json")
         .save_file()
         .await;
     if let Some(file) = file {
         match serde_json::to_string_pretty(&report) {
-            Ok(json) => {
-                if let Err(e) = std::fs::write(file.path(), json) {
-                    error!("Failed to write results file: {e}");
+            Ok(json) => match std::fs::write(file.path(), json) {
+                Err(e) => error!("Failed to write results file: {e}"),
+                Ok(()) => {
+                    if let Some(parent) = file.path().parent() {
+                        remember_dialog_dir(DialogPurpose::Save, parent);
+                    }
                 }
-            }
+            },
             Err(e) => error!("Failed to serialize results: {e}"),
         }
     }
@@ -1027,8 +1076,13 @@ pub(crate) fn App() -> Element {
     });
     let s_logging_config = use_signal(|| sa.logging_config.clone().unwrap_or_default());
     let s_error_folder = use_signal(|| sa.error_folder.clone().unwrap_or_default());
-    let s_download_folder = use_signal(|| sa.download_folder.clone().unwrap_or_default());
-    let s_ca_folder = use_signal(|| sa.ca_folder.clone().unwrap_or_default());
+    // Same shape as the settings file below: a saved value wins, otherwise a default under
+    // ~/.pittv3 so a machine that has never been configured is not refused on its first run. The
+    // default is put *into the field* rather than resolved behind it, so what the run will use is
+    // visible and can be changed or cleared.
+    let s_download_folder =
+        use_signal(|| saved_or_default(sa.download_folder.clone(), default_download_folder));
+    let s_ca_folder = use_signal(|| saved_or_default(sa.ca_folder.clone(), default_ca_folder));
     let s_generate = use_signal(|| sa.generate);
     let s_chase_aia_and_sia = use_signal(|| sa.chase_aia_and_sia);
     let s_cbor_ta_store = use_signal(|| sa.cbor_ta_store);
@@ -1040,14 +1094,9 @@ pub(crate) fn App() -> Element {
     // Effective settings file. Saved args win; otherwise the default in ~/.pittv3 so the app always
     // has settings, matching the browser frontend where localStorage always answers. The file need
     // not exist — read_settings treats a missing path as "all defaults".
-    let mut s_settings = use_signal(|| {
-        sa.settings
-            .clone()
-            .filter(|p| !p.is_empty())
-            .or_else(default_settings_path)
-            .unwrap_or_default()
-    });
-    let s_crl_folder = use_signal(|| sa.crl_folder.clone().unwrap_or_default());
+    let mut s_settings =
+        use_signal(|| saved_or_default(sa.settings.clone(), default_settings_path));
+    let s_crl_folder = use_signal(|| saved_or_default(sa.crl_folder.clone(), default_crl_folder));
     let s_cleanup = use_signal(|| sa.cleanup);
     let s_ta_cleanup = use_signal(|| sa.ta_cleanup);
     let s_report_only = use_signal(|| sa.report_only);
@@ -1079,6 +1128,11 @@ pub(crate) fn App() -> Element {
     // validating a second time. Held outside the signal system because the run produces it on a
     // worker thread; see `save::RetainedArtifacts`.
     let retained: RetainedArtifacts = use_hook(|| Arc::new(Mutex::new(None)));
+    // The moment the run began, which is what its saved artifacts are named after. Held so the
+    // archive and the path log carry the same name: they are separate buttons, so stamping at each
+    // save gave one run two names differing by however long the user took between clicks. `None`
+    // until a run starts, which the save buttons are disabled for anyway.
+    let mut s_run_stamp = use_signal(|| None::<u64>);
     let mut s_export_name = use_signal(|| DEFAULT_EXPORT_NAME.to_string());
     // Whether the last run left anything to save. The artifacts live behind a mutex the worker
     // thread fills, which the rsx cannot observe, so the buttons key off this instead.
@@ -1284,6 +1338,7 @@ pub(crate) fn App() -> Element {
                 *held = None;
             }
             s_can_export.set(false);
+            s_run_stamp.set(Some(now_as_unix_epoch()));
             let run_retained = retained.clone();
             let done_retained = retained.clone();
 
@@ -1363,7 +1418,10 @@ pub(crate) fn App() -> Element {
         let retained = retained.clone();
         move |_: MouseEvent| {
             let retained = retained.clone();
-            let name = save::export_name(&s_export_name());
+            let name = stamped_export_name(
+                &s_export_name(),
+                s_run_stamp().unwrap_or_else(now_as_unix_epoch),
+            );
             spawn(async move {
                 match save::artifacts_archive(&retained, &name) {
                     Ok(None) => s_log
@@ -1385,7 +1443,10 @@ pub(crate) fn App() -> Element {
         let retained = retained.clone();
         move |_: MouseEvent| {
             let retained = retained.clone();
-            let name = save::export_name(&s_export_name());
+            let name = stamped_export_name(
+                &s_export_name(),
+                s_run_stamp().unwrap_or_else(now_as_unix_epoch),
+            );
             spawn(async move {
                 match save::path_logs_text(&retained) {
                     None => s_log

--- a/pittv3-gui/src/save.rs
+++ b/pittv3-gui/src/save.rs
@@ -78,53 +78,9 @@ pub(crate) fn path_logs_text(artifacts: &RetainedArtifacts) -> Option<String> {
     }
 }
 
-/// The name an export takes when the user has not chosen one. The field is pre-populated with it,
-/// as the browser's is, so the common case needs no typing and both frontends produce a bundle under
-/// the same name for the same run.
-pub(crate) const DEFAULT_EXPORT_NAME: &str = "PITTv3Results";
-
-/// A filename stem for an export, from what the user typed or [`DEFAULT_EXPORT_NAME`] when the field
-/// has been cleared.
-///
-/// Sanitized because the value names a file and a folder inside the archive: a separator here would
-/// scatter the contents or, worse, land them somewhere other than where the save dialog said.
-pub(crate) fn export_name(typed: &str) -> String {
-    let trimmed = typed.trim();
-    let cleaned: String = trimmed
-        .chars()
-        .map(|c| match c {
-            '/' | '\\' | ':' => '_',
-            c => c,
-        })
-        .collect();
-    match cleaned.is_empty() {
-        true => DEFAULT_EXPORT_NAME.to_string(),
-        false => cleaned,
-    }
-}
-
 #[cfg(test)]
 mod tests {
     use super::*;
-
-    #[test]
-    fn a_cleared_name_falls_back_to_the_one_the_field_starts_with() {
-        assert_eq!(export_name(""), DEFAULT_EXPORT_NAME);
-        assert_eq!(export_name("   "), DEFAULT_EXPORT_NAME);
-    }
-
-    /// The name reaches a filesystem path and an archive entry, so a separator in it is not a name
-    /// but an instruction about where things land.
-    #[test]
-    fn separators_are_not_carried_into_the_name() {
-        assert_eq!(export_name("../etc/passwd"), ".._etc_passwd");
-        assert_eq!(export_name("C:\\runs\\one"), "C__runs_one");
-    }
-
-    #[test]
-    fn a_typed_name_is_kept_and_trimmed() {
-        assert_eq!(export_name("  dod run 3 "), "dod run 3");
-    }
 
     /// Nothing retained is not a failure -- it is the state before the first run, and after a run
     /// that found no paths.

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -27,7 +27,9 @@ use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::report::{RevocationStatus, TargetReport, ValidationReport};
 use pittv3_lib::uri_check::{check_uris_in_cert, UriCheckReport};
 
-use pittv3_gui_lib::export::{path_entries, paths_text, zip_paths};
+use pittv3_gui_lib::export::{
+    path_entries, paths_text, stamped_export_name, zip_paths, DEFAULT_EXPORT_NAME,
+};
 use pittv3_gui_lib::retrieval::{add_uploaded_crl, harvest_revocation_work, staple_uploaded_ocsp};
 
 use crate::relay::{
@@ -539,7 +541,11 @@ fn App() -> Element {
     // than generated because a bundle is usually about to be handed to someone else, and "the DoD
     // email cert Armen reported" survives that trip where a timestamp does not. PITTv2 prompts for
     // the same thing.
-    let mut export_name = use_signal(|| "PITTv3Results".to_string());
+    let mut export_name = use_signal(|| DEFAULT_EXPORT_NAME.to_string());
+    // The moment the run began, which its saved artifacts are named after. Held so the archive and
+    // the path log carry the same name rather than one each, stamped however long apart the two
+    // buttons were clicked. `None` until a run starts.
+    let mut run_stamp = use_signal(|| None::<u64>);
 
     // What asking a service for its stores produced, in a sentence, for the Resources view. A
     // statically hosted copy finding no service is the ordinary case and not a failure, but "the
@@ -774,7 +780,10 @@ fn App() -> Element {
             });
             return;
         }
-        let name = export_name();
+        let name = stamped_export_name(
+            &export_name(),
+            run_stamp().unwrap_or_else(now_as_unix_epoch),
+        );
         match zip_paths(&name, &entries) {
             Ok(zipped) => {
                 let js = format!(
@@ -802,7 +811,10 @@ fn App() -> Element {
             });
             return;
         }
-        let name = export_name();
+        let name = stamped_export_name(
+            &export_name(),
+            run_stamp().unwrap_or_else(now_as_unix_epoch),
+        );
         let uri = format!("data:text/plain;charset=utf-8,{}", percent_encode(&text));
         let js = format!(
             "const a = document.createElement('a'); a.href = \"{uri}\"; a.download = \"{name}.txt\"; a.click();"
@@ -934,6 +946,7 @@ fn App() -> Element {
     // own tab, so it is a separate action from certificate validation
     let validate_zips = move |_| {
         let started = Instant::now();
+        run_stamp.set(Some(now_as_unix_epoch()));
         // each Validate replaces the prior results rather than appending to them
         targets.write().clear();
         notes.write().clear();
@@ -992,6 +1005,7 @@ fn App() -> Element {
 
     let validate_loaded = move || async move {
         let started = Instant::now();
+        run_stamp.set(Some(now_as_unix_epoch()));
         // each Validate replaces the prior results rather than appending to them
         targets.write().clear();
         notes.write().clear();


### PR DESCRIPTION
- In desktop app, remember the last folder. Two flavors are recorded in ~/.pittv3/dialogs.json: one for reading and one for writing.
- Add a UTC timestamp to each run and append that timestamp to the base file name when exporting logs and artifacts. Taken at run start and shared by both save buttons, so an archive and its path log match.
- Use default CA, downloads, and CRL folders in the .pittv3 folder if no user selection has been entered. The defaults are visible in the fields where used.
- A default CRL folder also means a CrlSource is always registered, so fetched CRLs are retained and reach the artifact export.