### PR TITLE
Add support for raw base64 encoded data where PEM and DER are parsed

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5129,6 +5129,7 @@ name = "pittv3-lib"
 version = "0.2.0-pre"
 dependencies = [
  "async-recursion",
+ "base64ct",
  "bytes",
  "certval 0.2.0-pre",
  "ciborium",

--- a/certval/src/util/pdv_utilities.rs
+++ b/certval/src/util/pdv_utilities.rs
@@ -1003,8 +1003,9 @@ pub(crate) fn general_subtree_to_string(gs: &GeneralSubtree) -> String {
 /// input begins with `-----`, it is PEM-decoded: the strict RFC 7468 decoder is tried first, then a
 /// lenient fallback for real-world PEM that OpenSSL accepts but strict RFC 7468 rejects (a trailing
 /// blank line, or base64 wrapped at a width other than 64, as some DoD/FPKI tools emit) — drop the
-/// encapsulation-boundary lines, strip all whitespace, and base64-decode the body. Any bytes past the
-/// outer DER SEQUENCE are then trimmed (see `trim_to_outer_der_sequence`). Available in no_std.
+/// encapsulation-boundary lines, strip all whitespace, and base64-decode the body. An input with no
+/// boundaries at all is offered to [`decode_bare_base64`] before being taken for DER. Any bytes past
+/// the outer DER SEQUENCE are then trimmed (see `trim_to_outer_der_sequence`). Available in no_std.
 ///
 /// This decodes a *single* object. A multi-object PEM (a concatenated bundle) is not supported here:
 /// depending on byte alignment it yields only the first object or fails outright, so treat a bundle as
@@ -1029,11 +1030,48 @@ pub fn decode_pem_to_der(bytes: &[u8]) -> Result<Vec<u8>> {
                 }
             }
         }
+    } else if let Some(der) = decode_bare_base64(bytes) {
+        der
     } else {
+        // Unchanged for everything that is not recognizable base64, so bare DER still passes
+        // through untouched and genuinely unreadable bytes still reach the caller's parse and fail
+        // with the message they always did.
         bytes.to_vec()
     };
 
     Ok(trim_to_outer_der_sequence(der))
+}
+
+/// Decodes base64 that arrived with no encapsulation boundaries around it, or `None` when the bytes
+/// are not that.
+///
+/// The boundaries are what tell a decoder where a body starts, so a file without them is refused by
+/// the strict decoder and never reaches the lenient fallback above, which only engages once it has
+/// seen a leading `-----`. Such files are published: the FPKI PIV and PIV-I test certificates are
+/// `.crt` files holding one unwrapped line of base64. The failure was quiet in the way that matters
+/// — the file reached `Certificate::from_der` as ASCII and the target was reported unparseable, so
+/// it contributed no paths and a run's totals simply came out lower, with nothing to distinguish
+/// that from material that genuinely has no path.
+///
+/// What keeps this from turning any old text into an object is the tag check on the *result*: prose
+/// is often accidentally valid base64, but it does not decode to something whose first byte opens a
+/// DER `SEQUENCE` (a certificate, a CRL) or one of the `TrustAnchorChoice` context tags. Whitespace
+/// is stripped first, since the wrapping is the encoder's choice and no width is more correct than
+/// another. Available in no_std.
+pub fn decode_bare_base64(bytes: &[u8]) -> Option<Vec<u8>> {
+    use base64ct::{Base64, Encoding};
+
+    // The ordinary input here is bare DER, which is neither UTF-8 nor worth scanning.
+    if matches!(bytes.first(), Some(0x30 | 0xA1 | 0xA2)) {
+        return None;
+    }
+    let text = core::str::from_utf8(bytes).ok()?;
+    let body: String = text.chars().filter(|c| !c.is_whitespace()).collect();
+    if body.is_empty() {
+        return None;
+    }
+    let der = Base64::decode_vec(&body).ok()?;
+    matches!(der.first(), Some(0x30 | 0xA1 | 0xA2)).then_some(der)
 }
 
 /// Extensions for an input whose caller fans a file out into every certificate it holds.
