### PR TITLE
Revocation cache management, folder maintenance, and graph cache fixes

### DIFF
--- a/certval/src/builder/file_utils.rs
+++ b/certval/src/builder/file_utils.rs
@@ -289,48 +289,28 @@ fn cert_or_ta_folder_to_vec(
     Ok(certsvec.len() - initial_count)
 }
 
-/// Returns the file that records URI last-modified values: the [`PS_LAST_MODIFIED_MAP_FILE`] setting
-/// when one names a file, and `last_modified_map.json` in `download_folder` otherwise.
+/// Returns the file that records URI last-modified values: `last_modified_map.json` in
+/// `download_folder`.
 ///
-/// The setting is documented as the way to name this file and the getter has always existed, but the
-/// callers that fetch built the path from the download folder and never consulted it -- so a value
-/// the settings form accepted, stored and redisplayed had no effect on a run. Resolving it in one
-/// place keeps the precedence from being restated per call site.
+/// It lives in the folder it describes, and there is no setting to put it elsewhere. The map is a
+/// claim about what that folder holds, so separating the two is what lets them disagree — a folder
+/// emptied while its map survives leaves every URI answered 304 and nothing on disk to read. Keeping
+/// them together means anything that removes the folder's contents removes the claim with them.
 #[cfg(feature = "std")]
