### PR TITLE
Improve graph cache handling in pittv3

### DIFF
--- a/certval/src/source/cert_source.rs
+++ b/certval/src/source/cert_source.rs
@@ -12,12 +12,11 @@
 //! let mut pe = PkiEnvironment::default();
 //!
 //! let mut cert_source = CertSource::default();
-//! // populate the cert_source.buffers_and_paths and cert_source.certs fields.
-//! // See `populate_parsed_cert_vector` in `Pittv3` for file-system based sample. When initializing
-//! // a set of partial paths, the cert_source.buffers_and_paths.partial_paths field can be empty,
-//! // with population accurring via a call to find_all_partial_paths then index the certs,
-//! // i.e., populate the name and spki maps. See `populate_parsed_cert_vector` usage in PITTv3 for
-//! // a file system-based example.
+//! // Add certificates with `CertVector::push`, or, in a build with the `std` feature, read a
+//! // folder of them with `cert_folder_to_vec`. Then call
+//! // [`initialize`](crate::CertSource::initialize) to parse them and build the key identifier and
+//! // subject name indexes. Partial paths need not be supplied: leave them empty and call
+//! // [`find_all_partial_paths`](crate::CertSource::find_all_partial_paths) to discover them.
 //!
 //! // add cert_source to provide access to intermediate CA certificates
 //!  pe.add_certificate_source(Box::new(cert_source.clone()));