@@ -1294,6 +1332,49 @@ fn certs_only_pkcs7_fans_out_into_its_certificates() {
             "certificate DER appears verbatim in the container"
         );
     }
+}
+
+#[test]
+fn unarmored_base64_decodes_like_the_armored_spelling() {
+    use base64ct::{Base64, Encoding};
+    use x509_cert::Certificate;
+
+    // A real certificate, re-spelled the way the FPKI PIV/PIV-I test files arrive: one unwrapped
+    // line of base64 with no encapsulation boundaries. Before this it reached the caller as ASCII
+    // and the file was reported unparseable.
+    let armored = include_bytes!("../../tests/examples/TrustAnchorRootCertificate.crt");
+    let der = decode_pem_to_der(armored).unwrap();
+    Certificate::from_der(&der).expect("the fixture is a certificate");
+    let b64 = Base64::encode_string(&der);
+
+    assert_eq!(
+        decode_pem_to_der(b64.as_bytes()).unwrap(),
+        der,
+        "one unwrapped line, as the FPKI files arrive"
+    );
+
+    // The wrapping is the encoder's choice, so no width is more correct than another.
+    for width in [4, 64, 76] {
+        let wrapped = b64
+            .as_bytes()
+            .chunks(width)
+            .map(|c| core::str::from_utf8(c).unwrap())
+            .collect::<Vec<_>>()
+            .join("\r\n");
+        assert_eq!(decode_pem_to_der(wrapped.as_bytes()).unwrap(), der);
+    }
+
+    // Bare DER still passes through untouched rather than being scanned as text.
+    assert_eq!(decode_pem_to_der(&der).unwrap(), der);
+    assert!(decode_bare_base64(&der).is_none());
+
+    // What keeps prose from becoming an object is the tag check on the decoded bytes, not the
+    // base64 decoder: this text decodes cleanly and is still not a certificate.
+    assert!(Base64::decode_vec("dGhpc0lzVmFsaWRCYXNlNjRUZXh0").is_ok());
+    assert!(decode_bare_base64(b"dGhpc0lzVmFsaWRCYXNlNjRUZXh0").is_none());
+    assert!(decode_bare_base64(b"not a certificate in any encoding").is_none());
+    assert!(decode_bare_base64(b"").is_none());
+    assert!(decode_bare_base64(b"  \r\n\t ").is_none());
 }
 
 #[test]

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -518,7 +518,7 @@ fn spawn_pool_count(
         let toi = inputs.time_of_interest;
         let (crls, ocsp_responses) = count_revocation_inputs(inputs.rev.iter().map(String::as_str));
         let counts = PoolCounts {
-            trust_anchors: count_trust_anchor_inputs(inputs.ta.iter().map(String::as_str), toi),
+            trust_anchors: count_trust_anchor_inputs(inputs.ta.iter().map(String::as_str)),
             ca_certificates: count_ca_inputs(inputs.ca.iter().map(String::as_str), toi),
             crls,
             ocsp_responses,

--- a/pittv3-lib/Cargo.toml
+++ b/pittv3-lib/Cargo.toml
@@ -56,6 +56,8 @@ log = {version = "0.4.33"}
 walkdir = { version = "2.5.0", optional = true}
 
 [dev-dependencies]
+# Only to spell a fixture as base64 in the der_or_pem tests; the decoding itself is certval's.
+base64ct = { version = "1.8.3", default-features = false, features = ["alloc"] }
 hex-literal = "1.1.0"
 tempfile = "3.27.0"
 tokio-test = "0.4.5"

--- a/pittv3-lib/src/der_or_pem.rs
+++ b/pittv3-lib/src/der_or_pem.rs
@@ -15,7 +15,7 @@
 //! So the rule is: decode here, once, at every boundary where caller bytes arrive — and never let a
 //! DER-only parse be the first thing a file meets, the expansion of a container included.
 
-use certval::{certs_from_signed_data, decode_pem_to_ders, Error, Result};
+use certval::{certs_from_signed_data, decode_bare_base64, decode_pem_to_ders, Error, Result};
 
 // Re-exported so a caller has one place for both halves of "what is a certificate file": which
 // extensions to offer, and how to decode what arrives. pittv3-gui does not depend on certval.
@@ -26,15 +26,16 @@ pub use certval::{CERT_BUNDLE_EXTENSIONS, SINGLE_CERT_EXTENSIONS, TA_BUNDLE_EXTE
 /// DER is detected by its leading tag rather than by attempting a parse: `SEQUENCE` covers
 /// certificates and the certificate variant of `TrustAnchorChoice`, and the two context tags cover
 /// the `tbsCert` and `taInfo` variants of a DER-encoded RFC 5914 `TrustAnchorChoice`. Anything else
-/// is offered to the PEM decoder, and a failure there means the bytes are neither.
+/// is offered to the PEM decoder, then to [`decode_bare_base64`] for a file that is base64 with
+/// no boundaries at all; a failure there means the bytes are none of the three.
 pub fn maybe_pem(bytes: &[u8]) -> Result<Vec<u8>> {
     if !bytes.is_empty() && matches!(bytes[0], 0x30 | 0xA1 | 0xA2) {
         return Ok(bytes.to_vec());
     }
-    match pem_rfc7468::decode_vec(bytes) {
-        Ok((_label, der)) => Ok(der),
-        Err(_) => Err(Error::Unrecognized),
+    if let Ok((_label, der)) = pem_rfc7468::decode_vec(bytes) {
+        return Ok(der);
     }
+    decode_bare_base64(bytes).ok_or(Error::Unrecognized)
 }
 
 /// Returns every certificate a caller's buffer carries, in DER, whatever container it arrived in.
@@ -63,6 +64,15 @@ pub fn certs_in(bytes: &[u8]) -> Result<Vec<Vec<u8>>> {
     if matches!(bytes.first(), Some(0x30 | 0xA1 | 0xA2)) {
         return Ok(vec![bytes.to_vec()]);
     }
+    // One object with no boundaries around it. Tried before the armor check below because that
+    // check is what would otherwise refuse it: an unarmored file is not a bundle, so there is
+    // nothing here for the multi-object decoder to do that the single-object one has not.
+    if let Some(der) = decode_bare_base64(bytes) {
+        return match certs_from_signed_data(&der) {
+            Some(certs) => Ok(certs),
+            None => Ok(vec![der]),
+        };
+    }
     // Guarded on the armor rather than left to decode_pem_to_ders, which passes unarmored bytes
     // through as a single object: bytes that are neither DER nor PEM have to stay an error here, or
     // an unreadable upload becomes a certificate-shaped nothing that fails quietly later instead.
@@ -79,6 +89,7 @@ const ARMOR: &[u8] = b"-----BEGIN";
 #[cfg(test)]
 mod tests {
     use super::*;
+    use base64ct::Encoding as _;
 
     /// The two encodings of one certificate must reduce to the same bytes — the property every
     /// caller of this depends on, and the one whose absence caused both bugs above.
@@ -202,11 +213,65 @@ mod tests {
                 .is_err(),
             "armor alone does not make a file readable"
         );
+        assert!(
+            certs_in(b"dGhpc0lzVmFsaWRCYXNlNjRUZXh0").is_err(),
+            "and accepting unarmored base64 does not admit text that merely decodes"
+        );
+    }
+
+    /// The FPKI PIV/PIV-I test certificates ship as `.crt` files holding one unwrapped line of
+    /// base64 with no encapsulation boundaries. Both decoders `maybe_pem` used to reach for want
+    /// the armor, so twenty such targets were refused as unparseable and a run over them reported
+    /// fewer paths with nothing to say why. Every spelling of one certificate must reduce to the
+    /// same DER, and the wrapping width is not part of the question. Both entry points, since an
+    /// unarmored file reaches whichever one the caller happens to be.
+    #[test]
+    fn unarmored_base64_decodes_like_the_armored_spelling() {
+        use base64ct::{Base64, Encoding};
+        let der = include_bytes!("../../certval/tests/examples/amazon.com/2-target.der").to_vec();
+        let b64 = Base64::encode_string(&der);
+
+        assert_eq!(
+            maybe_pem(b64.as_bytes()).unwrap(),
+            der,
+            "one unwrapped line, as the FPKI files arrive"
+        );
+
+        assert_eq!(
+            certs_in(b64.as_bytes()).unwrap(),
+            vec![der.clone()],
+            "and the bundle entry point agrees with the single-object one"
+        );
+
+        for width in [64, 76] {
+            let wrapped: String = b64
+                .as_bytes()
+                .chunks(width)
+                .map(|c| String::from_utf8_lossy(c).into_owned())
+                .collect::<Vec<_>>()
+                .join("\n");
+            assert_eq!(
+                maybe_pem(wrapped.as_bytes()).unwrap(),
+                der,
+                "wrapped at {width}, still the same certificate"
+            );
+        }
     }
 
     #[test]
     fn neither_encoding_is_refused_rather_than_guessed() {
         assert!(maybe_pem(b"").is_err());
         assert!(maybe_pem(b"not a certificate in any encoding").is_err());
+        assert!(
+            maybe_pem(b"   \n\t  ").is_err(),
+            "whitespace is not an empty certificate"
+        );
+        // Prose is often accidentally valid base64; what it is not is DER. Without the tag check on
+        // the decoded bytes this becomes a certificate-shaped nothing that fails somewhere later.
+        assert!(
+            base64ct::Base64::decode_vec("dGhpc0lzVmFsaWRCYXNlNjRUZXh0").is_ok(),
+            "the guard has to be doing the work, not the base64 decoder"
+        );
+        assert!(maybe_pem(b"dGhpc0lzVmFsaWRCYXNlNjRUZXh0").is_err());
     }
 }

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -143,15 +143,17 @@ use crate::std_utils::*;
 use crate::sha1_sig::verify_signature_message_rust_crypto_sha1;
 
 /// Added to the no-paths diagnosis, and logged where the folder is read, when a trust anchor folder
-/// was supplied and yielded nothing. The filtering happens quietly in `ta_folder_to_vec`, which
-/// returns `Ok(0)` for a folder it emptied — indistinguishable from no folder at all by the time the
-/// environment is queried. Note the validity filter there is not governed by
-/// `PS_ENFORCE_TRUST_ANCHOR_VALIDITY`: that setting applies during path validation, where it also
-/// (correctly) passes an anchor that asserts no validity to enforce.
+/// was supplied and yielded nothing. `ta_folder_to_vec` returns `Ok(0)` for a folder it emptied —
+/// indistinguishable from no folder at all by the time the environment is queried.
+///
+/// Expiry is no longer among the reasons: anchors load whatever their validity period says, and
+/// `PS_ENFORCE_TRUST_ANCHOR_VALIDITY` decides during validation whether one may anchor a path (see
+/// [`load_trust_anchors`]). What empties a folder now is material that does not parse as a trust
+/// anchor, or file names the walk does not recognize.
 const TA_FOLDER_EMPTY: &str =
     "A trust anchor folder was supplied but no anchor was read from it: objects that do not parse \
-     as a trust anchor, or that are expired at the time of interest, are dropped when the folder \
-     is read.";
+     as a trust anchor are dropped when the folder is read, as are files whose extension is not \
+     one the walk recognizes.";
 
 /// Added to the no-paths diagnosis when a CA folder was supplied and nothing was read from it. The
 /// folder is folded into the graph at validation time, so an empty read is the one case where the
@@ -337,11 +339,7 @@ async fn options_std_inner(
         let pe = PkiEnvironment::default();
 
         // Load up the trust anchors. This occurs once and is not effected by the dynamic_build flag.
-        match load_trust_anchors(
-            &pe,
-            args,
-            TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
-        ) {
+        match load_trust_anchors(&pe, args) {
             Ok(Some(ta_store)) => ta_store.log_tas(),
             Ok(None) => {}
             Err(msg) => {
@@ -438,11 +436,7 @@ async fn options_std_inner(
             };
         }
 
-        let ta_store = match load_trust_anchors(
-            &pe,
-            args,
-            TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
-        ) {
+        let ta_store = match load_trust_anchors(&pe, args) {
             Ok(ta_store) => ta_store,
             Err(msg) => {
                 println!("Failed to load trust anchors: {msg}");
@@ -867,11 +861,7 @@ async fn generate_and_validate(
     }
 
     // Load up the trust anchors. This occurs once and is not effected by the dynamic_build flag.
-    match load_trust_anchors(
-        &pe,
-        args,
-        TimeOfInterest::from_unix_secs(args.time_of_interest).unwrap(),
-    ) {
+    match load_trust_anchors(&pe, args) {
         Ok(Some(ta_store)) => {
             // A folder whose objects were all filtered contributes nothing, which is otherwise
             // indistinguishable from having supplied no folder at all — and this is the loudest

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -312,11 +312,20 @@ pub fn load_capi_ca_stores(
 /// [`PkiEnvironment::add_trust_anchor_source`]. `Err` carries a message naming the input that
 /// failed, for a caller to surface; an input that yields no anchor is not an error here (see
 /// `TA_FOLDER_EMPTY` in `options_std`), only an empty result.
+///
+/// **Anchors are loaded whatever their validity period says.** A trust anchor is trust in a *key*,
+/// and RFC 5280 path validation does not check the anchor's own validity; whether an expired one
+/// may anchor a path is what `PS_ENFORCE_TRUST_ANCHOR_VALIDITY` decides, during validation, where
+/// the user can turn it off. Filtering here instead would decide it for them and leave that setting
+/// with nothing to act on — and it did, until 2026-09-03: a folder of eleven anchors loaded ten,
+/// while the same folder uploaded to the browser app loaded eleven, because that side never had the
+/// filter. The anchor a run declines to use is a validation result and reads as one; an anchor
+/// dropped as the folder is read is indistinguishable from a path that was never there. Use
+/// `--ta-cleanup`, which exists to remove expired anchors and says so, when that is what is wanted.
 #[cfg(feature = "std")]
 pub fn load_trust_anchors(
     pe: &PkiEnvironment,
     args: &Pittv3Args,
-    time_of_interest: TimeOfInterest,
 ) -> core::result::Result<Option<TaSource>, String> {
     #[cfg(all(windows, feature = "capi"))]
     let no_capi = args.capi_ta_stores.is_empty();
@@ -378,7 +387,7 @@ pub fn load_trust_anchors(
     // inputs were named in. Nothing depends on the order otherwise: `push` deduplicates, so an
     // anchor appearing in two inputs is carried once whichever was read first.
     for path in args.ta_folder.iter().chain(args.ta_inputs.iter()) {
-        push_trust_anchor_input(pe, path, &mut ta_store, time_of_interest)?;
+        push_trust_anchor_input(pe, path, &mut ta_store, TimeOfInterest::disabled())?;
     }
 
     if let Err(e) = ta_store.initialize() {
@@ -404,20 +413,18 @@ pub fn load_trust_anchors(
 /// inputs while it is still being assembled; the run is where a trust anchor that will not load is
 /// an error, and it says so there.
 ///
-/// `time_of_interest` is epoch seconds rather than a [`TimeOfInterest`] so that a frontend reaching
-/// certval only through this crate can ask -- the desktop GUI is one. It matters to the answer:
-/// loading drops an anchor not valid at that time, so a count is a count *as of* a moment. A value
-/// that is not a time leaves validity unchecked, which counts the material rather than nothing.
+/// There is no time of interest here, and taking one would be the bug: [`load_trust_anchors`] loads
+/// anchors without regard to their validity period, so a count taken *as of* a moment would differ
+/// from the number the run goes on to use, and the pool would be telling the user something the run
+/// then contradicts. The CA-side counterparts still take one because their loading still filters.
 #[cfg(feature = "std")]
-pub fn count_trust_anchor_inputs<'a>(
-    paths: impl IntoIterator<Item = &'a str>,
-    time_of_interest: u64,
-) -> usize {
-    let toi = counting_time_of_interest(time_of_interest);
+pub fn count_trust_anchor_inputs<'a>(paths: impl IntoIterator<Item = &'a str>) -> usize {
     let pe = PkiEnvironment::default();
     let mut ta_store = TaSource::new();
     for path in paths {
-        if let Err(e) = push_trust_anchor_input(&pe, path, &mut ta_store, toi) {
+        if let Err(e) =
+            push_trust_anchor_input(&pe, path, &mut ta_store, TimeOfInterest::disabled())
+        {
             debug!("Counting no trust anchors from {path}: {e}");
         }
     }

--- a/pittv3-lib/tests/input_counts.rs
+++ b/pittv3-lib/tests/input_counts.rs
@@ -72,24 +72,35 @@ fn folder_with(dir: &Path, label: &str, names: &[&str]) -> String {
 #[test]
 fn a_bundle_counts_as_the_certificates_in_it() {
     assert_eq!(6, count_ca_inputs([BUNDLE], BUNDLE_TOI));
-    assert_eq!(6, count_trust_anchor_inputs([BUNDLE], BUNDLE_TOI));
+    assert_eq!(6, count_trust_anchor_inputs([BUNDLE]));
 }
 
-/// A count is an answer as of a moment, because loading drops material not valid at the time of
+/// A CA count is an answer as of a moment, because loading drops material not valid at the time of
 /// interest. Same file, same pool, five of the six expired: one.
 #[test]
-fn a_count_is_as_of_the_time_of_interest() {
+fn a_ca_count_is_as_of_the_time_of_interest() {
     assert_eq!(1, count_ca_inputs([BUNDLE], BUNDLE_LATER));
-    assert_eq!(1, count_trust_anchor_inputs([BUNDLE], BUNDLE_LATER));
+}
+
+/// A trust anchor count is *not*, and the asymmetry is the point: an anchor is trust in a key, and
+/// whether an expired one may anchor a path is `PS_ENFORCE_TRUST_ANCHOR_VALIDITY`'s decision at
+/// validation time. Loading anchors used to filter them here, so a folder of eleven anchors loaded
+/// ten while the same folder uploaded to the browser app loaded eleven; the count has to follow the
+/// loader, or the pool tells the user a number the run then contradicts. Five of these six are
+/// expired at `BUNDLE_LATER` and all six still count.
+#[test]
+fn a_trust_anchor_count_is_not() {
+    assert_eq!(1, count_ca_inputs([BUNDLE], BUNDLE_LATER));
+    assert_eq!(6, count_trust_anchor_inputs([BUNDLE]));
 }
 
 /// A time certval will not take disables the check rather than standing in for it, so the material
 /// is counted rather than nothing. Without this the fallback would be a silent zero, which reads as
-/// "these inputs are empty" — the opposite of what happened.
+/// "these inputs are empty" — the opposite of what happened. Only the CA side has a time to get
+/// wrong now.
 #[test]
 fn an_impossible_time_leaves_validity_unchecked() {
     assert_eq!(6, count_ca_inputs([BUNDLE], u64::MAX));
-    assert_eq!(6, count_trust_anchor_inputs([BUNDLE], u64::MAX));
 }
 
 /// A folder counts as what is in it, and entries of different shapes add up: the whole point of a
@@ -118,7 +129,7 @@ fn material_named_twice_counts_once() {
     assert_eq!(4, count_ca_inputs([folder.as_str(), also.as_str()], TOI));
     assert_eq!(
         4,
-        count_trust_anchor_inputs([folder.as_str(), also.as_str()], TOI)
+        count_trust_anchor_inputs([folder.as_str(), also.as_str()])
     );
 }
 
@@ -158,7 +169,7 @@ fn an_unreadable_entry_counts_as_nothing() {
     assert_eq!(1, count_ca_inputs(["does/not/exist", good.as_str()], TOI));
     assert_eq!(
         1,
-        count_trust_anchor_inputs(["does/not/exist", good.as_str()], TOI)
+        count_trust_anchor_inputs(["does/not/exist", good.as_str()])
     );
 }
 

--- a/pittv3-lib/tests/load_trust_anchors.rs
+++ b/pittv3-lib/tests/load_trust_anchors.rs
@@ -61,7 +61,7 @@ fn args_with_inputs(ta_inputs: &[String]) -> Pittv3Args {
 }
 
 fn load(args: &Pittv3Args) -> Option<TaSource> {
-    load_trust_anchors(&PkiEnvironment::default(), args, toi()).unwrap()
+    load_trust_anchors(&PkiEnvironment::default(), args).unwrap()
 }
 
 /// The DER of each anchor, sorted. Labels are deliberately excluded: a store carries the label its
@@ -111,7 +111,7 @@ fn combining_a_store_and_a_folder_does_not_duplicate_anchors() {
 #[test]
 fn an_unreadable_store_is_an_error_rather_than_an_empty_set() {
     let args = args_with(Some("does/not/exist.cbor".to_string()), None);
-    assert!(load_trust_anchors(&PkiEnvironment::default(), &args, toi()).is_err());
+    assert!(load_trust_anchors(&PkiEnvironment::default(), &args).is_err());
 
     // A file that exists but is not a store is the likelier mistake, and the one that would
     // otherwise leave a run validating against no anchors at all.
@@ -119,7 +119,7 @@ fn an_unreadable_store_is_an_error_rather_than_an_empty_set() {
     let junk = dir.path().join("junk.cbor");
     fs::write(&junk, b"not a cbor store").unwrap();
     let args = args_with(Some(junk.to_str().unwrap().to_string()), None);
-    assert!(load_trust_anchors(&PkiEnvironment::default(), &args, toi()).is_err());
+    assert!(load_trust_anchors(&PkiEnvironment::default(), &args).is_err());
 }
 
 /// A pool entry naming a folder anchors what `ta_folder` naming the same folder anchors. The pool
@@ -179,7 +179,7 @@ fn the_pool_and_the_singular_arguments_are_combined_without_duplication() {
 fn an_unreadable_pool_entry_fails_the_load() {
     let args = args_with_inputs(&["does/not/exist".to_string(), ta_folder()]);
     // `TaSource` is not Debug, so the Ok side cannot be unwrapped into an assertion message.
-    match load_trust_anchors(&PkiEnvironment::default(), &args, toi()) {
+    match load_trust_anchors(&PkiEnvironment::default(), &args) {
         Err(e) => assert!(
             e.contains("does/not/exist"),
             "the message names the input: {e}"


### PR DESCRIPTION
- certval: decode_bare_base64 strips whitespace and decodes a body carrying no encapsulation boundaries, accepting the result only when it opens a DER SEQUENCE or a TrustAnchorChoice context tag. decode_pem_to_der tries it ahead of the bare-DER passthrough, so decode_pem_to_ders and the folder loaders inherit it.
- pittv3-lib: maybe_pem and certs_in defer to certval rather than each carrying a decoder; base64ct becomes a dev-dependency.