-pub fn last_modified_map_file(cps: &CertificationPathSettings, download_folder: &str) -> String {
-    fetch_state_file(
-        cps.get_last_modified_map_file(),
-        download_folder,
-        "last_modified_map.json",
-    )
+pub fn last_modified_map_file(download_folder: &str) -> String {
+    fetch_state_file(download_folder, "last_modified_map.json")
 }
 
-/// Returns the file listing URIs not worth retrying: the [`PS_URI_BLOCKLIST_FILE`] setting when one
-/// names a file, and `blocklist.json` in `download_folder` otherwise. See
-/// [`last_modified_map_file`] for why the resolution lives here.
+/// Returns the file listing URIs not worth retrying: `blocklist.json` in `download_folder`. Kept
+/// beside the material it describes for the reason on [`last_modified_map_file`].
 #[cfg(feature = "std")]
-pub fn uri_blocklist_file(cps: &CertificationPathSettings, download_folder: &str) -> String {
-    fetch_state_file(
-        cps.get_uri_blocklist_file(),
-        download_folder,
-        "blocklist.json",
-    )
+pub fn uri_blocklist_file(download_folder: &str) -> String {
+    fetch_state_file(download_folder, "blocklist.json")
 }
 
-/// An empty configured value is treated as absent rather than as a request to use "": the settings
-/// form writes an empty string when a field is cleared, and honoring that literally would send the
-/// reader at a path that cannot exist.
+/// A file the fetching machinery keeps beside what it fetched.
 #[cfg(feature = "std")]
-fn fetch_state_file(
-    configured: Option<String>,
-    download_folder: &str,
-    default_name: &str,
-) -> String {
-    if let Some(configured) = configured {
-        if !configured.is_empty() {
-            return configured;
-        }
-    }
+fn fetch_state_file(download_folder: &str, default_name: &str) -> String {
     Path::new(download_folder)
         .join(default_name)
         .to_str()

--- a/certval/src/builder/graph_builder.rs
+++ b/certval/src/builder/graph_builder.rs
@@ -104,8 +104,8 @@ pub async fn build_graph(pe: &PkiEnvironment, cps: &CertificationPathSettings) -
         let mut uris_count = 0;
         let max_certs = cps.get_max_aia_sia_certs();
 
-        let lmm_file = last_modified_map_file(cps, &download_folder);
-        let blocklist_file = uri_blocklist_file(cps, &download_folder);
+        let lmm_file = last_modified_map_file(&download_folder);
+        let blocklist_file = uri_blocklist_file(&download_folder);
 
         loop {
             {

--- a/certval/src/source/crl_source.rs
+++ b/certval/src/source/crl_source.rs
@@ -645,9 +645,12 @@ fn index_crls_internal(
 
                             // Store indexing is lenient about an absent nextUpdate (Duration::MAX):
                             // the fail-closed staleness decision belongs to path validation, which
-                            // reads the operator's PS_REVOCATION_MAX_AGE. Deleting a nextUpdate-less
-                            // CRL here would discard one that a validation configured with a tolerance
-                            // could still use. A CRL with an expired nextUpdate is still pruned below.
+                            // reads the operator's PS_REVOCATION_MAX_AGE. A nextUpdate-less CRL is
+                            // therefore indexed, since a validation configured with a tolerance can
+                            // still use it.
+                            //
+                            // A CRL that does not cover the time of interest is skipped, NOT deleted.
+                            // Skipping leaves the file for a run whose time of interest it does cover.
                             if check_crl_validity(toi, core::time::Duration::MAX, &crl).is_ok() {
                                 add_crl_info(
                                     crl_info,
@@ -657,10 +660,10 @@ fn index_crls_internal(
                                     &crl,
                                     cur_crl_info,
                                 );
-                            } else if fs::remove_file(e.path()).is_err() {
-                                if let Some(filename) = e.path().to_str() {
-                                    error!("Failed to delete stale CRL at {filename}");
-                                }
+                            } else if let Some(filename) = e.path().to_str() {
+                                debug!(
+                                    "Not indexing {filename}: it does not cover the time of interest"
+                                );
                             }
                         }
                         Err(_) => {
@@ -841,10 +844,9 @@ mod tests {
             fs::read(&der).unwrap()
         );
 
-        // Indexed from a copy because indexing DELETES any CRL that is not valid at the time of
-        // interest, and this CRL expired in 2022. TimeOfInterest::disabled() skips the validity
-        // check, so nothing is pruned as written; the copy is what keeps the fixtures safe if that
-        // time of interest is ever changed.
+        // Indexed from a copy, which used to be necessary because indexing deleted any CRL not
+        // valid at the time of interest and this CRL expired in 2022. Indexing no longer deletes
+        // anything, so the copy is now only isolation from whatever else a test run does.
         let dir = tempfile::tempdir().unwrap();
         for name in ["AmazonRootCA1.der.crl", "AmazonRootCA1.pem.crl"] {
             fs::copy(fixtures.join(name), dir.path().join(name)).unwrap();
@@ -870,8 +872,8 @@ mod tests {
     fn premature_return_upon_crl_parse_error() {
         let fixtures = Path::new("tests/examples/pem_crl");
 
-        // Copied for the same reason as the test above: indexing deletes CRLs that are not valid at
-        // the time of interest, and TimeOfInterest::disabled() is what keeps this one from pruning.
+        // Copied for the same reason as the test above. Indexing no longer deletes anything, so the
+        // copy is belt and braces rather than a requirement.
         let dir = tempfile::tempdir().unwrap();
         fs::copy(
             fixtures.join("AmazonRootCA1.der.crl"),

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -435,10 +435,6 @@ pub static PS_TRUST_ANCHOR_FOLDER: &str = "psTrustAnchorFolder";
 pub static PS_CERTIFICATION_AUTHORITY_FOLDER: &str = "psCertificationAuthorityFolder";
 /// PS_DOWNLOAD_FOLDER is used to retrieve a String value containing the full path of a folder where certificates downloaded via SIA or AIA should be stored
 pub static PS_DOWNLOAD_FOLDER: &str = "psDownloadFolder";
-/// PS_LAST_MODIFIED_MAP_FILE is used to retrieve a String value containing the full path and filename of a file mapping URIs to last modified values
-pub static PS_LAST_MODIFIED_MAP_FILE: &str = "psLastModifiedMapFile";
-/// PS_URI_BLOCKLIST_FILE is used to retrieve a String value containing the full path and filename of a file that lists non-functional URIs that should be avoided
-pub static PS_URI_BLOCKLIST_FILE: &str = "psUriBlocklistFile";
 /// PS_CBOR_TA_STORE is used to indicate a generated graph will include only trust anchors, so no need for partial paths and no need to exclude self-signed certificates.
 pub static PS_CBOR_TA_STORE: &str = "psCborTaStore";
 /// PS_REQUIRE_TA_STORE is used to indicate that the validator should require a TA to affirm given TA is actually a TA.
@@ -840,6 +836,7 @@ pub fn read_settings(fname: &Option<String>) -> Result<CertificationPathSettings
                 let r: SerdeResult<CertificationPathSettings> = serde_json::from_slice(&json);
                 match r {
                     Ok(cps) => {
+                        warn_retired_keys(&cps);
                         return Ok(cps);
                     }
                     Err(_e) => return Err(Error::ParseError),
@@ -850,11 +847,27 @@ pub fn read_settings(fname: &Option<String>) -> Result<CertificationPathSettings
     Ok(CertificationPathSettings::new())
 }
 
+/// Names a settings file may still carry that no longer do anything.
+///
+/// Both once pointed the last-modified map and the URI blocklist somewhere other than the folder
+/// whose contents they describe. Those files now live beside that material and cannot be moved: a
+/// map kept apart from the folder it describes can outlive it, and then every URI is answered 304
+/// with nothing on disk to read. A file naming them still parses, so say so rather than ignore it
+/// silently — the value is visibly there and its effect is not.
+#[cfg(feature = "std")]
+fn warn_retired_keys(cps: &CertificationPathSettings) {
+    for key in ["psLastModifiedMapFile", "psUriBlocklistFile"] {
+        if cps.0.contains_key(key) {
+            log::warn!(
+                "Ignoring {key}: the last-modified map and the URI blocklist are kept in the folder they describe and can no longer be relocated"
+            );
+        }
+    }
+}
+
 cps_gets_and_sets!(PS_TRUST_ANCHOR_FOLDER, String);
 cps_gets_and_sets!(PS_CERTIFICATION_AUTHORITY_FOLDER, String);
 cps_gets_and_sets!(PS_DOWNLOAD_FOLDER, String);
-cps_gets_and_sets!(PS_LAST_MODIFIED_MAP_FILE, String);
-cps_gets_and_sets!(PS_URI_BLOCKLIST_FILE, String);
 cps_gets_and_sets_with_default!(PS_CBOR_TA_STORE, bool, false);
 
 #[test]
@@ -948,8 +961,6 @@ fn test_no_default_gets_cps() {
     assert_eq!(None, cps.get_trust_anchor_folder());
     assert_eq!(None, cps.get_certification_authority_folder());
     assert_eq!(None, cps.get_download_folder());
-    assert_eq!(None, cps.get_last_modified_map_file());
-    assert_eq!(None, cps.get_uri_blocklist_file());
 }
 
 #[test]
@@ -1174,10 +1185,4 @@ fn test_no_default_sets_cps() {
     assert_eq!(&f, &cps.get_certification_authority_folder().unwrap());
     cps.set_download_folder(f.clone());
     assert_eq!(&f, &cps.get_download_folder().unwrap());
-
-    let f = "/some/file.txt".to_string();
-    cps.set_last_modified_map_file(f.clone());
-    assert_eq!(&f, &cps.get_last_modified_map_file().unwrap());
-    cps.set_uri_blocklist_file(f.clone());
-    assert_eq!(&f, &cps.get_uri_blocklist_file().unwrap());
 }

--- a/pittv3-gui-lib/src/gui_rows.rs
+++ b/pittv3-gui-lib/src/gui_rows.rs
@@ -243,6 +243,12 @@ pub fn CheckboxRow(
     /// argument help for `name`, so a control named after a flag is described in the flag's words.
     #[props(default)]
     title: String,
+    /// Whether the control is settable. A checkbox whose value is dictated by another setting is
+    /// shown disabled rather than hidden, so the state it is being held at stays visible: hiding it
+    /// would leave the run behaving in a way nothing on screen accounts for. The caller is
+    /// responsible for holding the signal at the value it displays.
+    #[props(default)]
+    disabled: bool,
 ) -> Element {
     let title = tooltip(title, &name);
     rsx! {
@@ -254,6 +260,7 @@ pub fn CheckboxRow(
                 r#type: "checkbox",
                 name,
                 checked: sig(),
+                disabled,
                 onchange: move |ev| sig.set(ev.checked()),
             }
         }

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -569,6 +569,19 @@ pub fn EditSettings(
     /// default applies, which is the case for the desktop and the CLI.
     #[props(default)]
     revocation_default: Option<bool>,
+    /// Rows the frontend adds to the Folders & files tab, rendered inside that tab's grid so they
+    /// line up with the rows above them.
+    ///
+    /// The desktop uses it for settings that are `Pittv3Args` fields rather than
+    /// `CertificationPathSettings` keys — a results folder, an error folder, a logging
+    /// configuration — and for the actions that maintain those folders. They cannot be *stored*
+    /// with the settings above, since this form's file is the CLI's `-s` JSON and must stay that,
+    /// but to the person using the app they are folders like the rest and belong beside them.
+    /// Nothing here knows what is in them or where the frontend persists them.
+    ///
+    /// `Option` because `Element` is a `Result` and has no `Default` for the props derive.
+    #[props(default)]
+    extra_folder_rows: Option<Element>,
     on_save: EventHandler<SettingsModel>,
     on_close: EventHandler<()>,
 ) -> Element {
@@ -886,22 +899,15 @@ pub fn EditSettings(
                             value: m.download_folder.clone(),
                             onchange: move |v| model.write().download_folder = v,
                         }
-                        SettingTextRow {
-                            label: "Last-modified map file",
-                            value: m.last_modified_map_file.clone(),
-                            onchange: move |v| model.write().last_modified_map_file = v,
-                        }
-                        SettingTextRow {
-                            label: "URI blocklist file",
-                            value: m.uri_blocklist_file.clone(),
-                            onchange: move |v| model.write().uri_blocklist_file = v,
-                        }
                         BoolRow {
                             label: "CBOR contains only trust anchors",
                             checked: m.cbor_ta_store.unwrap_or(false),
                             overridden: m.cbor_ta_store.is_some(),
                             onchange: move |v| model.write().cbor_ta_store = Some(v),
                         }
+                        // Inside the grid, not after it: a second `.controls` alongside would
+                        // measure its own label column and none of the labels would line up.
+                        {extra_folder_rows.clone()}
                     }
                 },
             }
@@ -927,7 +933,13 @@ pub fn EditSettings(
 /// and writes the edited settings back on save, preserving settings the form does not cover.
 #[cfg(feature = "std")]
 #[component]
-pub fn EditSettingsFile(path: String, on_close: EventHandler<()>) -> Element {
+pub fn EditSettingsFile(
+    path: String,
+    /// Passed to [`EditSettings`]; see its documentation.
+    #[props(default)]
+    extra_folder_rows: Option<Element>,
+    on_close: EventHandler<()>,
+) -> Element {
     let initial = use_hook({
         let path = path.clone();
         move || SettingsModel::from_cps(&FileSettingsStore::new(path).load())
@@ -960,6 +972,7 @@ pub fn EditSettingsFile(path: String, on_close: EventHandler<()>) -> Element {
         EditSettings {
             initial,
             caps: Capabilities::desktop(),
+            extra_folder_rows,
             on_save,
             on_close: move |_| on_close.call(()),
         }

--- a/pittv3-gui-lib/src/gui_settings_model.rs
+++ b/pittv3-gui-lib/src/gui_settings_model.rs
@@ -123,10 +123,6 @@ pub struct SettingsModel {
     pub certification_authority_folder: Option<String>,
     /// Folder to receive downloaded artifacts
     pub download_folder: Option<String>,
-    /// File containing the last-modified map used when fetching
-    pub last_modified_map_file: Option<String>,
-    /// File containing the URI blocklist used when fetching
-    pub uri_blocklist_file: Option<String>,
     /// Generated CBOR contains only trust anchors
     pub cbor_ta_store: Option<bool>,
 }
@@ -207,8 +203,6 @@ impl SettingsModel {
             trust_anchor_folder: cps.get_trust_anchor_folder(),
             certification_authority_folder: cps.get_certification_authority_folder(),
             download_folder: cps.get_download_folder(),
-            last_modified_map_file: cps.get_last_modified_map_file(),
-            uri_blocklist_file: cps.get_uri_blocklist_file(),
             cbor_ta_store: present(cps, PS_CBOR_TA_STORE).then(|| cps.get_cbor_ta_store()),
         }
     }
@@ -425,18 +419,6 @@ impl SettingsModel {
         set_or_remove(cps, PS_DOWNLOAD_FOLDER, &self.download_folder, |c, v| {
             c.set_download_folder(v)
         });
-        set_or_remove(
-            cps,
-            PS_LAST_MODIFIED_MAP_FILE,
-            &self.last_modified_map_file,
-            |c, v| c.set_last_modified_map_file(v),
-        );
-        set_or_remove(
-            cps,
-            PS_URI_BLOCKLIST_FILE,
-            &self.uri_blocklist_file,
-            |c, v| c.set_uri_blocklist_file(v),
-        );
         set_or_remove(cps, PS_CBOR_TA_STORE, &self.cbor_ta_store, |c, v| {
             c.set_cbor_ta_store(v)
         });

--- a/pittv3-gui-lib/src/settings_store.rs
+++ b/pittv3-gui-lib/src/settings_store.rs
@@ -106,6 +106,19 @@ pub fn default_download_folder() -> Option<String> {
     app_home_folder("downloads")
 }
 
+/// Default folder for material a run set aside, `errors` in [`app_home`].
+///
+/// The one default here that changes what an action *does* rather than only where it looks. Cleanup
+/// deletes what it removes when no error folder is set and moves it when one is, so naming a
+/// default makes cleanup non-destructive: an expired intermediate or a superseded CRL ends up in
+/// `errors` instead of gone. That matters because neither is always refetchable, and both are
+/// exactly what a validation at a past time of interest needs. Failing paths' certificates are
+/// written here too.
+#[cfg(feature = "std")]
+pub fn default_error_folder() -> Option<String> {
+    app_home_folder("errors")
+}
+
 /// Default CRL index folder, `crls` in [`app_home`]. See [`default_ca_folder`] for why these are
 /// offered rather than resolved.
 ///

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -38,18 +38,20 @@ use pittv3_gui_lib::gui_utils::{
     ChannelAppender, DialogPurpose,
 };
 use pittv3_gui_lib::settings_store::{
-    default_ca_folder, default_crl_folder, default_download_folder, default_settings_path,
-    expand_tilde, saved_or_default,
+    default_ca_folder, default_crl_folder, default_download_folder, default_error_folder,
+    default_settings_path, expand_tilde, saved_or_default,
 };
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
 use pittv3_lib::graph_cache;
 use pittv3_lib::options_std::options_std_retaining;
 use pittv3_lib::report::ValidationReport;
+use pittv3_lib::std_utils::{cleanup_certificate_folder, cleanup_crls, purge_folder};
 use pittv3_lib::std_utils::{
     count_ca_inputs, count_end_entity_inputs, count_revocation_inputs, count_trust_anchor_inputs,
 };
 use pittv3_lib::uri_check::{check_uris_from_bytes, UriCheckReport};
+use pittv3_lib::RevocationCache;
 
 use crate::peek;
 use crate::stores;
@@ -198,6 +200,25 @@ async fn pick_file_or_folder_into(mut sig: Signal<String>) {
 /// A save dialog rather than a fixed location: this is the user's own copy of what a run used, and
 /// the desktop's other writes -- the peek folder, a materialized store -- go under the application
 /// home precisely because nobody chose where they should live. Here somebody is choosing.
+/// Confirms an action that cannot be undone by fetching the material again.
+///
+/// Cleanup is offered without one: what it removes is unusable or refetchable, and asking every
+/// time is how a confirmation stops being read. Purge takes everything, including artifacts a
+/// repository may no longer publish, so it asks.
+async fn confirm_purge(folder: &str) -> bool {
+    rfd::AsyncMessageDialog::new()
+        .set_title("Purge folder")
+        .set_description(format!(
+            "Remove every file in {folder}?\n\nCertificates can generally be fetched again. A \
+             superseded CRL usually cannot: a CA publishes the current one and nothing else, so \
+             validating as of a time it covered will no longer be possible."
+        ))
+        .set_buttons(rfd::MessageButtons::YesNo)
+        .show()
+        .await
+        == rfd::MessageDialogResult::Yes
+}
+
 /// Where a file dialog should open: the folder that kind of dialog last used, falling back to the
 /// user's home as it always did when nothing has been remembered yet.
 fn dialog_dir(purpose: DialogPurpose) -> std::path::PathBuf {
@@ -1075,7 +1096,8 @@ pub(crate) fn App() -> Element {
         }
     });
     let s_logging_config = use_signal(|| sa.logging_config.clone().unwrap_or_default());
-    let s_error_folder = use_signal(|| sa.error_folder.clone().unwrap_or_default());
+    let s_error_folder =
+        use_signal(|| saved_or_default(sa.error_folder.clone(), default_error_folder));
     // Same shape as the settings file below: a saved value wins, otherwise a default under
     // ~/.pittv3 so a machine that has never been configured is not refused on its first run. The
     // default is put *into the field* rather than resolved behind it, so what the run will use is
@@ -1087,9 +1109,38 @@ pub(crate) fn App() -> Element {
     let s_chase_aia_and_sia = use_signal(|| sa.chase_aia_and_sia);
     let s_cbor_ta_store = use_signal(|| sa.cbor_ta_store);
     let s_validate_all = use_signal(|| sa.validate_all);
+    // Held in the browser's polarity, not the argument's. `Pittv3Args` carries the CLI's
+    // `no_revocation_cache`, because a clap bool flag names a deviation from the default; a
+    // checkbox names a state, and the browser already settled which state it shows. Inverting here
+    // keeps the two apps' controls reading the same way round -- see the wasm app's
+    // "Reuse revocation determinations".
+    let s_reuse_rev_cache = use_signal(|| !sa.no_revocation_cache);
+    // Owned here rather than made per run, so a certificate checked on one Validate is not checked
+    // again on the next. `Arc<RevocationCache>` implements `RevocationStatusCache` for exactly this
+    // -- the run registers a clone and the handle stays here to be cleared.
+    let rev_cache = use_hook(|| Arc::new(RevocationCache::new()));
+    let rev_cache_for_toggle = rev_cache.clone();
+    let mut s_rev_cache_status = use_signal(String::new);
+    // Turning reuse off and on again must not bring back the determinations the user was trying to
+    // stop reusing, so the toggle clears -- the browser's rule, and its reason. It fires once on
+    // first render against an empty cache, which costs nothing.
+    //
+    // What the desktop cannot do that the browser does is clear on a settings change: settings here
+    // live in a file that can change without the app being told, and a cached answer vetted under
+    // one revocation policy is not vetted under a stricter one, nor valid again if the time of
+    // interest moves backward. That is what the Clear button is for, and why its hint says so.
+    use_effect(move || {
+        let _ = s_reuse_rev_cache();
+        rev_cache_for_toggle.clear();
+    });
     let s_validate_self_signed = use_signal(|| sa.validate_self_signed);
     let s_dynamic_build = use_signal(|| sa.dynamic_build);
-    let s_use_downloaded_cas = use_signal(|| sa.use_downloaded_cas);
+    // No control: the run always builds from what earlier runs downloaded. The toggle that used to
+    // sit here was really "I do not trust what has piled up in that folder", and the Cleanup and
+    // Purge buttons answer that directly -- the folder gets fixed instead of routed around. The CLI
+    // keeps `--use-downloaded-cas` for a genuinely self-contained run.
+    let s_use_downloaded_cas = use_signal(|| true);
+    let mut s_folder_status = use_signal(String::new);
     let s_results_folder = use_signal(|| sa.results_folder.clone().unwrap_or_default());
     // Effective settings file. Saved args win; otherwise the default in ~/.pittv3 so the app always
     // has settings, matching the browser frontend where localStorage always answers. The file need
@@ -1200,6 +1251,7 @@ pub(crate) fn App() -> Element {
             crl_folder: path_or_none(s_crl_folder),
             rev_inputs: pool(s_rev_inputs),
             keep_crl_entries_in_memory: false,
+            no_revocation_cache: !s_reuse_rev_cache(),
             cleanup: s_cleanup(),
             ta_cleanup: s_ta_cleanup(),
             report_only: s_report_only(),
@@ -1264,6 +1316,7 @@ pub(crate) fn App() -> Element {
 
     let run_command = {
         let retained = retained.clone();
+        let rev_cache = rev_cache.clone();
         move |_: ()| {
             if s_running() {
                 return;
@@ -1339,6 +1392,7 @@ pub(crate) fn App() -> Element {
             }
             s_can_export.set(false);
             s_run_stamp.set(Some(now_as_unix_epoch()));
+            let run_cache = rev_cache.clone();
             let run_retained = retained.clone();
             let done_retained = retained.clone();
 
@@ -1359,7 +1413,8 @@ pub(crate) fn App() -> Element {
                 };
                 // Retention is asked for here and nowhere else: the desktop offers the artifacts after
                 // a run, so it keeps what the run built. The CLI passes false and pays nothing.
-                let (report, run_artifacts) = rt.block_on(options_std_retaining(&args, true));
+                let (report, run_artifacts) =
+                    rt.block_on(options_std_retaining(&args, true, Some(&run_cache)));
                 if let Ok(mut held) = run_retained.lock() {
                     *held = run_artifacts;
                 }
@@ -1635,26 +1690,57 @@ pub(crate) fn App() -> Element {
                                         sig: s_dynamic_build,
                                         title: "Fetch missing intermediates by following AIA and SIA URIs. They are written to the download folder, or the CA folder when none is set; name one on the Settings view.",
                                     }
+
+                                    // Label and hint are the browser's, verbatim: the same setting
+                                    // reading two ways round in the two apps is the divergence, not
+                                    // the wording. `arg_help` is not used here because it describes
+                                    // the argument, which is the negative of what this box shows.
+                                    // Kept in the main group rather than under Advanced because its
+                                    // absence is silent -- a run that reuses determinations produces
+                                    // a bundle short of evidence and says nothing about it.
                                     CheckboxRow {
-                                        label: "Use downloaded certificates",
-                                        name: "use-downloaded-cas",
-                                        sig: s_use_downloaded_cas,
-                                        title: "Build paths from what earlier runs downloaded as well, so a certificate already fetched is not fetched again.",
+                                        label: "Reuse revocation determinations",
+                                        name: "no-revocation-cache",
+                                        sig: s_reuse_rev_cache,
+                                        title: "On, a certificate checked on one path is not checked again on another, including across runs. Off, every path obtains its own revocation data - slower, but each path then carries the evidence for its own result, which an export needs.",
+                                    }
+                                    // Clearing is its own action rather than a side effect of the
+                                    // checkbox, which is the browser's arrangement and for its
+                                    // reason: turning reuse off to clear also changes how the run
+                                    // behaves, giving up the retrievals reuse would have spared.
+                                    //
+                                    // Emitted as grid children of the surrounding `.controls`, like
+                                    // every other row: a nested div becomes one grid item, blows out
+                                    // the `max-content` label column and pushes the rest off the
+                                    // view. The explanation is the button's tooltip rather than
+                                    // standing text, for the reason CheckboxRow's `title` documents.
+                                    div { class: "visible label-cell",
+                                        label { "Cached determinations: " }
+                                    }
+                                    div { class: "field",
+                                        button {
+                                            title: "Discards what has been determined so far without changing whether reuse is on. Use it after changing settings or the time of interest: a determination reached under the old ones is not re-checked against the new.",
+                                            onclick: {
+                                                let rev_cache = rev_cache.clone();
+                                                move |_| {
+                                                    rev_cache.clear();
+                                                    s_rev_cache_status
+                                                        .set(
+                                                            "Revocation determinations cleared."
+                                                                .to_string(),
+                                                        );
+                                                }
+                                            },
+                                            "Clear cached determinations"
+                                        }
+                                    }
+                                    // Transient, not standing text: it appears only after a click.
+                                    if !s_rev_cache_status().is_empty() {
+                                        span { class: "hint", "{s_rev_cache_status}" }
                                     }
                                 }
                                 details { class: "advanced",
                                     summary { "Advanced" }
-                                    div { class: "controls",
-                                        FolderRow { label: "Results Folder", name: "results-folder", sig: s_results_folder }
-                                        FolderRow { label: "Error Folder", name: "error-folder", sig: s_error_folder }
-                                        FileRow {
-                                            label: "Logging Configuration",
-                                            name: "logging-config",
-                                            sig: s_logging_config,
-                                            filter_name: "log4rs Configuration",
-                                            extensions: ["yaml"].as_slice(),
-                                        }
-                                    }
                                     div { class: "controls",
                                         div { class: "field check-group",
                                             // "WebPKI TAs" was here. It is an anchor set, so it is
@@ -1896,6 +1982,108 @@ pub(crate) fn App() -> Element {
                             } else {
                                 EditSettingsFile {
                                     path: s_settings(),
+                                    // Folders the run writes to, and the actions that maintain
+                                    // them, beside the folders it reads from. They persist with the
+                                    // rest of the args rather than into the settings file, which
+                                    // stays the CLI's `-s` JSON.
+                                    extra_folder_rows: Some(rsx! {
+                                        FolderRow { label: "Results Folder", name: "results-folder", sig: s_results_folder }
+                                        FolderRow { label: "Error Folder", name: "error-folder", sig: s_error_folder }
+                                        FileRow {
+                                            label: "Logging Configuration",
+                                            name: "logging-config",
+                                            sig: s_logging_config,
+                                            filter_name: "log4rs Configuration",
+                                            extensions: ["yaml"].as_slice(),
+                                        }
+                                        div { class: "visible label-cell",
+                                            label { "Downloaded certificates: " }
+                                        }
+                                        div { class: "field",
+                                            button {
+                                                title: "Removes certificates a run could not use: unparseable, expired at the time of interest, self-signed, or not a CA. Moved to the error folder rather than deleted whenever one is set, which it is by default.",
+                                                onclick: move |_| {
+                                                    let m = cleanup_certificate_folder(
+                                                        &s_download_folder(),
+                                                        &s_error_folder(),
+                                                        s_time_of_interest().parse().unwrap_or(0),
+                                                    );
+                                                    s_folder_status
+                                                        .set(format!("Removed {} downloaded certificate(s).", m.removed));
+                                                },
+                                                "Cleanup Downloads"
+                                            }
+                                            button {
+                                                title: "Removes every file in the download folder.",
+                                                onclick: move |_| {
+                                                    spawn(async move {
+                                                        let folder = s_download_folder();
+                                                        if confirm_purge(&folder).await {
+                                                            let m = purge_folder(&folder);
+                                                            s_folder_status
+                                                                .set(format!("Removed {} file(s) from the download folder.", m.removed));
+                                                        }
+                                                    });
+                                                },
+                                                "Purge Downloads"
+                                            }
+                                        }
+                                        div { class: "visible label-cell",
+                                            label { "CRL index: " }
+                                        }
+                                        div { class: "field",
+                                            button {
+                                                title: "Removes CRLs that do not cover the time of interest, and any file that cannot be read as a CRL. A superseded CRL generally cannot be fetched again, so this forecloses validating as of a time it covered.",
+                                                onclick: move |_| {
+                                                    let m = cleanup_crls(
+                                                        &s_crl_folder(),
+                                                        s_time_of_interest().parse().unwrap_or(0),
+                                                    );
+                                                    s_folder_status.set(format!("Removed {} CRL(s).", m.removed));
+                                                },
+                                                "Cleanup CRLs"
+                                            }
+                                            button {
+                                                title: "Removes every file in the CRL folder, including the last-modified map that makes fetches conditional.",
+                                                onclick: move |_| {
+                                                    spawn(async move {
+                                                        let folder = s_crl_folder();
+                                                        if confirm_purge(&folder).await {
+                                                            let m = purge_folder(&folder);
+                                                            s_folder_status
+                                                                .set(format!("Removed {} file(s) from the CRL folder.", m.removed));
+                                                        }
+                                                    });
+                                                },
+                                                "Purge CRLs"
+                                            }
+                                        }
+                                        div { class: "visible label-cell",
+                                            label { "Cached graphs: " }
+                                        }
+                                        div { class: "field",
+                                            button {
+                                                title: "Removes every cached graph. Nothing else removes one, and a run whose inputs, settings or time of interest differ from the last writes another, so the folder grows until it is emptied. Rebuilding one costs the partial-path search on the next run that needs it.",
+                                                onclick: move |_| {
+                                                    spawn(async move {
+                                                        let folder = graph_cache::cache_folder();
+                                                        if folder.is_empty() {
+                                                            s_folder_status
+                                                                .set("No graph cache folder to empty.".to_string());
+                                                        } else if confirm_purge(&folder).await {
+                                                            let m = purge_folder(&folder);
+                                                            s_folder_status
+                                                                .set(format!("Removed {} cached graph file(s).", m.removed));
+                                                        }
+                                                    });
+                                                },
+                                                "Purge Graphs"
+                                            }
+                                        }
+                                        if !s_folder_status().is_empty() {
+                                            span { class: "hint", "{s_folder_status}" }
+                                        }
+                                    }),
                                     on_close: move |_| s_view.set(View::Validate),
                                 }
                             }

--- a/pittv3-lib/src/args.rs
+++ b/pittv3-lib/src/args.rs
@@ -196,9 +196,9 @@ pub struct Pittv3Args {
     /// before path validation begins. Only files with a .crl extension are processed. The indexed
     /// CRLs are the local revocation source, consulted before any remote retrieval, and the folder
     /// also receives CRLs fetched remotely along with the last-modified map that makes those
-    /// fetches conditional. Note that the folder is written as well as read: indexing deletes any
-    /// CRL that is not valid at the time of interest, i.e. one whose thisUpdate is in the future or
-    /// whose nextUpdate has passed.
+    /// fetches conditional. Note that the folder is written as well as read, though only added to:
+    /// a CRL that does not cover the time of interest is left out of the index and left on disk, so
+    /// a later run asking about a different time can still use it.
     #[cfg(feature = "std")]
     pub crl_folder: Option<String>,
 
@@ -208,8 +208,7 @@ pub struct Pittv3Args {
     /// matched to path positions by issuer name, OCSP responses by the CertID each answers about.
     ///
     /// This is read-only, which is what distinguishes it from `crl_folder`: that argument names an
-    /// *index*, written as well as read, and indexing deletes any CRL not valid at the time of
-    /// interest. An artifact named here is used and left alone. Supply what a run needs when there
+    /// *index*, which a run adds fetched CRLs to. An artifact named here is used and left alone. Supply what a run needs when there
     /// is no network to fetch it from, or when the answer should come from a captured artifact
     /// rather than from whatever a responder says today.
     #[cfg(all(feature = "std", feature = "revocation"))]
@@ -221,6 +220,23 @@ pub struct Pittv3Args {
     /// without re-parsing or re-verifying the CRL.
     #[cfg(feature = "std")]
     pub keep_crl_entries_in_memory: bool,
+
+    /// Makes every path derive every certificate's revocation status from revocation data of its
+    /// own, instead of reusing a determination reached while validating an earlier path.
+    ///
+    /// Both caches are declined, not just the per-certificate one: a CRL folder is registered as a
+    /// revocation status cache as well as a CRL source, and `PkiEnvironment::get_status` returns the
+    /// first determination any registered cache offers, so leaving either in place would keep
+    /// answering.
+    ///
+    /// Costs re-fetching, and buys two things. A path that accounts for itself: every position's
+    /// status is derived from data examined for that path, which is what makes a validation
+    /// independent of what another one established. And artifacts: a cached determination examines
+    /// nothing and so leaves nothing behind, which for a results folder or an exported bundle means
+    /// a position that reports a status and carries no evidence for it.
+    #[cfg(all(feature = "std", feature = "revocation"))]
+    #[serde(default)]
+    pub no_revocation_cache: bool,
 
     /// Paired with ca_folder to remove expired, unparseable certificates, self-signed
     /// certificates and non-CA certificates from consideration. When paired with error_folder,

--- a/pittv3-lib/src/graph_cache.rs
+++ b/pittv3-lib/src/graph_cache.rs
@@ -27,7 +27,10 @@ use log::{debug, info};
 use sha2::{Digest, Sha256};
 use walkdir::WalkDir;
 
-use certval::{CertSource, CertVector, CertificationPathBuilderFormats, CertificationPathSettings};
+use certval::{
+    CertSource, CertVector, CertificationPathBuilderFormats, CertificationPathSettings,
+    PS_TIME_OF_INTEREST,
+};
 
 use crate::args::Pittv3Args;
 
@@ -47,6 +50,16 @@ fn cache_dir() -> Option<PathBuf> {
             Some(Path::new(&home).join(".pittv3").join("graphs"))
         }
     }
+}
+
+/// The folder cached graphs live in, as a string, or empty when caching is off or there is no home
+/// directory. For a frontend offering to empty it: the cache is written on every run whose key is
+/// new and nothing removes an entry, so it grows until someone clears it.
+#[cfg(feature = "std")]
+pub fn cache_folder() -> String {
+    cache_dir()
+        .map(|p| p.to_string_lossy().to_string())
+        .unwrap_or_default()
 }
 
 /// Folds one input path into `hasher`: the path itself, and the size and modification time of every
@@ -78,15 +91,18 @@ fn hash_path(hasher: &mut Sha256, label: &str, path: &str) {
 /// than the handful of values known to reach path building, so a setting that starts mattering
 /// cannot silently reuse a graph built without it. The cost is a missed cache when an unrelated
 /// setting changes, which costs exactly what there was before this existed.
+///
+/// One exclusion: the time of interest. It is normally "now", so keying on it meant the key never
+/// repeated and the cache was written but never read.
 pub fn fingerprint(args: &Pittv3Args, cps: &CertificationPathSettings) -> Option<String> {
     if args.generate || (args.ca_folder.is_none() && args.ca_inputs.is_empty()) {
         return None;
     }
-    #[cfg(feature = "remote")]
-    if args.dynamic_build {
-        // The graph grows as URIs are chased, so what pass 0 built is not what the run ends with.
-        return None;
-    }
+    // Dynamic building is cached like the rest. The graph does grow as URIs are chased, but the only
+    // thing written is pass 0's graph -- `graph_cache::store` is guarded on `0 == pass`, before any
+    // chasing has added anything -- so the artifact matches the key: the graph built from the named
+    // inputs. Later passes rebuild in memory and are never stored. Refusing to key a dynamic run
+    // meant the desktop app, which builds dynamically by default, never cached anything at all.
 
     let mut hasher = Sha256::new();
     hasher.update(b"pittv3 graph v1");
@@ -109,8 +125,17 @@ pub fn fingerprint(args: &Pittv3Args, cps: &CertificationPathSettings) -> Option
     }
     #[cfg(feature = "webpki")]
     hasher.update([u8::from(args.webpki_tas)]);
-    hasher.update(args.time_of_interest.to_le_bytes());
-    if let Ok(settings) = serde_json::to_string(cps) {
+    // The time of interest is deliberately NOT part of the key, and it has to be dropped in two
+    // places to stay out: it is not hashed directly here, and it is removed from the settings before
+    // they are, because the caller sets it into them just before asking for a fingerprint.
+    //
+    // Keying on it made the key unrepeatable -- the time of interest is normally "now", which is new
+    // every run -- so every run wrote an entry that could never be hit again and nothing was ever
+    // reused. What the graph is built from is the trust material, and a change there is caught by
+    // hashing each input's size and modification time.
+    let mut keyed = cps.clone();
+    keyed.0.remove(PS_TIME_OF_INTEREST);
+    if let Ok(settings) = serde_json::to_string(&keyed) {
         hasher.update(settings.as_bytes());
     }
 
@@ -123,12 +148,9 @@ pub fn fingerprint(args: &Pittv3Args, cps: &CertificationPathSettings) -> Option
 /// For callers outside a run — the desktop's graph export asks which graph the form in front of it
 /// keys to, and computing that a second way would answer a different question.
 pub fn fingerprint_for_args(args: &Pittv3Args) -> Option<String> {
-    let mut cps = certval::read_settings(&args.settings).ok()?;
-    if !cps.0.contains_key(certval::PS_TIME_OF_INTEREST) {
-        cps.set_time_of_interest(
-            certval::TimeOfInterest::from_unix_secs(args.time_of_interest).ok()?,
-        );
-    }
+    // No need to settle a time of interest first: the key excludes it either way, so the settings
+    // as read key identically to the settings a run adjusts.
+    let cps = certval::read_settings(&args.settings).ok()?;
     fingerprint(args, &cps)
 }
 

--- a/pittv3-lib/src/help.rs
+++ b/pittv3-lib/src/help.rs
@@ -124,22 +124,29 @@ pub fn arg_help(name: &str) -> &'static str {
             "occurrence may name a single artifact or a folder to traverse, and may hold either a ",
             "CRL or an OCSP response \u{2014} the bytes decide, since an OCSP response has no settled ",
             "file extension. CRLs are matched to path positions by issuer name, OCSP responses by ",
-            "the CertID each answers about. Unlike --crl-folder, which is an index that deletes ",
-            "CRLs not valid at the time of interest, artifacts named here are read and left alone.",
+            "the CertID each answers about. Unlike --crl-folder, which is an index a run adds ",
+            "fetched CRLs to, artifacts named here are read and left alone.",
         ),
         "crl-folder" => concat!(
             "Full path of a folder containing DER- or PEM-encoded CRLs, traversed recursively and indexed ",
             "before path validation begins. Only files with a .crl extension are processed. The indexed ",
             "CRLs are the local revocation source, consulted before any remote retrieval, and the folder ",
             "also receives CRLs fetched remotely along with the last-modified map that makes those fetches ",
-            "conditional. Note that the folder is written as well as read: indexing deletes any CRL that is ",
-            "not valid at the time of interest, i.e. one whose thisUpdate is in the future or whose ",
-            "nextUpdate has passed.",
+            "conditional. Note that the folder is written as well as read, though only added to: a CRL ",
+            "that does not cover the time of interest is left out of the index and left on disk, so a later ",
+            "run asking about a different time can still use it.",
         ),
         "keep-crl-entries-in-memory" => concat!(
             "When set together with crl_folder, retain the revoked serial numbers of each verified ",
             "full/direct CRL in memory so subsequent certificates under the same scope are answered ",
             "without re-parsing or re-verifying the CRL.",
+        ),
+        "no-revocation-cache" => concat!(
+            "Makes every path derive every certificate's revocation status from revocation data of ",
+            "its own, instead of reusing a determination reached while validating an earlier path. ",
+            "Costs re-fetching. Buys a path that accounts for itself, and artifacts for every ",
+            "position: a cached determination examines nothing, so a position answered from cache ",
+            "reports a status and carries no evidence for it in a results folder or an export.",
         ),
         "cleanup" => concat!(
             "Paired with ca_folder to remove expired, unparseable certificates, self-signed certificates ",
@@ -230,6 +237,17 @@ mod tests {
         let help = arg_help("crl-folder");
         assert!(help.contains("CRLs"));
         assert!(!help.contains("intermediate CA certificates"));
+    }
+
+    /// The GUI row for this one passes no title of its own, so `arg_help` is the tooltip: a key that
+    /// does not match returns "" and the control loses its explanation with nothing failing. The
+    /// name is also the one the CLI flag derives, so this pins the two together.
+    #[test]
+    fn the_revocation_cache_knob_has_help_under_the_name_the_row_uses() {
+        let help = arg_help("no-revocation-cache");
+        assert!(!help.is_empty());
+        assert!(help.contains("revocation data of"));
+        assert!(help.contains("carries no evidence"));
     }
 
     /// `validate_all` is declared twice in `Pittv3Args` behind opposing `std_app` gates. The help

--- a/pittv3-lib/src/lib.rs
+++ b/pittv3-lib/src/lib.rs
@@ -85,3 +85,9 @@ pub fn run_blocking(args: &Pittv3Args) -> report::ValidationReport {
 }
 
 pub use crate::args::Pittv3Args;
+
+/// Re-exported because [`options_std_retaining`](crate::options_std::options_std_retaining) takes
+/// one in its signature: a frontend that owns the revocation status cache across runs has to be
+/// able to name the type, and not every frontend depends on certval directly.
+#[cfg(all(feature = "std", feature = "revocation"))]
+pub use certval::RevocationCache;

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -222,7 +222,7 @@ fn normalize_pem_wrap(pem: &str) -> Option<String> {
 /// report. The CLI ignores the return value (log/file output is unchanged); GUI and server
 /// frontends consume it.
 pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
-    let (report, _) = options_std_retaining(args, false).await;
+    let (report, _) = options_std_retaining(args, false, None).await;
     report
 }
 
@@ -236,12 +236,27 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
 /// `None` comes back whenever nothing was validated — the actions that generate, clean up, or run a
 /// diagnostic have no paths to keep — and whenever `retain` is false, which is the CLI's case and
 /// costs it nothing.
+///
+/// `cache` lets a caller own the revocation status cache instead of the run creating one and
+/// dropping it. A frontend that stays open passes the same one to every run, so a certificate
+/// checked on one run is not checked again on the next, and can offer to discard the contents; a
+/// process that runs once passes `None` and gets a cache for the run, which is what the CLI does.
+/// `--no-revocation-cache` declines either.
 pub async fn options_std_retaining(
     args: &Pittv3Args,
     retain: bool,
+    #[cfg(all(feature = "std", feature = "revocation"))] cache: Option<
+        &std::sync::Arc<RevocationCache>,
+    >,
 ) -> (ValidationReport, Option<RetainedRun>) {
     let mut kept = None;
-    let report = options_std_inner(args, retain.then_some(&mut kept)).await;
+    let report = options_std_inner(
+        args,
+        retain.then_some(&mut kept),
+        #[cfg(all(feature = "std", feature = "revocation"))]
+        cache,
+    )
+    .await;
     (report, kept)
 }
 
@@ -252,6 +267,9 @@ pub async fn options_std_retaining(
 async fn options_std_inner(
     args: &Pittv3Args,
     kept: Option<&mut Option<RetainedRun>>,
+    #[cfg(all(feature = "std", feature = "revocation"))] cache: Option<
+        &std::sync::Arc<RevocationCache>,
+    >,
 ) -> ValidationReport {
     if args.cleanup {
         // Cleanup runs in isolation before other actions
@@ -467,9 +485,9 @@ async fn options_std_inner(
 
             #[cfg(feature = "remote")]
             {
-                let lmm_file = last_modified_map_file(&cps, &download_folder);
+                let lmm_file = last_modified_map_file(&download_folder);
                 let lmm_file = lmm_file.as_str();
-                let blocklist_file = uri_blocklist_file(&cps, &download_folder);
+                let blocklist_file = uri_blocklist_file(&download_folder);
                 let blocklist_file = blocklist_file.as_str();
 
                 if let Some(download_folder) = &args.download_folder {
@@ -699,7 +717,13 @@ async fn options_std_inner(
         };
     } else {
         // Generate, validate certificate file, or validate certificates folder per args.
-        return generate_and_validate(args, kept).await;
+        return generate_and_validate(
+            args,
+            kept,
+            #[cfg(all(feature = "std", feature = "revocation"))]
+            cache,
+        )
+        .await;
     }
     ValidationReport::default()
 }
@@ -730,6 +754,9 @@ async fn options_std_inner(
 async fn generate_and_validate(
     args: &Pittv3Args,
     kept: Option<&mut Option<RetainedRun>>,
+    #[cfg(all(feature = "std", feature = "revocation"))] cache: Option<
+        &std::sync::Arc<RevocationCache>,
+    >,
 ) -> ValidationReport {
     let retain = kept.is_some();
     let mut retained: Vec<RetainedPath> = vec![];
@@ -963,15 +990,30 @@ async fn generate_and_validate(
     // The CrlSourceFolders serves CRLs (as a CrlSource) and, when keep_crl_entries_in_memory is set,
     // answers revocation status from its retained CRL serials (as a RevocationStatusCache). Register
     // it in both roles via a shared Arc, with its revocation cache FIRST so the kept fast path is
-    // consulted before the per-certificate memo. A RevocationCache is always registered as that memo
-    // for OCSP determinations and anything not covered by a kept CRL.
+    // consulted before the per-certificate memo. A RevocationCache is otherwise registered as that
+    // memo for OCSP determinations and anything not covered by a kept CRL.
+    //
+    // --no-revocation-cache declines BOTH roles while leaving the CRL source itself registered: the
+    // run still reads the folder for CRLs, it just stops answering from what an earlier path
+    // established. Declining only one would not do -- get_status consults every registered cache in
+    // turn and returns the first determination offered, so either one left in place keeps answering.
     #[cfg(all(feature = "std", feature = "revocation"))]
     {
+        let cache_determinations = !args.no_revocation_cache;
         if let Some(crl_source) = crl_source {
             pe.add_crl_source(Box::new(crl_source.clone()));
-            pe.add_revocation_cache(Box::new(crl_source));
+            if cache_determinations {
+                pe.add_revocation_cache(Box::new(crl_source));
+            }
         }
-        pe.add_revocation_cache(Box::new(RevocationCache::new()));
+        if cache_determinations {
+            // The caller's cache when it offered one, so determinations outlive the run and it can
+            // clear them; otherwise one for this run, which is what a process that runs once wants.
+            match cache {
+                Some(cache) => pe.add_revocation_cache(Box::new(cache.clone())),
+                None => pe.add_revocation_cache(Box::new(RevocationCache::new())),
+            }
+        }
     }
 
     // Opened once rather than per pass: opening snapshots what the store already holds, which is a
@@ -1023,6 +1065,11 @@ async fn generate_and_validate(
                 }
             }
         };
+
+        // What the pool held before this pass did anything. Only fetching adds to it after the
+        // first pass -- the CA inputs are loaded under `0 == pass` -- so comparing against this
+        // says whether the pass brought back anything at all.
+        let certs_at_pass_start = cert_source.len();
 
         // The same augmented graph as last time, when nothing it was built from has changed. What
         // is skipped is the folder walk and the partial-path search, which is the expensive half of
@@ -1107,9 +1154,9 @@ async fn generate_and_validate(
         if uri_threshold != fresh_uris.len() {
             #[cfg(feature = "remote")]
             if args.dynamic_build {
-                let lmm_file = last_modified_map_file(&cps, &download_folder);
+                let lmm_file = last_modified_map_file(&download_folder);
                 let lmm_file = lmm_file.as_str();
-                let blocklist_file = uri_blocklist_file(&cps, &download_folder);
+                let blocklist_file = uri_blocklist_file(&download_folder);
                 let blocklist_file = blocklist_file.as_str();
 
                 // read the last modified map and blocklist once
@@ -1117,7 +1164,12 @@ async fn generate_and_validate(
                 let mut blocklist = read_blocklist(blocklist_file);
 
                 //let bap_ref = &mut cert_source.buffers_and_paths.buffers;
-                if 1 == pass {
+                // Skipped when the pass-0 load already took this folder in: `load_ca_inputs` chains
+                // `reuse_downloads`, which is this same folder, whenever --use-downloaded-cas is set.
+                // Reading it twice added the certificates a second time, which changed the pool size
+                // on every pass 1 and so forced a full partial-path search and a multi-megabyte
+                // serialize on every run, whether or not anything had been fetched.
+                if 1 == pass && !args.use_downloaded_cas {
                     // on first dynamic action, pick up certs from downloads folder
                     if cert_folder_to_vec(
                         &pe,
@@ -1236,7 +1288,13 @@ async fn generate_and_validate(
 
         // If this is not the first pass, find all partial paths present in buffers_and_paths. If
         // this is the first pass, we expect this to have been present in the deserialized CBOR.
-        if 0 < pass {
+        //
+        // Skipped when the pass fetched nothing. Searching the same buffers again yields the same
+        // partial paths, and re-serializing them rewrites a blob the next pass would deserialize
+        // back into what it already has -- on a revalidation where every fetch comes back 304, that
+        // was a full search and a multi-megabyte round trip per pass to discover there was nothing
+        // to do. `cbor` is deliberately left as it was: it still describes this pool.
+        if 0 < pass && cert_source.len() != certs_at_pass_start {
             cert_source.find_all_partial_paths(&pe, &cps);
 
             // After finding all partial paths, serialize as CBOR and save for next pass

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -1678,3 +1678,182 @@ pub fn ta_cleanup(pe: &PkiEnvironment, args: &Pittv3Args) {
         TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
     );
 }
+
+/// Outcome of a folder maintenance action: how many files it removed, and how many it could not.
+#[cfg(feature = "std")]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+pub struct FolderMaintenance {
+    /// Files removed
+    pub removed: usize,
+    /// Files that could not be removed, or could not be read to decide
+    pub failed: usize,
+}
+
+/// Discards the last-modified map for `folder`, if there is one.
+///
+/// **Every function that removes downloaded artifacts must call this.** The map records, per URI,
+/// the `Last-Modified` a previous fetch saw, and a run sends it back as `If-Modified-Since`; a 304
+/// then means "you already have this" and the artifact is neither transferred nor added to the run
+/// — `fetch_crl` returns `ResourceUnchanged` and the certificate path skips the URI. So the map is
+/// a claim that a copy exists on disk. Remove the copy and leave the claim, and the next run is
+/// told nothing has changed and comes away with nothing, from the network or the folder.
+///
+/// The whole map goes rather than the entries for what was removed: a saved certificate is named
+/// from its URL's last path segment and a saved CRL from a hash of its content, so a file cannot be
+/// mapped back to the URI that fetched it. Discarding all of it costs one conditional request per
+/// URI on the next run, which is the right price for an action the user asked for.
+#[cfg(feature = "std")]
+pub fn forget_last_modified(folder: &str) -> bool {
+    if folder.is_empty() {
+        return false;
+    }
+    let lmm_file = last_modified_map_file(folder);
+    if !Path::new(&lmm_file).exists() {
+        return false;
+    }
+    match fs::remove_file(&lmm_file) {
+        Ok(()) => {
+            info!("Discarded the last-modified map at {lmm_file}");
+            true
+        }
+        Err(e) => {
+            error!("Failed to discard the last-modified map at {lmm_file}: {e}");
+            false
+        }
+    }
+}
+
+/// Removes the CRLs in `folder` that do not cover `toi`, leaving the rest.
+///
+/// This is the predicate indexing used to apply on its own, on every run. It is a maintenance
+/// action now rather than a side effect of reading, because whether a CRL is worth keeping is a
+/// question about the folder and not about the run that happens to be reading it: a run at a past
+/// time of interest would otherwise remove every CRL issued since, and a run at the present time
+/// would remove the superseded ones a historical run needs.
+///
+/// A CRL with no nextUpdate is kept. It has no upper bound to be past, and how much age to tolerate
+/// is the operator's call at validation time, not this function's.
+///
+/// Note what "stale" costs here: a superseded CRL generally cannot be fetched again, since a CA
+/// publishes the current one and nothing else. Removing it forecloses validating anything as of a
+/// time it covered.
+#[cfg(feature = "std")]
+pub fn cleanup_crls(folder: &str, toi_secs: u64) -> FolderMaintenance {
+    use x509_cert::certificate::Raw;
+    use x509_cert::crl::CertificateList;
+
+    let mut outcome = FolderMaintenance::default();
+    if toi_secs == 0 {
+        info!("Not removing any CRL: no time of interest to judge one against");
+        return outcome;
+    }
+    for entry in WalkDir::new(folder) {
+        let Ok(e) = entry else {
+            outcome.failed += 1;
+            continue;
+        };
+        let path = e.path();
+        if e.file_type().is_dir() || path.extension().and_then(OsStr::to_str) != Some("crl") {
+            continue;
+        }
+        let bytes = get_file_as_byte_vec_pem(path).unwrap_or_default();
+        let Ok(crl) = CertificateList::<Raw>::from_der(bytes.as_slice()) else {
+            // Unreadable as a CRL is stale in the only sense that matters for an index of CRLs.
+            match fs::remove_file(path) {
+                Ok(()) => outcome.removed += 1,
+                Err(_) => outcome.failed += 1,
+            }
+            continue;
+        };
+        let this_update = crl.tbs_cert_list.this_update.to_unix_duration().as_secs();
+        let covers = match crl.tbs_cert_list.next_update {
+            Some(nu) => this_update <= toi_secs && toi_secs < nu.to_unix_duration().as_secs(),
+            None => true,
+        };
+        if !covers {
+            match fs::remove_file(path) {
+                Ok(()) => outcome.removed += 1,
+                Err(e) => {
+                    error!("Failed to remove {}: {e}", path.display());
+                    outcome.failed += 1;
+                }
+            }
+        }
+    }
+    if outcome.removed > 0 {
+        forget_last_modified(folder);
+    }
+    info!(
+        "Removed {} CRL(s) from {folder} that do not cover the time of interest ({} could not be removed)",
+        outcome.removed, outcome.failed
+    );
+    outcome
+}
+
+/// Removes the certificates in `folder` that a run could not use: unparseable, not valid at
+/// `toi_secs`, self-signed, or not a CA. Moved to `error_folder` instead of deleted when one is
+/// given, which is what `--cleanup` does and for the same reason.
+///
+/// Wraps [`cleanup_certs`] so a frontend needs no `PkiEnvironment` of its own, and counts what
+/// changed by comparing the folder before and after — `cleanup_certs` reports through the log
+/// rather than returning, and a button needs something to say.
+#[cfg(feature = "std")]
+pub fn cleanup_certificate_folder(
+    folder: &str,
+    error_folder: &str,
+    toi_secs: u64,
+) -> FolderMaintenance {
+    let count = || {
+        WalkDir::new(folder)
+            .into_iter()
+            .filter_map(|e| e.ok())
+            .filter(|e| !e.file_type().is_dir())
+            .count()
+    };
+    let before = count();
+    let mut pe = PkiEnvironment::default();
+    pe.populate_5280_pki_environment();
+    let toi =
+        TimeOfInterest::from_unix_secs(toi_secs).unwrap_or_else(|_| TimeOfInterest::disabled());
+    cleanup_certs(&pe, folder, error_folder, false, toi);
+    let after = count();
+    let removed = before.saturating_sub(after);
+    if removed > 0 {
+        forget_last_modified(folder);
+    }
+    FolderMaintenance { removed, failed: 0 }
+}
+
+/// Removes every file in `folder`, leaving the folder itself. Subfolders are traversed.
+///
+/// The blunt counterpart to the cleanup functions: those decide file by file, this one does not
+/// decide at all. Kept separate for that reason — a caller offering both is offering two different
+/// promises, and only one of them can be undone by fetching the material again.
+#[cfg(feature = "std")]
+pub fn purge_folder(folder: &str) -> FolderMaintenance {
+    let mut outcome = FolderMaintenance::default();
+    for entry in WalkDir::new(folder) {
+        let Ok(e) = entry else {
+            outcome.failed += 1;
+            continue;
+        };
+        if e.file_type().is_dir() {
+            continue;
+        }
+        match fs::remove_file(e.path()) {
+            Ok(()) => outcome.removed += 1,
+            Err(err) => {
+                error!("Failed to remove {}: {err}", e.path().display());
+                outcome.failed += 1;
+            }
+        }
+    }
+    // The map is a file in the folder, so the sweep above already took it. Named anyway so the
+    // invariant is stated where it is relied on rather than left to the reader to notice.
+    forget_last_modified(folder);
+    info!(
+        "Removed {} file(s) from {folder} ({} could not be removed)",
+        outcome.removed, outcome.failed
+    );
+    outcome
+}

--- a/pittv3-service/src/settings.rs
+++ b/pittv3-service/src/settings.rs
@@ -66,8 +66,12 @@ pub const PATH_BEARING_SETTINGS: &[&str] = &[
     PS_TRUST_ANCHOR_FOLDER,
     PS_CERTIFICATION_AUTHORITY_FOLDER,
     PS_DOWNLOAD_FOLDER,
-    PS_LAST_MODIFIED_MAP_FILE,
-    PS_URI_BLOCKLIST_FILE,
+    // Retired settings, kept on the list by name rather than by constant. They no longer steer
+    // anything -- the last-modified map and the URI blocklist live in the folder they describe --
+    // but a client that still sends one gets a note saying it was dropped, which is better than
+    // retaining a key that silently does nothing.
+    "psLastModifiedMapFile",
+    "psUriBlocklistFile",
     PS_CBOR_TA_STORE,
 ];
 

--- a/pittv3/src/cliargs.rs
+++ b/pittv3/src/cliargs.rs
@@ -211,9 +211,9 @@ pub struct Pittv3CliArgs {
     /// before path validation begins. Only files with a .crl extension are processed. The indexed
     /// CRLs are the local revocation source, consulted before any remote retrieval, and the folder
     /// also receives CRLs fetched remotely along with the last-modified map that makes those
-    /// fetches conditional. Note that the folder is written as well as read: indexing deletes any
-    /// CRL that is not valid at the time of interest, i.e. one whose thisUpdate is in the future or
-    /// whose nextUpdate has passed.
+    /// fetches conditional. Note that the folder is written as well as read, though only added to:
+    /// a CRL that does not cover the time of interest is left out of the index and left on disk, so
+    /// a later run asking about a different time can still use it.
     #[cfg(feature = "std")]
     #[clap(long, help_heading = "VALIDATION")]
     pub crl_folder: Option<String>,
@@ -222,8 +222,8 @@ pub struct Pittv3CliArgs {
     /// occurrence may name a single artifact or a folder to traverse, and may hold either a CRL or
     /// an OCSP response — the bytes decide, since an OCSP response has no settled file extension.
     /// CRLs are matched to path positions by issuer name, OCSP responses by the CertID each answers
-    /// about. Unlike --crl-folder, which is an index that deletes CRLs not valid at the time of
-    /// interest, artifacts named here are read and left alone.
+    /// about. Unlike --crl-folder, which is an index a run adds fetched CRLs to, artifacts named
+    /// here are read and left alone.
     #[cfg(all(feature = "std", feature = "revocation"))]
     #[clap(long = "rev", value_name = "REV_INPUT", help_heading = "VALIDATION")]
     pub rev_inputs: Vec<String>,
@@ -234,6 +234,14 @@ pub struct Pittv3CliArgs {
     #[cfg(feature = "std")]
     #[clap(long, help_heading = "VALIDATION")]
     pub keep_crl_entries_in_memory: bool,
+
+    /// Makes every path derive every certificate's revocation status from revocation data of its
+    /// own, instead of reusing a determination reached while validating an earlier path. Costs
+    /// re-fetching; buys a path that accounts for itself, and artifacts for every position, since a
+    /// cached determination examines nothing and leaves nothing behind.
+    #[cfg(all(feature = "std", feature = "revocation"))]
+    #[clap(long, help_heading = "VALIDATION")]
+    pub no_revocation_cache: bool,
 
     /// Paired with ca_folder to remove expired, unparseable certificates, self-signed
     /// certificates and non-CA certificates from consideration. When paired with error_folder,
@@ -395,6 +403,8 @@ impl From<Pittv3CliArgs> for Pittv3Args {
             rev_inputs: v.rev_inputs,
             #[cfg(feature = "std")]
             keep_crl_entries_in_memory: v.keep_crl_entries_in_memory,
+            #[cfg(all(feature = "std", feature = "revocation"))]
+            no_revocation_cache: v.no_revocation_cache,
             #[cfg(feature = "std")]
             cleanup: v.cleanup,
             #[cfg(feature = "std")]


### PR DESCRIPTION
- certval: Indexing CRLs no longer deletes stale CRLs (since the time of interest is validation-specific).
- certval: Drop psLastModifiedMapFile and psUriBlocklistFile. The last-modified map and the URI blocklist now live in the folder they describe. Settings files that still feature these values cause a log message, and pittv3-service keeps the retired names on its strip list so a client that sends one still gets a note.
- Add --no-revocation-cache. Declines both caches a run registers: the per-certificate one, and the CRL folder, which is a revocation status cache as well as a CRL source. In the GUI it is labeled "Reuse revocation determinations" (as in the WASM app).
- options_std_retaining now takes an Option<&Arc<RevocationCache>>, so the GUI keeps one across runs and can clear it. The CLI passes None and gets one per run. Added a Clear cached determinations button (as in the WASM app).
- Add Cleanup and Purge buttons for the download and CRL folders, and Purge for the graph cache. Cleanup drops artifacts that are not applicable to the current settings (i.e., time of interest) or are unusable (i.e., parse failure); Purge drops everything after soliciting user confirmation. Both discard the folder's last-modified map.
- Default the error folder to ~/.pittv3/errors.
- Move the results folder, error folder and logging configuration onto the Folders & files settings tab.
- Drop the "use downloaded certificates" checkbox; the GUI always reuses them. The CLI keeps --use-downloaded-cas.
- Cache the graph for dynamic runs. Graphs are cached based on a hash of the current settings and environment with time of interest removed from consideration (since it is usually the moving target "now")
- Improve graph cache serialization and deserialization to avoid unnecessary work.