@@ -428,8 +427,9 @@ impl BuffersAndPaths {
 ///
 /// Dynamic building support can return a list of AIAs and SIAs encountered during path discovery for
 /// consideration, i.e., enabling additional certs to be downloaded before repeating the steps above to
-/// gather new paths. Dynamic building consists of augmenting the buffers deserialized
-/// from CBOR, re-parsing and re-indexing, then re-discovering all partial paths.
+/// gather new paths. Dynamic building consists of appending the downloaded certificates to the
+/// instance, calling [`initialize`](CertSource::initialize) again -- which parses what was appended
+/// and rebuilds the indexes -- then re-discovering all partial paths.
 /// [PITTv3](https://github.com/carl-wallace/rust-pki/tree/main/pittv3) demonstrates an approach to performing these steps.
 #[derive(Clone)]
 pub struct CertSource {
@@ -454,9 +454,9 @@ pub struct CertSource {
 }
 
 impl Default for CertSource {
-    /// CertSource::default instantiates a new empty CertSource. The caller is responsible for populating
-    /// the buffers_and_paths member then calling populate_parsed_cert_vector to populate the certs
-    /// member then preparing skid and name maps prior to using instance.
+    /// CertSource::default instantiates a new empty CertSource. The caller adds certificates with
+    /// `CertVector::push`, then calls [`initialize`](CertSource::initialize) to parse them and build
+    /// the key identifier and subject name indexes, before using the instance.
     fn default() -> Self {
         Self::new()
     }
@@ -481,9 +481,9 @@ impl CertVector for CertSource {
 }
 
 impl CertSource {
-    /// CertSource::new instantiates a new empty CertSource. The caller is responsible for populating
-    /// the buffers_and_paths member then calling populate_parsed_cert_vector to populate the certs
-    /// member then preparing skid and name maps prior to using instance.
+    /// CertSource::new instantiates a new empty CertSource. The caller adds certificates with
+    /// `CertVector::push`, then calls [`initialize`](CertSource::initialize) to parse them and build
+    /// the key identifier and subject name indexes, before using the instance.
     pub fn new() -> Self {
         Self {
             certs: Vec::new(),

--- a/certval/src/source/cert_source.rs
+++ b/certval/src/source/cert_source.rs
@@ -518,6 +518,11 @@ impl CertSource {
     }
 
     /// Processes any buffers passed to the instance, i.e., via new_from_cbor
+    ///
+    /// Can be called again after more buffers have been added with only the ones not already parsed
+    /// beung parsed, and the key identifier and name maps are rebuilt over the result. That allows a
+    /// caller to have one instance while appending certificates fetched from AIA and SIA instead of
+    /// discarding it and deserializing a fresh one to get a vector that lines up with its buffers.
     pub fn initialize(&mut self, cps: &CertificationPathSettings) -> Result<()> {
         self.populate_parsed_cert_vector(cps)?;
         self.index_certs();
@@ -977,9 +982,19 @@ impl CertSource {
     /// The two vectors stay index-aligned: a buffer that fails to parse, or that is not valid at the
     /// time of interest carried in `cps`, leaves a `None` in `certs` rather than being skipped,
     /// because the partial paths in [`BuffersAndPaths`] address certificates by index.
+    ///
+    /// Only the buffers that have not been parsed yet are parsed, with the index alignment determining
+    /// which.
     fn populate_parsed_cert_vector(&mut self, cps: &CertificationPathSettings) -> Result<()> {
         let time_of_interest = cps.get_time_of_interest();
-        for (i, cert_file) in self.buffers_and_paths.buffers.iter().enumerate() {
+        let already_parsed = self.certs.len();
+        for (i, cert_file) in self
+            .buffers_and_paths
+            .buffers
+            .iter()
+            .enumerate()
+            .skip(already_parsed)
+        {
             if let Ok(cert) =
                 CertificateInner::from_der(self.buffers_and_paths.buffers[i].bytes.as_slice())
             {
@@ -1029,7 +1044,13 @@ impl CertSource {
 
     /// index_certs prepares internally used key identifier and name maps after the caller has modified
     /// the buffers_and_paths and certs fields.
+    ///
+    /// Both maps are rebuilt rather than added to, so calling this again after more certificates have
+    /// been parsed does not enter the ones already indexed a second time. The values are positions in
+    /// `certs`, which only grows, so a rebuild yields what was there plus the new positions.
     pub fn index_certs(&mut self) {
+        self.skid_map.clear();
+        self.name_map.clear();
         for (i, cert) in self.certs.iter().enumerate() {
             if let Some(cert) = cert {
                 let hex_skid = hex_skid_from_cert(cert);
@@ -1798,6 +1819,62 @@ fn get_certificates_test() {
 
     let v = cert_store.get_encoded_certificates().unwrap();
     assert_eq!(399, v.len());
+}
+
+// A dynamic build appends what it fetched to the source it already has and initializes it again,
+// rather than starting over from a serialized copy. That only works if the second call parses just
+// the buffers that were added and rebuilds the two maps instead of adding to them -- otherwise the
+// parsed vector ends up twice as long as the buffers it is positionally paired with, and every
+// certificate is indexed at two positions.
+#[cfg(feature = "std")]
+#[test]
+fn initialize_again_after_appending_test() {
+    use crate::file_utils::cert_folder_to_vec;
+    use hex_literal::hex;
+
+    let pe = PkiEnvironment::default();
+    let toi = TimeOfInterest::from_unix_secs(1647258133).unwrap();
+    let cps = CertificationPathSettings::default();
+
+    let mut cert_store = CertSource::new();
+    assert!(cert_folder_to_vec(
+        &pe,
+        "tests/examples/PKITS_data_2048/certs",
+        &mut cert_store,
+        toi,
+    )
+    .is_ok());
+    assert!(cert_store.initialize(&cps).is_ok());
+
+    let buffers_before = cert_store.num_buffers();
+    let certs_before = cert_store.num_certs();
+    assert_eq!(buffers_before, certs_before);
+    let skid = hex!("A83C099D67F6D847BAA2D0FC18725688406D9595");
+    assert_eq!(
+        cert_store.get_certificates_for_skid(&skid).unwrap().len(),
+        1
+    );
+
+    // A certificate the folder does not hold, pushed the way a fetch pushes what it retrieved.
+    let extra = std::fs::read("tests/examples/DigiCertGlobalCAG2.der").unwrap();
+    cert_store.push(CertFile {
+        filename: "DigiCertGlobalCAG2.der".to_string(),
+        bytes: extra,
+    });
+    assert_eq!(cert_store.num_buffers(), buffers_before + 1);
+
+    assert!(cert_store.initialize(&cps).is_ok());
+
+    // Grew by exactly the buffer that was added, so the two vectors still address the same
+    // certificate at the same index.
+    assert_eq!(cert_store.num_certs(), certs_before + 1);
+    assert_eq!(cert_store.num_buffers(), cert_store.num_certs());
+    assert_eq!(399 + 1, cert_store.get_certificates().unwrap().len());
+    // And a certificate that was already indexed is still held at one position rather than two.
+    assert_eq!(
+        cert_store.get_certificates_for_skid(&skid).unwrap().len(),
+        1
+    );
 }
 
 // Building the partial-path graph records the trust-anchor-to-CA signature it verifies into a

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -45,6 +45,7 @@ use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::args::{get_now_as_unix_epoch, Pittv3Args};
 use pittv3_lib::graph_cache;
 use pittv3_lib::options_std::options_std_retaining;
+use pittv3_lib::prepared_graph::PreparedGraph;
 use pittv3_lib::report::ValidationReport;
 use pittv3_lib::std_utils::{cleanup_certificate_folder, cleanup_crls, purge_folder};
 use pittv3_lib::std_utils::{
@@ -1119,6 +1120,12 @@ pub(crate) fn App() -> Element {
     // again on the next. `Arc<RevocationCache>` implements `RevocationStatusCache` for exactly this
     // -- the run registers a clone and the handle stays here to be cleared.
     let rev_cache = use_hook(|| Arc::new(RevocationCache::new()));
+    // Owned here for the same reason and on the same terms: a run leaves the certificates it
+    // prepared here, and the next run over the same material takes them rather than deserializing
+    // the store and parsing and indexing every certificate again. Nothing has to invalidate it --
+    // the key covers the inputs, the settings and the time of interest -- so the button that empties
+    // it is about releasing the memory, not about being right.
+    let prepared_graph = use_hook(|| Arc::new(PreparedGraph::new()));
     let rev_cache_for_toggle = rev_cache.clone();
     let mut s_rev_cache_status = use_signal(String::new);
     // Turning reuse off and on again must not bring back the determinations the user was trying to
@@ -1317,6 +1324,7 @@ pub(crate) fn App() -> Element {
     let run_command = {
         let retained = retained.clone();
         let rev_cache = rev_cache.clone();
+        let prepared_graph = prepared_graph.clone();
         move |_: ()| {
             if s_running() {
                 return;
@@ -1393,6 +1401,7 @@ pub(crate) fn App() -> Element {
             s_can_export.set(false);
             s_run_stamp.set(Some(now_as_unix_epoch()));
             let run_cache = rev_cache.clone();
+            let run_prepared = prepared_graph.clone();
             let run_retained = retained.clone();
             let done_retained = retained.clone();
 
@@ -1413,8 +1422,12 @@ pub(crate) fn App() -> Element {
                 };
                 // Retention is asked for here and nowhere else: the desktop offers the artifacts after
                 // a run, so it keeps what the run built. The CLI passes false and pays nothing.
-                let (report, run_artifacts) =
-                    rt.block_on(options_std_retaining(&args, true, Some(&run_cache)));
+                let (report, run_artifacts) = rt.block_on(options_std_retaining(
+                    &args,
+                    true,
+                    Some(&run_cache),
+                    Some(&run_prepared),
+                ));
                 if let Ok(mut held) = run_retained.lock() {
                     *held = run_artifacts;
                 }
@@ -2078,6 +2091,26 @@ pub(crate) fn App() -> Element {
                                                     });
                                                 },
                                                 "Purge Graphs"
+                                            }
+                                            // The in-memory counterpart, and the only one of these
+                                            // buttons that frees memory rather than disk. Discarding
+                                            // costs the next run a parse and nothing else: the graph
+                                            // on disk is untouched.
+                                            button {
+                                                title: "Discards the parsed certificates this session is holding, which is tens of megabytes for a large store. The next run over the same material parses them again; no result changes either way.",
+                                                onclick: {
+                                                    let prepared_graph = prepared_graph.clone();
+                                                    move |_| {
+                                                        s_folder_status
+                                                            .set(match prepared_graph.clear() {
+                                                                Some(certs) => {
+                                                                    format!("Discarded {certs} prepared certificate(s).")
+                                                                }
+                                                                None => "Nothing has been prepared this session.".to_string(),
+                                                            });
+                                                    }
+                                                },
+                                                "Discard Prepared Graph"
                                             }
                                         }
                                         if !s_folder_status().is_empty() {

--- a/pittv3-lib/src/graph_cache.rs
+++ b/pittv3-lib/src/graph_cache.rs
@@ -1,22 +1,24 @@
-//! Caches the graph a run builds when it augments a CBOR store with other material.
+//! Caches the graph a run builds when it augments a CBOR store with other certificates.
 //!
 //! A validation run that is given intermediates as well as a store folds them together and searches
-//! the combined material for partial paths. That search is the expensive part of preparing a run —
+//! the combined PKI for partial paths. That search is the expensive part of preparing a run —
 //! milliseconds against a small community PKI, but the better part of half a second against the
 //! Web PKI's CCADB set — and it produces the same graph every time the inputs are the same. This
 //! module keeps the result so that only the first of a series of runs pays for it.
 //!
-//! **What makes a hit.** The key is a fingerprint of everything the graph depends on: the paths
-//! that contributed material, each one's size and modification time, the time of interest, whether
-//! webpki anchors were in play, and the settings as serialized. Anything else changing is not a
-//! reason to rebuild, and anything in that list changing means the cached graph describes inputs
-//! that no longer exist. Size and modification time rather than content: reading every input to
-//! decide whether to avoid reading every input would spend most of what the cache saves. The
-//! failure mode that leaves is a file replaced within the filesystem's timestamp granularity and at
-//! exactly its old length, which is worth the trade here — this is a path-building index, and a run
-//! that wants no part of it can delete the folder or set `PITTV3_GRAPH_CACHE` to `off`.
+//! The key is a fingerprint of everything the graph depends on: the paths that contributed
+//! certificates, each one's size and modification time, whether webpki anchors were in play, and the
+//! settings as serialized apart from the time of interest. Anything else changing is not a reason to
+//! rebuild, and anything in that list changing means the cached graph describes inputs that no
+//! longer exist. The time of interest is left out because it is normally "now": keying on it meant
+//! the key never repeated, so entries were written and never read.
+//! Size and modification time rather than content: reading every input to decide whether to avoid
+//! reading every input would spend most of what the cache saves. The failure mode that leaves is a
+//! file replaced within the filesystem's timestamp granularity and at exactly its old length, which
+//! is worth the trade here — this is a path-building index, and a run that wants no part of it can
+//! delete the folder or set `PITTV3_GRAPH_CACHE` to `off`.
 //!
-//! **Only augmented graphs are cached.** A run that uses a store alone already has the store's own
+//! Only augmented graphs are cached. A run that uses a store alone already has the store's own
 //! partial paths and searches nothing, so there is nothing to save; a generate run writes its graph
 //! where it was asked to. Both are left alone.
 
@@ -84,17 +86,29 @@ fn hash_path(hasher: &mut Sha256, label: &str, path: &str) {
     }
 }
 
-/// The identity of the graph a run would build, or `None` when the run builds no augmented graph
-/// and so has nothing worth caching.
+/// The identity of the graph a run would build, or `None` when the run builds no augmented graph.
+///
+/// `None` for a generate run, which rewrites its own CA input while it runs, so nothing that can be
+/// named before it starts describes what it ends up with. `None` too for a run given a store and
+/// nothing else, which already has that store's partial paths and searches nothing, so there is no
+/// result to identify.
+///
+/// Names the graph for both the copy on disk and the one a caller keeps in memory — see
+/// [`PreparedGraph`](crate::prepared_graph::PreparedGraph). Deliberately one key: the two hold the
+/// same graph at different stages of preparation, and a second key would differ only by the time of
+/// interest, which cannot be in this one and has nothing to add to the other. Excluded because it is
+/// normally "now", so keying on it meant the key never repeated and the cache was written but never
+/// read; and nothing needs it, because the run that has no file to fall back on is the store-only
+/// run, which is the run this refuses to key at all.
 ///
 /// Deliberately conservative about the settings: the whole serialized blob goes into the key rather
 /// than the handful of values known to reach path building, so a setting that starts mattering
 /// cannot silently reuse a graph built without it. The cost is a missed cache when an unrelated
 /// setting changes, which costs exactly what there was before this existed.
-///
-/// One exclusion: the time of interest. It is normally "now", so keying on it meant the key never
-/// repeated and the cache was written but never read.
-pub fn fingerprint(args: &Pittv3Args, cps: &CertificationPathSettings) -> Option<String> {
+pub fn saved_graph_fingerprint(
+    args: &Pittv3Args,
+    cps: &CertificationPathSettings,
+) -> Option<String> {
     if args.generate || (args.ca_folder.is_none() && args.ca_inputs.is_empty()) {
         return None;
     }
@@ -127,12 +141,9 @@ pub fn fingerprint(args: &Pittv3Args, cps: &CertificationPathSettings) -> Option
     hasher.update([u8::from(args.webpki_tas)]);
     // The time of interest is deliberately NOT part of the key, and it has to be dropped in two
     // places to stay out: it is not hashed directly here, and it is removed from the settings before
-    // they are, because the caller sets it into them just before asking for a fingerprint.
-    //
-    // Keying on it made the key unrepeatable -- the time of interest is normally "now", which is new
-    // every run -- so every run wrote an entry that could never be hit again and nothing was ever
-    // reused. What the graph is built from is the trust material, and a change there is caught by
-    // hashing each input's size and modification time.
+    // they are, because the caller sets it into them just before asking for a fingerprint. What the
+    // graph is built from is the PKI, and a change there is caught by hashing each input's size and
+    // modification time.
     let mut keyed = cps.clone();
     keyed.0.remove(PS_TIME_OF_INTEREST);
     if let Ok(settings) = serde_json::to_string(&keyed) {
@@ -151,7 +162,7 @@ pub fn fingerprint_for_args(args: &Pittv3Args) -> Option<String> {
     // No need to settle a time of interest first: the key excludes it either way, so the settings
     // as read key identically to the settings a run adjusts.
     let cps = certval::read_settings(&args.settings).ok()?;
-    fingerprint(args, &cps)
+    saved_graph_fingerprint(args, &cps)
 }
 
 /// Reads the cached graph for `fingerprint` and deserializes it once, returning both forms.
@@ -188,7 +199,7 @@ pub fn cached(fingerprint: &str) -> Option<Vec<u8>> {
 /// run reused it.
 pub fn load(fingerprint: &str) -> Option<CertSource> {
     let (_, source) = read_cached(fingerprint)?;
-    info!("Reusing the cached graph for this trust material");
+    info!("Reusing the cached graph for this PKI");
     Some(source)
 }
 
@@ -206,7 +217,7 @@ pub fn cached_anchors(fingerprint: &str) -> Option<Vec<u8>> {
 /// live in a [`TaSource`](certval::TaSource) that never enters the [`CertSource`] — so a graph
 /// exported on its own describes paths to certificates it does not carry. Caching both means what
 /// is handed out is the whole of what the run validated against, and the two are written under one
-/// key, so they cannot be paired with each other's material.
+/// key, so they cannot be paired with each other's PKI.
 pub fn store_anchors(fingerprint: &str, anchors: Vec<certval::CertFile>) {
     let Some(dir) = cache_dir() else { return };
     if fs::create_dir_all(&dir).is_err() {

--- a/pittv3-lib/src/graph_cache.rs
+++ b/pittv3-lib/src/graph_cache.rs
@@ -154,26 +154,42 @@ pub fn fingerprint_for_args(args: &Pittv3Args) -> Option<String> {
     fingerprint(args, &cps)
 }
 
-/// The cached graph for `fingerprint`, or `None` when there is not one. Says nothing: a caller that
-/// wants the fact recorded should say what it is doing with it.
-pub fn cached(fingerprint: &str) -> Option<Vec<u8>> {
+/// Reads the cached graph for `fingerprint` and deserializes it once, returning both forms.
+///
+/// Once, because the two are the same work: proving the file is not truncated or corrupt means
+/// parsing it, and parsing it is what a run does with it anyway. Returning the bytes alongside the
+/// source is what lets the caller that wants to hand the file on -- an export -- have them without
+/// a second pass over several megabytes.
+fn read_cached(fingerprint: &str) -> Option<(Vec<u8>, CertSource)> {
     let path = cache_dir()?.join(format!("{fingerprint}.cbor"));
     let bytes = fs::read(&path).ok()?;
     // A truncated or corrupt cache file must not take the run down with it: fall through to
     // building the graph, which is what a miss does anyway.
-    if CertSource::new_from_cbor(&bytes).is_err() {
-        debug!("Discarding unreadable cached graph at {}", path.display());
-        let _ = fs::remove_file(&path);
-        return None;
+    match CertSource::new_from_cbor(&bytes) {
+        Ok(source) => Some((bytes, source)),
+        Err(_) => {
+            debug!("Discarding unreadable cached graph at {}", path.display());
+            let _ = fs::remove_file(&path);
+            None
+        }
     }
-    Some(bytes)
 }
 
-/// The cached graph for `fingerprint`, noting in the log that a run reused it.
-pub fn load(fingerprint: &str) -> Option<Vec<u8>> {
-    let bytes = cached(fingerprint)?;
+/// The cached graph for `fingerprint` as the bytes it is stored as, or `None` when there is not one.
+/// Says nothing: a caller that wants the fact recorded should say what it is doing with it.
+///
+/// For handing the artifact on rather than running against it — the desktop's graph export. A run
+/// wants [`load`], which does not make it deserialize what this already deserialized.
+pub fn cached(fingerprint: &str) -> Option<Vec<u8>> {
+    read_cached(fingerprint).map(|(bytes, _)| bytes)
+}
+
+/// The cached graph for `fingerprint` as a source ready to be initialized, noting in the log that a
+/// run reused it.
+pub fn load(fingerprint: &str) -> Option<CertSource> {
+    let (_, source) = read_cached(fingerprint)?;
     info!("Reusing the cached graph for this trust material");
-    Some(bytes)
+    Some(source)
 }
 
 /// The cached trust anchors that go with the graph for `fingerprint`, or `None` when there are not

--- a/pittv3-lib/src/lib.rs
+++ b/pittv3-lib/src/lib.rs
@@ -18,6 +18,8 @@ pub mod options_no_std;
 pub mod options_std;
 pub mod options_std_app;
 pub mod pitt_log;
+#[cfg(feature = "std")]
+pub mod prepared_graph;
 pub mod report;
 pub mod retained;
 pub mod stats;

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -133,6 +133,7 @@ use log::{debug, error, info};
 
 use crate::args::Pittv3Args;
 use crate::graph_cache;
+use crate::prepared_graph::PreparedGraph;
 use crate::report::{ReportTotals, TargetReport, ValidationReport};
 use crate::retained::{RetainedPath, RetainedRun};
 use crate::stats::{PVStats, PathValidationStats, PathValidationStatsGroup};
@@ -222,7 +223,7 @@ fn normalize_pem_wrap(pem: &str) -> Option<String> {
 /// report. The CLI ignores the return value (log/file output is unchanged); GUI and server
 /// frontends consume it.
 pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
-    let (report, _) = options_std_retaining(args, false, None).await;
+    let (report, _) = options_std_retaining(args, false, None, None).await;
     report
 }
 
@@ -242,12 +243,19 @@ pub async fn options_std(args: &Pittv3Args) -> ValidationReport {
 /// checked on one run is not checked again on the next, and can offer to discard the contents; a
 /// process that runs once passes `None` and gets a cache for the run, which is what the CLI does.
 /// `--no-revocation-cache` declines either.
+///
+/// `prepared` is the same arrangement for the certificates themselves. A run given one takes its
+/// graph from it when the material is the one it holds, and leaves its own there when it is not,
+/// which spares the next run deserializing the store and parsing and indexing every certificate in
+/// it. `None` prepares from the inputs and drops the result, which is what a process that runs once
+/// wants.
 pub async fn options_std_retaining(
     args: &Pittv3Args,
     retain: bool,
     #[cfg(all(feature = "std", feature = "revocation"))] cache: Option<
         &std::sync::Arc<RevocationCache>,
     >,
+    prepared: Option<&PreparedGraph>,
 ) -> (ValidationReport, Option<RetainedRun>) {
     let mut kept = None;
     let report = options_std_inner(
@@ -255,6 +263,7 @@ pub async fn options_std_retaining(
         retain.then_some(&mut kept),
         #[cfg(all(feature = "std", feature = "revocation"))]
         cache,
+        prepared,
     )
     .await;
     (report, kept)
@@ -270,6 +279,7 @@ async fn options_std_inner(
     #[cfg(all(feature = "std", feature = "revocation"))] cache: Option<
         &std::sync::Arc<RevocationCache>,
     >,
+    prepared: Option<&PreparedGraph>,
 ) -> ValidationReport {
     if args.cleanup {
         // Cleanup runs in isolation before other actions
@@ -722,6 +732,7 @@ async fn options_std_inner(
             kept,
             #[cfg(all(feature = "std", feature = "revocation"))]
             cache,
+            prepared,
         )
         .await;
     }
@@ -750,6 +761,9 @@ async fn options_std_inner(
 /// When `retain` is set, every validated path is kept and returned with the environment it was
 /// validated against, so a frontend can export the artifacts behind a result once the run is over
 /// rather than having to name a results folder before it starts.
+///
+/// When `prepared` is given, the graph is taken from it rather than assembled, whenever it holds one
+/// prepared from the same material; either way the run leaves its own there for the next.
 #[cfg(feature = "std")]
 async fn generate_and_validate(
     args: &Pittv3Args,
@@ -757,6 +771,7 @@ async fn generate_and_validate(
     #[cfg(all(feature = "std", feature = "revocation"))] cache: Option<
         &std::sync::Arc<RevocationCache>,
     >,
+    prepared: Option<&PreparedGraph>,
 ) -> ValidationReport {
     let retain = kept.is_some();
     let mut retained: Vec<RetainedPath> = vec![];
@@ -817,7 +832,10 @@ async fn generate_and_validate(
     // off AIA/SIA retrieval, and anchor validity for webpki anchors — and a caller outside a run
     // has no way to reproduce those adjustments. Both are covered by the key anyway: chasing runs
     // are not cached at all, and webpki_tas is hashed in its own right.
-    let graph_fingerprint = graph_cache::fingerprint(args, &cps);
+    //
+    // One key for both copies of the graph, the one on disk and the one the caller keeps: they hold
+    // the same graph, so a run that finds neither files both under the same name.
+    let graph_fingerprint = graph_cache::saved_graph_fingerprint(args, &cps);
 
     #[cfg(feature = "remote")]
     if !args.dynamic_build {
@@ -946,10 +964,6 @@ async fn generate_and_validate(
     // folder that yielded nothing from no folder at all.
     let mut ca_folder_certs = 0;
 
-    // Whether the graph came off the cache rather than being built. Its identity was settled
-    // before the settings were adjusted for the run — see `graph_fingerprint` above.
-    let mut graph_from_cache = false;
-
     // Whether the CA input was a CBOR store adopted with the partial paths it carries, which means
     // the graph is already built and searching again would recompute it.
     let mut ca_store_paths_adopted = false;
@@ -1032,26 +1046,46 @@ async fn generate_and_validate(
         None => None,
     };
 
+    // Whether the graph arrived already parsed and indexed, which only the caller's own does.
+    let mut graph_already_parsed = false;
+
     // The pool the run builds paths from, prepared once here and carried across every pass.
     //
-    // The cache is asked first so that a hit does not also read and deserialize the store it is
-    // about to replace. A hit is the same augmented graph as last time, when nothing it was built
-    // from has changed: what it skips is the folder walk and the partial-path search, which is the
-    // expensive half of preparing a run. The certificates are still parsed, since they have to be.
+    // Asked for in the order of how much of the work is already done. What the caller holds in
+    // memory is parsed and indexed and needs nothing further. The graph on disk is the result of
+    // searching this same material, so it skips the folder walk and the partial-path search, but
+    // its certificates still have to be parsed. The inputs themselves are the whole job. Asking in
+    // that order is also what keeps a hit from reading and deserializing a store it is about to
+    // throw away.
     //
-    // Preparing it once matters most to the passes after the first. This used to be rebuilt from
-    // CBOR at the top of every pass, and from pass 1 on it was rebuilt from the *store* -- so a
+    // Preparing it once rather than per pass matters most after the first. This used to be rebuilt
+    // from CBOR at the top of every pass, and from pass 1 on it was rebuilt from the *store* -- so a
     // dynamic build went back for an AIA URI and came back holding neither the CA folder's
     // certificates nor the cached graph, having quietly returned to what the store alone carries,
-    // having paid a multi-megabyte deserialize to do it. What forced the rebuild was that
+    // and paid a multi-megabyte deserialize to do it. What forced the rebuild was that
     // `CertSource::initialize` could not be called twice; it now parses only the buffers appended
     // since, so one source serves the whole run and the indices that the partial paths and the pass
     // threshold are expressed in mean the same thing from one pass to the next.
-    let mut cert_source = match graph_fingerprint.as_deref().and_then(graph_cache::load) {
-        Some(from_cache) => {
-            graph_from_cache = true;
-            from_cache
+    let ready_made = match prepared
+        .zip(graph_fingerprint.as_deref())
+        .and_then(|(prepared, key)| prepared.get(key))
+    {
+        Some(from_memory) => {
+            info!("Reusing the certificates prepared for this PKI");
+            graph_already_parsed = true;
+            Some(from_memory)
         }
+        None => graph_fingerprint.as_deref().and_then(graph_cache::load),
+    };
+
+    // Whether the graph arrived ready-made rather than being assembled from the inputs, which is
+    // what says the CA inputs must not be folded in again and the partial paths must not be searched
+    // for again. Its identity was settled before the settings were adjusted for the run -- see
+    // `graph_fingerprint` above.
+    let graph_from_cache = ready_made.is_some();
+
+    let mut cert_source = match ready_made {
+        Some(graph) => graph,
         None => {
             let cbor = read_cbor(&args.cbor);
             if cbor.is_empty() {
@@ -1247,8 +1281,8 @@ async fn generate_and_validate(
         // Nothing arrived this pass, so there is nothing left for the loop to do. `threshold` is the
         // size of the pool this pass started with, and a path is only returned to the caller when
         // `above_threshold` finds an index at or above it, which no path can satisfy once the pool
-        // has stopped growing -- so this pass would find zero paths, rebuild the same graph and
-        // re-serialize it to the same bytes, and the next pass would do it again.
+        // has stopped growing -- so this pass would find zero paths and validate nothing, and the
+        // next pass would do the same.
         //
         // The loop had no other way out of that. The fetch block above stops running once the URI
         // set stops changing, and the `break` for a non-dynamic run lives inside it, so a dynamic
@@ -1264,12 +1298,18 @@ async fn generate_and_validate(
 
         // Parses whatever this pass appended and reindexes. On pass 0 that is the whole pool; on
         // later passes only what came back from AIA and SIA, since the source is the same one.
+        //
+        // Skipped entirely on pass 0 for a graph that came out of memory, which arrives parsed and
+        // indexed. Not merely redundant: `index_certs` rebuilds both maps whether or not anything
+        // was added to parse, so calling it would give back the larger half of what holding the
+        // graph saved.
         //TODO refactor to make TaSource.tas and CertSource.certs RefCells with on demand parsing
         //instead of holding all certs parsed all the time?
-        let r = cert_source.initialize(&cps);
-        if let Err(e) = r {
-            error!("Failed to populate cert map: {e}");
-            break;
+        if !(graph_already_parsed && 0 == pass) {
+            if let Err(e) = cert_source.initialize(&cps) {
+                error!("Failed to populate cert map: {e}");
+                break;
+            }
         }
 
         // Certificates read from the CA folder arrive with no partial paths, and a path that spans
@@ -1282,6 +1322,17 @@ async fn generate_and_validate(
             cert_source.find_all_partial_paths(&pe, &cps);
             if let Some(fingerprint) = &graph_fingerprint {
                 graph_cache::store(fingerprint, &cert_source);
+            }
+        }
+
+        // Left for the next run over this material, which then neither deserializes nor parses any
+        // of it. Here rather than at the end of the run, and so on pass 0 and before anything has
+        // been fetched, because what is kept has to be what the key describes: the certificates the
+        // run was given, not the ones it went out and got. `graph_cache::store` above is guarded the
+        // same way and for the same reason.
+        if 0 == pass && !graph_already_parsed {
+            if let Some((prepared, key)) = prepared.zip(graph_fingerprint.as_deref()) {
+                prepared.keep(key.to_string(), &cert_source);
             }
         }
 

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -931,10 +931,6 @@ async fn generate_and_validate(
     // augmenting with AIA/SIA).
     let mut pass: u8 = 0;
 
-    // Read CBOR from a file only once. It will be generated following AIA/SIA fetch while looping
-    // in support of dynamic path building.
-    let mut cbor = read_cbor(&args.cbor);
-
     // define a vector to receive URIs scraped from AIA and SIA extensions.
     let mut fresh_uris: Vec<String> = vec![];
 
@@ -1036,110 +1032,111 @@ async fn generate_and_validate(
         None => None,
     };
 
-    loop {
-        // Create a new CertSource and (re-)deserialize on every iteration due references to
-        // buffers in the certs member. On the first pass, cbor will contain data read from file,
-        // on subsequent passes it will contain a fresh CBOR blob that features buffers downloaded
-        // from AIA or SIA locations.
-        let mut cert_source = if cbor.is_empty() {
-            // Empty CBOR is fine when doing dynamic building, when the intermediates come from a
-            // CA folder, or when validating certificates issued by a trust anchor. Only worth
-            // saying when a store was actually named: a run that supplied none is not missing one.
-            if 0 == pass && !cbor_file.is_empty() {
-                info!("Empty CBOR file at {cbor_file}. Proceeding without it.");
-            }
-            CertSource::default()
-
-            // Not harvesting URIs and doing dynamic on first pass on off chance the end entity
-            // was issued by a trust anchor. It may be better to harvest here and save a loop.
-        } else {
-            // we want to use the buffers as augmented by last round but want to start from scratch
-            // on the partial paths.
-            match CertSource::new_from_cbor(cbor.as_slice()) {
-                Ok(cbor_data) => cbor_data,
-                Err(e) => {
-                    error!(
-                        "Failed to parse CBOR file at {cbor_file} with: {e}. Proceeding without it."
-                    );
-                    CertSource::default()
+    // The pool the run builds paths from, prepared once here and carried across every pass.
+    //
+    // The cache is asked first so that a hit does not also read and deserialize the store it is
+    // about to replace. A hit is the same augmented graph as last time, when nothing it was built
+    // from has changed: what it skips is the folder walk and the partial-path search, which is the
+    // expensive half of preparing a run. The certificates are still parsed, since they have to be.
+    //
+    // Preparing it once matters most to the passes after the first. This used to be rebuilt from
+    // CBOR at the top of every pass, and from pass 1 on it was rebuilt from the *store* -- so a
+    // dynamic build went back for an AIA URI and came back holding neither the CA folder's
+    // certificates nor the cached graph, having quietly returned to what the store alone carries,
+    // having paid a multi-megabyte deserialize to do it. What forced the rebuild was that
+    // `CertSource::initialize` could not be called twice; it now parses only the buffers appended
+    // since, so one source serves the whole run and the indices that the partial paths and the pass
+    // threshold are expressed in mean the same thing from one pass to the next.
+    let mut cert_source = match graph_fingerprint.as_deref().and_then(graph_cache::load) {
+        Some(from_cache) => {
+            graph_from_cache = true;
+            from_cache
+        }
+        None => {
+            let cbor = read_cbor(&args.cbor);
+            if cbor.is_empty() {
+                // Empty CBOR is fine when doing dynamic building, when the intermediates come from
+                // a CA folder, or when validating certificates issued by a trust anchor. Only
+                // worth saying when a store was actually named: a run that supplied none is not
+                // missing one.
+                if !cbor_file.is_empty() {
+                    info!("Empty CBOR file at {cbor_file}. Proceeding without it.");
+                }
+                CertSource::default()
+            } else {
+                match CertSource::new_from_cbor(cbor.as_slice()) {
+                    Ok(cbor_data) => cbor_data,
+                    Err(e) => {
+                        error!(
+                            "Failed to parse CBOR file at {cbor_file} with: {e}. Proceeding without it."
+                        );
+                        CertSource::default()
+                    }
                 }
             }
+        }
+    };
+
+    // A CA folder is the intermediates the user already has, and it fed generation only: at
+    // validation time the graph came from the CBOR store alone, so -t tas -c cas -e ee.der
+    // found no paths at all and the folder had to be compiled into a store first. Fold it into
+    // the graph here so it is a validation input in its own right; a store supplied alongside
+    // it is augmented rather than displaced, since both are just certificates to build from. A
+    // generate run is exempt because the CBOR read above was built from this same folder.
+    if !args.generate && !graph_from_cache {
+        // Where downloaded intermediates land, when the run was asked to reuse them. Last in the
+        // order so it augments what was named explicitly rather than being mistaken for the
+        // whole CA input: a store named in the pool still gets its partial paths adopted.
+        #[cfg(feature = "remote")]
+        let reuse_downloads = match args.use_downloaded_cas && !download_folder.is_empty() {
+            true => Some(download_folder.clone()),
+            false => None,
         };
+        #[cfg(not(feature = "remote"))]
+        let reuse_downloads: Option<String> = None;
 
-        // What the pool held before this pass did anything. Only fetching adds to it after the
-        // first pass -- the CA inputs are loaded under `0 == pass` -- so comparing against this
-        // says whether the pass brought back anything at all.
+        // The singular argument first, then the pool, so a log read top to bottom follows the
+        // order the inputs were named in.
+        let outcome = load_ca_inputs(
+            &pe,
+            args.ca_folder
+                .iter()
+                .chain(args.ca_inputs.iter())
+                .chain(reuse_downloads.iter())
+                .map(String::as_str),
+            &mut cert_source,
+            cps.get_time_of_interest(),
+        );
+        ca_folder_certs = outcome.certs;
+        ca_store_paths_adopted = outcome.paths_adopted;
+
+        // After the path-shaped inputs, because adopting a CBOR store's graph replaces the
+        // source wholesale (see `load_ca_inputs`) and would discard anything pushed before it.
+        // The writable store is read here too, so a run that will later write to it starts
+        // from what earlier runs left there.
+        #[cfg(all(windows, feature = "capi"))]
+        {
+            let specs: Vec<String> = args
+                .capi_ca_stores
+                .iter()
+                .chain(args.capi_ca_store_rw.iter())
+                .cloned()
+                .collect();
+            match load_capi_ca_stores(&specs, &mut cert_source) {
+                Ok(added) => ca_folder_certs += added,
+                Err(msg) => {
+                    println!("Failed to read CA certificates from CAPI: {msg}");
+                    return ValidationReport::default();
+                }
+            }
+        }
+    }
+
+    loop {
+        // What the pool held before this pass did anything. Only fetching adds to it now that the
+        // CA inputs are folded in before the loop, so comparing against this says whether the pass
+        // brought back anything at all.
         let certs_at_pass_start = cert_source.len();
-
-        // The same augmented graph as last time, when nothing it was built from has changed. What
-        // is skipped is the folder walk and the partial-path search, which is the expensive half of
-        // preparing a run; the certificates are still parsed, since they have to be.
-        if 0 == pass && !graph_from_cache {
-            if let Some(cached) = graph_fingerprint.as_deref().and_then(graph_cache::load) {
-                match CertSource::new_from_cbor(cached.as_slice()) {
-                    Ok(from_cache) => {
-                        cert_source = from_cache;
-                        graph_from_cache = true;
-                    }
-                    Err(e) => debug!("Ignoring an unusable cached graph: {e:?}"),
-                }
-            }
-        }
-
-        // A CA folder is the intermediates the user already has, and it fed generation only: at
-        // validation time the graph came from the CBOR store alone, so -t tas -c cas -e ee.der
-        // found no paths at all and the folder had to be compiled into a store first. Fold it into
-        // the graph here so it is a validation input in its own right; a store supplied alongside
-        // it is augmented rather than displaced, since both are just certificates to build from. A
-        // generate run is exempt because the CBOR read above was built from this same folder.
-        if 0 == pass && !args.generate && !graph_from_cache {
-            // Where downloaded intermediates land, when the run was asked to reuse them. Last in the
-            // order so it augments what was named explicitly rather than being mistaken for the
-            // whole CA input: a store named in the pool still gets its partial paths adopted.
-            #[cfg(feature = "remote")]
-            let reuse_downloads = match args.use_downloaded_cas && !download_folder.is_empty() {
-                true => Some(download_folder.clone()),
-                false => None,
-            };
-            #[cfg(not(feature = "remote"))]
-            let reuse_downloads: Option<String> = None;
-
-            // The singular argument first, then the pool, so a log read top to bottom follows the
-            // order the inputs were named in.
-            let outcome = load_ca_inputs(
-                &pe,
-                args.ca_folder
-                    .iter()
-                    .chain(args.ca_inputs.iter())
-                    .chain(reuse_downloads.iter())
-                    .map(String::as_str),
-                &mut cert_source,
-                cps.get_time_of_interest(),
-            );
-            ca_folder_certs = outcome.certs;
-            ca_store_paths_adopted = outcome.paths_adopted;
-
-            // After the path-shaped inputs, because adopting a CBOR store's graph replaces the
-            // source wholesale (see `load_ca_inputs`) and would discard anything pushed before it.
-            // The writable store is read here too, so a run that will later write to it starts
-            // from what earlier runs left there.
-            #[cfg(all(windows, feature = "capi"))]
-            {
-                let specs: Vec<String> = args
-                    .capi_ca_stores
-                    .iter()
-                    .chain(args.capi_ca_store_rw.iter())
-                    .cloned()
-                    .collect();
-                match load_capi_ca_stores(&specs, &mut cert_source) {
-                    Ok(added) => ca_folder_certs += added,
-                    Err(msg) => {
-                        println!("Failed to read CA certificates from CAPI: {msg}");
-                        return ValidationReport::default();
-                    }
-                }
-            }
-        }
 
         // We don't want to return previously returned paths on subsequent passes through the loop.
         // Since buffers from AIA/SIA are appended to the cert_source.buffers_and_paths.buffers
@@ -1265,6 +1262,8 @@ async fn generate_and_validate(
             break;
         }
 
+        // Parses whatever this pass appended and reindexes. On pass 0 that is the whole pool; on
+        // later passes only what came back from AIA and SIA, since the source is the same one.
         //TODO refactor to make TaSource.tas and CertSource.certs RefCells with on demand parsing
         //instead of holding all certs parsed all the time?
         let r = cert_source.initialize(&cps);
@@ -1289,21 +1288,13 @@ async fn generate_and_validate(
         // If this is not the first pass, find all partial paths present in buffers_and_paths. If
         // this is the first pass, we expect this to have been present in the deserialized CBOR.
         //
-        // Skipped when the pass fetched nothing. Searching the same buffers again yields the same
-        // partial paths, and re-serializing them rewrites a blob the next pass would deserialize
-        // back into what it already has -- on a revalidation where every fetch comes back 304, that
-        // was a full search and a multi-megabyte round trip per pass to discover there was nothing
-        // to do. `cbor` is deliberately left as it was: it still describes this pool.
+        // Skipped when the pass fetched nothing: searching the same buffers again yields the same
+        // partial paths, which on a revalidation where every fetch comes back 304 was a full search
+        // per pass to discover there was nothing to do. Nothing is serialized here any more -- the
+        // blob only ever existed to be deserialized back into the source at the top of the next
+        // pass, and the source is now the same one.
         if 0 < pass && cert_source.len() != certs_at_pass_start {
             cert_source.find_all_partial_paths(&pe, &cps);
-
-            // After finding all partial paths, serialize as CBOR and save for next pass
-            match cert_source.serialize(CertificationPathBuilderFormats::Cbor) {
-                Ok(new_cbor) => {
-                    cbor = new_cbor;
-                }
-                Err(e) => error!("Failed to serialize CBOR after dynamic building with {e:?}"),
-            }
 
             #[cfg(feature = "remote")]
             if args.dynamic_build {

--- a/pittv3-lib/src/prepared_graph.rs
+++ b/pittv3-lib/src/prepared_graph.rs
@@ -1,0 +1,81 @@
+//! The graph a run prepared, kept in memory so the next run over the same PKI does not perform
+//! duplicative work.
+//!
+//! [`graph_cache`](crate::graph_cache) saves a map of a given PKI, so a second run against for the
+//! same PKI can reuse it without having to rebuild the graph. However, this serialized may cannot
+//! save the work of turning those bytes back into something usable, i.e., deserializing the store,
+//! parsing every certificate in it, and indexing them by key identifier and by subject name. The
+//! `PreparedGraph` struct provides this capability.
+
+use std::sync::{PoisonError, RwLock};
+
+use certval::CertSource;
+
+/// A prepared graph and the identity of the PKI associated with it.
+///
+/// Selecting a different PKI simply replaces the entry.
+///
+/// A caller does not have to invalidate this. The key covers the inputs, the settings and the time
+/// of interest, so anything that would make the entry the wrong answer keys differently and misses.
+/// [`clear`](PreparedGraph::clear) exists to release the memory, not to preserve correctness.
+///
+/// One thing it does not cover, which it inherits from the key it shares with the graph on disk: the
+/// download folder feeds the graph but is not keyed, so certificates a dynamic build fetched on an
+/// earlier run reach a rebuild and do not reach a hit.
+#[derive(Default)]
+pub struct PreparedGraph {
+    /// `None` until a run has prepared something. Poisoning is ignored throughout: a panic in one
+    /// run is not a reason to make every later run rebuild, and there is nothing here to leave
+    /// inconsistent — the two fields are written together or not at all.
+    entry: RwLock<Option<Entry>>,
+}
+
+/// A prepared graph and an identifier of the PKI associated with it.
+struct Entry {
+    /// From [`prepared_key`](crate::graph_cache::prepared_key), so it names the inputs, the settings
+    /// and the time of interest together.
+    key: String,
+    /// Parsed and indexed, and carrying the partial paths the run found among them.
+    graph: CertSource,
+}
+
+impl PreparedGraph {
+    /// A `PreparedGraph` with nothing in it.
+    pub fn new() -> Self {
+        Self::default()
+    }
+
+    /// The graph prepared from the PKI `key` names, or `None` when there is no entry or the entry
+    /// came from something else.
+    ///
+    /// A clone is returned so a dynamic build can append to the graph it is. The next run gets the
+    /// same starting point this one got rather than whatever the last run happened to fetch (unless
+    /// the updated graph is swapped into place).
+    pub fn get(&self, key: &str) -> Option<CertSource> {
+        let entry = self.entry.read().unwrap_or_else(PoisonError::into_inner);
+        let entry = entry.as_ref()?;
+        (entry.key == key).then(|| entry.graph.clone())
+    }
+
+    /// Keeps `graph` as the graph prepared from the PKI the `key` names, replacing any entry.
+    pub fn keep(&self, key: String, graph: &CertSource) {
+        let mut entry = self.entry.write().unwrap_or_else(PoisonError::into_inner);
+        *entry = Some(Entry {
+            key,
+            graph: graph.clone(),
+        });
+    }
+
+    /// Discards the entry, reporting how many certificates went with it. `None` when there was
+    /// nothing to discard, which a frontend needs to tell from having discarded an empty graph.
+    pub fn clear(&self) -> Option<usize> {
+        let mut entry = self.entry.write().unwrap_or_else(PoisonError::into_inner);
+        entry.take().map(|entry| entry.graph.num_certs())
+    }
+
+    /// How many certificates are prepared, or `None` when nothing is.
+    pub fn certificates(&self) -> Option<usize> {
+        let entry = self.entry.read().unwrap_or_else(PoisonError::into_inner);
+        entry.as_ref().map(|entry| entry.graph.num_certs())
+    }
+}

--- a/pittv3-lib/tests/prepared_graph.rs
+++ b/pittv3-lib/tests/prepared_graph.rs
@@ -1,0 +1,218 @@
+//! Integration tests for the graph a run prepares and a caller keeps in memory.
+//!
+//! What has to hold is the same thing the graph saved on disk has to satisfy — reuse is invisible in
+//! the answer — plus the thing specific to keeping the *parsed* form: that a run really does stop
+//! reading its inputs when it can be served from memory.
+//!
+//! **Its own test binary on purpose.** These tests point the graph cache somewhere harmless through
+//! an environment variable, and environment variables belong to the process rather than to a test.
+//! See the module comment on `graph_cache.rs`, which shares the hazard and the arrangement.
+//!
+//! Gated on `revocation` as well as `std` because `options_std_retaining` takes the revocation cache
+//! as a parameter only when both are on, so the call below has a different shape without it. The
+//! tests themselves check no revocation status; the settings turn it off.
+#![cfg(all(feature = "std", feature = "revocation"))]
+
+use std::fs;
+use std::path::{Path, PathBuf};
+use std::sync::Mutex;
+
+use certval::*;
+use pittv3_lib::args::Pittv3Args;
+use pittv3_lib::graph_cache;
+use pittv3_lib::options_std::options_std_retaining;
+use pittv3_lib::prepared_graph::PreparedGraph;
+use pittv3_lib::report::{TargetStatus, ValidationReport};
+
+/// Serializes the tests in this file, which each set the same environment variable. Poison ignored
+/// so one failure reports itself rather than being masked by the other test failing to acquire.
+static CACHE_ENV_LOCK: Mutex<()> = Mutex::new(());
+
+/// A time at which the PKITS fixtures are valid
+const TOI: u64 = 1648039783;
+
+const FLAVOR: &str = "../certval/tests/examples/PKITS_data_p256/certs";
+
+fn example(name: &str) -> PathBuf {
+    Path::new(FLAVOR).join(name)
+}
+
+fn folder_with(dir: &Path, names: &[&str]) -> String {
+    fs::create_dir_all(dir).unwrap();
+    for name in names {
+        fs::copy(example(name), dir.join(name)).unwrap();
+    }
+    dir.to_str().unwrap().to_string()
+}
+
+/// Settings that carry no time of interest, so the run takes it from the arguments.
+fn settings_file(dir: &Path) -> String {
+    let mut cps = CertificationPathSettings::new();
+    cps.set_check_revocation_status(false);
+    let path = dir.join("settings.json");
+    fs::write(&path, serde_json::to_string(&cps).unwrap()).unwrap();
+    path.to_str().unwrap().to_string()
+}
+
+fn args_for(dir: &Path, ta_folder: String, ca_folder: String, toi: u64) -> Pittv3Args {
+    Pittv3Args {
+        ta_folder: Some(ta_folder),
+        ca_folder: Some(ca_folder),
+        end_entity_file: Some(
+            example("ValidCertificatePathTest1EE.crt")
+                .to_str()
+                .unwrap()
+                .to_string(),
+        ),
+        settings: Some(settings_file(dir)),
+        time_of_interest: toi,
+        ..Default::default()
+    }
+}
+
+fn validate(args: &Pittv3Args, prepared: Option<&PreparedGraph>) -> ValidationReport {
+    let (report, _) = tokio_test::block_on(options_std_retaining(args, false, None, prepared));
+    report
+}
+
+/// Overwrites a certificate with the same number of bytes of nonsense, then puts its timestamps
+/// back.
+///
+/// The key is each input's path, size and modification time, so this leaves it identical while
+/// making the file useless. A run that still finds the path afterwards did not read the file, which
+/// is the only way to show reuse from the outside: a hit is otherwise indistinguishable from doing
+/// the work again correctly.
+fn corrupt_in_place(path: &Path) {
+    let before = fs::metadata(path).unwrap();
+    let times = fs::FileTimes::new()
+        .set_accessed(before.accessed().unwrap())
+        .set_modified(before.modified().unwrap());
+
+    fs::write(path, vec![0xff; before.len() as usize]).unwrap();
+
+    let file = fs::File::options().write(true).open(path).unwrap();
+    file.set_times(times).unwrap();
+
+    let after = fs::metadata(path).unwrap();
+    assert_eq!(before.len(), after.len(), "the corruption changed the size");
+    assert_eq!(
+        before.modified().unwrap(),
+        after.modified().unwrap(),
+        "the modification time did not survive being put back, so the key moved and this test \
+         cannot say anything about reuse"
+    );
+}
+
+/// Points the graph cache at nothing, so only the caller's own prepared graph can answer.
+///
+/// # Safety
+///
+/// The lock the caller holds serializes every test in this binary that touches this variable.
+unsafe fn disable_graph_cache() {
+    unsafe { std::env::set_var("PITTV3_GRAPH_CACHE", "off") };
+}
+
+#[test]
+fn a_prepared_graph_is_reused_without_reading_the_inputs_again() {
+    let _guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: serialized by the lock above.
+    unsafe { disable_graph_cache() };
+    let dir = tempfile::tempdir().unwrap();
+
+    let ta_folder = folder_with(&dir.path().join("ta"), &["TrustAnchorRootCertificate.crt"]);
+    let ca_dir = dir.path().join("ca");
+    let ca_folder = folder_with(&ca_dir, &["GoodCACert.crt"]);
+    let args = args_for(dir.path(), ta_folder, ca_folder, TOI);
+
+    let prepared = PreparedGraph::new();
+    assert_eq!(
+        None,
+        prepared.certificates(),
+        "nothing has been prepared yet"
+    );
+
+    let first = validate(&args, Some(&prepared));
+    assert_eq!(TargetStatus::Valid, first.targets[0].status);
+    assert_eq!(
+        Some(1),
+        prepared.certificates(),
+        "the run should have left its prepared certificates behind"
+    );
+
+    // The intermediate is now unreadable, and keyed exactly as it was.
+    corrupt_in_place(&ca_dir.join("GoodCACert.crt"));
+
+    // A fresh PreparedGraph has to go to the folder, and the folder no longer has a usable CA in
+    // it. This
+    // is the control: without it, the run below passing would only show that validation works.
+    let unprepared = validate(&args, Some(&PreparedGraph::new()));
+    assert_ne!(
+        TargetStatus::Valid,
+        unprepared.targets[0].status,
+        "the corrupted intermediate still produced a valid path, so the run below proves nothing"
+    );
+
+    // Same run, given what the first one prepared: the path is found, from certificates that exist
+    // only in memory.
+    let second = validate(&args, Some(&prepared));
+    assert_eq!(TargetStatus::Valid, second.targets[0].status);
+    assert_eq!(first.totals.paths_found, second.totals.paths_found);
+    assert_eq!(first.totals.valid_paths, second.totals.valid_paths);
+    assert_eq!(
+        first.targets[0].paths[0].certs.len(),
+        second.targets[0].paths[0].certs.len()
+    );
+
+    unsafe { std::env::remove_var("PITTV3_GRAPH_CACHE") };
+}
+
+/// One graph is kept, under the key of the PKI it was prepared from.
+#[test]
+fn what_is_kept_is_keyed_to_the_pki_it_came_from() {
+    let _guard = CACHE_ENV_LOCK.lock().unwrap_or_else(|e| e.into_inner());
+    // SAFETY: serialized by the lock above.
+    unsafe { disable_graph_cache() };
+    let dir = tempfile::tempdir().unwrap();
+
+    let ta_folder = folder_with(&dir.path().join("ta"), &["TrustAnchorRootCertificate.crt"]);
+    let ca_folder = folder_with(&dir.path().join("ca"), &["GoodCACert.crt"]);
+    let args = args_for(dir.path(), ta_folder.clone(), ca_folder, TOI);
+
+    let prepared = PreparedGraph::new();
+    assert_eq!(
+        TargetStatus::Valid,
+        validate(&args, Some(&prepared)).targets[0].status
+    );
+
+    // The settings the run keyed on, as read from the file. The time of interest is taken back out
+    // before hashing, so it does not matter that these do not carry the one the run settled.
+    let cps = read_settings(&args.settings).unwrap();
+    let key = graph_cache::saved_graph_fingerprint(&args, &cps)
+        .expect("every run that is not a generate run keys");
+    assert!(
+        prepared.get(&key).is_some(),
+        "the run filed its graph under a key its own arguments do not reproduce"
+    );
+    assert!(prepared.get("not the key").is_none());
+
+    // Selecting a different PKI replaces what is kept rather than accumulating beside it.
+    let bigger = folder_with(
+        &dir.path().join("ca2"),
+        &["GoodCACert.crt", "BasicSelfIssuedNewKeyCACert.crt"],
+    );
+    let other = args_for(dir.path(), ta_folder, bigger, TOI);
+    assert_eq!(
+        TargetStatus::Valid,
+        validate(&other, Some(&prepared)).targets[0].status
+    );
+    assert!(
+        prepared.get(&key).is_none(),
+        "one graph is supposed to be kept, not a map of them"
+    );
+
+    assert_eq!(Some(2), prepared.certificates());
+    assert_eq!(Some(2), prepared.clear(), "clear reports what it discarded");
+    assert_eq!(None, prepared.clear(), "and says so when there was nothing");
+
+    unsafe { std::env::remove_var("PITTV3_GRAPH_CACHE") };
+}


### PR DESCRIPTION
- certval: CertSource::initialize can now be called again after buffers are appended because it now parses only what has not already been parsed. index_certs now rebuilds the skid and name maps instead of adding to them.
- options_std prepares one CertSource before the loop and retains it. Dynamic builds use the CA folder's certificates and the cached graph, and the per-pass serialize/deserialize round trip was eliminated.
- The graph cache is consulted before the CBOR store is read (which is OK because the CBOR is factored into the cache fingerprint). This allows a store deserialization to be avoided.
- Refactored graph_cache's load and cached into read_cached, load, and cached to enable returning bytes and a parsed CertSource.
- Fix some stale documentation comments
- New PreparedGraph in pittv3-lib keeps one parsed, indexed CertSource and the key of the PKI it came from, so a later run over the same PKI does not deserialize the store or parse and index its certificates again. PreparedGraph instances are caller-owned, like the revocation cache.
- generate_and_validate consults memory, then the graph cache, then the inputs, all under one key. A graph that comes from memory skips initialize on pass 0, avoiding reindexing of the whole pool whether or not anything was added to parse.
- pittv3-gui keeps one for the session and offers Discard Prepared Graph beside Purge Graphs on the Settings tab.