### PR TITLE
Minor logging tweaks

### DIFF
--- a/certval/src/builder/uri_utils.rs
+++ b/certval/src/builder/uri_utils.rs
@@ -284,8 +284,6 @@ pub async fn fetch_to_buffer(
         if blocklist.contains(target) {
             error!("Skipping due to blocklist: {target}");
             continue;
-        } else {
-            info!("Downloading {target}");
         }
 
         // Read saved last modified time, if any, for use in avoiding unnecessary download below
@@ -294,6 +292,18 @@ pub async fn fetch_to_buffer(
         } else {
             ""
         };
+
+        // Announced after the last-modified map is consulted rather than before it, and as a check
+        // rather than a download, because a URI the map knows is usually answered 304 with no bytes
+        // moving. Saying "Downloading" ahead of the request made a run that transferred nothing read
+        // as one re-fetching everything, and made the empty download folder that a 304 leaves behind
+        // look like a second fault. Every URI reaching here now says what became of it: checked,
+        // then fetched, unchanged, or skipped.
+        if h.is_empty() {
+            info!("Fetching {target}");
+        } else {
+            info!("Checking {target} (If-Modified-Since: {h})");
+        }
 
         let response = if h.is_empty() {
             client
@@ -325,6 +335,7 @@ pub async fn fetch_to_buffer(
                 // seen it before, skip it now
                 if 304 == response.status() {
                     //TODO read buffer from folder
+                    info!("Unchanged, nothing transferred: {target}");
                     continue;
                 }
 
@@ -344,6 +355,7 @@ pub async fn fetch_to_buffer(
 
                 // some things "succeed" when handing us an HTML page with an error. skip those.
                 if "text/html" == content_type {
+                    info!("Skipping an HTML response rather than an artifact: {target}");
                     continue;
                 }
 
@@ -351,7 +363,7 @@ pub async fn fetch_to_buffer(
 
                 match read_capped_body(response, max_bytes, target).await {
                     Ok(bytes) => {
-                        debug!("Downloaded buffer {target}");
+                        info!("Fetched {} bytes from {target}", bytes.len());
 
                         // save_certs_from_p7
                         if "application/pkcs7-mime" == content_type {

--- a/pittv3-gui-lib/src/export.rs
+++ b/pittv3-gui-lib/src/export.rs
@@ -88,11 +88,12 @@ pub fn path_entries(
     path: &CertificationPath,
     cps: Option<&CertificationPathSettings>,
     cpr: &CertificationPathResults,
+    duration_ms: Option<u64>,
 ) -> Vec<ExportEntry> {
     let mut out = vec![];
 
     let mut manifest = Vec::new();
-    render_path_manifest(pe, &mut manifest, path, cpr, cps);
+    render_path_manifest(pe, &mut manifest, path, cpr, cps, duration_ms);
     out.push((MANIFEST_NAME.to_string(), manifest));
 
     out.push(("0-ta.der".to_string(), path.trust_anchor.encoded_ta.clone()));

--- a/pittv3-gui-lib/src/validate.rs
+++ b/pittv3-gui-lib/src/validate.rs
@@ -549,11 +549,12 @@ fn validate_target(
             r = check_revocation_local(pe, &path_cps, path, &mut cpr);
         }
 
+        let duration_ms = path_start.elapsed().as_millis() as u64;
         path_reports.push(PathReport::from_path_results(
             path,
             &cpr,
             r.as_ref().err(),
-            path_start.elapsed().as_millis() as u64,
+            duration_ms,
         ));
         // Kept for a later export, with the settings this path was actually judged under rather than
         // the run's -- `path_cps` carries the RFC 5937 trust anchor constraints folded in above, and
@@ -566,6 +567,7 @@ fn validate_target(
                 path: path.clone(),
                 cps: path_cps.clone(),
                 cpr: cpr.clone(),
+                duration_ms,
             });
         }
         let cert_count = path.intermediates.len() + 2;

--- a/pittv3-gui/src/save.rs
+++ b/pittv3-gui/src/save.rs
@@ -44,7 +44,15 @@ fn build_entries(artifacts: &RetainedArtifacts) -> Vec<Vec<(String, Vec<u8>)>> {
     };
     run.paths
         .iter()
-        .map(|r| path_entries(&run.environment, &r.path, Some(&r.cps), &r.cpr))
+        .map(|r| {
+            path_entries(
+                &run.environment,
+                &r.path,
+                Some(&r.cps),
+                &r.cpr,
+                Some(r.duration_ms),
+            )
+        })
         .collect()
 }
 

--- a/pittv3-lib/src/no_std_utils.rs
+++ b/pittv3-lib/src/no_std_utils.rs
@@ -100,6 +100,8 @@ pub(crate) fn validate_cert(
             stats.paths_per_target + _i,
             Some(&cpr),
             Some(&path_cps),
+            // No clock in a no-std build, so nothing here times a path.
+            None,
         );
 
         stats.results.push(cpr.clone());

--- a/pittv3-lib/src/pitt_log.rs
+++ b/pittv3-lib/src/pitt_log.rs
@@ -974,6 +974,7 @@ pub fn log_path(
     index: usize,
     cpr: Option<&CertificationPathResults>,
     cps: Option<&CertificationPathSettings>,
+    duration_ms: Option<u64>,
 ) {
     let target_folder = if let Some(rf) = f { rf } else { "" };
     if target_folder.is_empty() {
@@ -1028,7 +1029,7 @@ pub fn log_path(
             error!("Failed to create manifest file");
             return;
         };
-        render_path_manifest(pe, &mut f, path, cpr, cps);
+        render_path_manifest(pe, &mut f, path, cpr, cps, duration_ms);
         write_cpr_artifacts(&np, cpr);
     }
 }
@@ -1046,6 +1047,7 @@ pub fn render_path_manifest(
     path: &CertificationPath,
     cpr: &CertificationPathResults,
     cps: Option<&CertificationPathSettings>,
+    duration_ms: Option<u64>,
 ) {
     {
         let s = get_filename_from_metadata(&path.target);
@@ -1107,6 +1109,15 @@ pub fn render_path_manifest(
                 .as_bytes(),
         )
         .expect("Unable to write manifest file");
+        // What the path cost, from the same measurement `PathReport::duration_ms` carries. A
+        // manifest that cannot say this can only be compared against another manifest by going back
+        // to a console that may be gone, which is the whole difficulty a bundle exists to remove.
+        // `None` from a caller that has no run to time rather than a zero, which would read as a
+        // path that took no time at all.
+        if let Some(ms) = duration_ms {
+            f.write_all(format!("Time to build and validate: {ms} ms\n\n").as_bytes())
+                .expect("Unable to write manifest file");
+        }
         render_cpr(f, cpr);
         render_revocation_details(f, path, cpr);
     }

--- a/pittv3-lib/src/retained.rs
+++ b/pittv3-lib/src/retained.rs
@@ -46,6 +46,10 @@ pub struct RetainedPath {
     pub cps: CertificationPathSettings,
     /// The results recorded while validating it
     pub cpr: CertificationPathResults,
+    /// What building and validating this path took, in milliseconds -- the same measurement
+    /// `PathReport::duration_ms` carries, kept here so an export can state it. A bundle that cannot
+    /// say how long its run took cannot be compared against another bundle on its own.
+    pub duration_ms: u64,
 }
 
 /// Everything a run keeps so its artifacts can be exported once it is over: the paths, and the

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -980,15 +980,19 @@ pub async fn validate_cert_bytes_retaining(
     // counted twenty paths twice that way, which is what made it report more paths found than the
     // same material yielded in the browser, whose totals come from the reports themselves.
     //
-    // Logged at debug on every suppression on purpose. Deduplicating here is a backstop over
-    // whatever the builder's own `threshold` did, so silence would hide the builder handing back
-    // paths it was asked to withhold; a run that suppresses nothing says the threshold held.
+    // Logged on every suppression on purpose. Deduplicating here is a backstop over whatever the
+    // builder's own `threshold` did, so silence would hide the builder handing back paths it was
+    // asked to withhold; a run that suppresses nothing says the threshold held. At `info` rather
+    // than `debug` because the level has to be one people run at for that reasoning to reach
+    // anyone: a pass whose paths are all repeats validates nothing, so at `debug` it prints its
+    // opening line and a timing line and says nothing about why a target that reported a full
+    // validation block earlier in the run reported none this time.
     let mut to_validate = Vec::with_capacity(paths.len());
     for (i, path) in paths.iter().enumerate() {
         if stats.reported_chains.insert(chain_fingerprint(path)) {
             to_validate.push(i);
         } else {
-            debug!(
+            info!(
                 "Suppressing a certification path already reported for {cert_filename} (offered again with threshold {threshold})"
             );
             suppressed += 1;
@@ -1042,6 +1046,9 @@ pub async fn validate_cert_bytes_retaining(
             r = check_revocation(pe, &path_cps, path, &mut cpr).await;
         }
 
+        // Taken before the results folder is written so it measures building and validating the
+        // path, which is what the field says it is, rather than that plus a directory of files.
+        let duration_ms = (Instant::now() - path_start).as_millis() as u64;
         log_path(
             pe,
             &opts.results_folder,
@@ -1049,13 +1056,14 @@ pub async fn validate_cert_bytes_retaining(
             stats.paths_per_target + reported,
             Some(&cpr),
             Some(&path_cps),
+            Some(duration_ms),
         );
         reported += 1;
         stats.path_reports.push(PathReport::from_path_results(
             path,
             &cpr,
             r.as_ref().err(),
-            (Instant::now() - path_start).as_millis() as u64,
+            duration_ms,
         ));
         // Kept for a later export, with the settings this path was actually judged under rather than
         // the run's -- `path_cps` carries the RFC 5937 trust anchor constraints folded in above, and
@@ -1069,6 +1077,7 @@ pub async fn validate_cert_bytes_retaining(
                 path: path.clone(),
                 cps: path_cps.clone(),
                 cpr: cpr.clone(),
+                duration_ms,
             });
         }
         stats.results.push(cpr);
@@ -1084,7 +1093,7 @@ pub async fn validate_cert_bytes_retaining(
             Err(e) => {
                 stats.invalid_paths_per_target += 1;
 
-                log_path(pe, &opts.error_folder, path, i, None, None);
+                log_path(pe, &opts.error_folder, path, i, None, None, None);
                 info!("Failed to validate {cert_filename} with {e:?}");
                 // A revoked end entity is the same certificate on every candidate path, so the
                 // first path to report it has settled the target and the rest cost a signature
@@ -1117,12 +1126,27 @@ pub async fn validate_cert_bytes_retaining(
 
     let finish = Instant::now();
     let duration2 = finish - start2;
-    info!(
-        "{:?} to build and validate {} path(s) for {}",
-        duration2,
-        paths.len(),
-        cert_filename
-    );
+    // `paths.len()` is what the builder offered, not what was validated, and the two differ on
+    // every pass after the first. Saying which is which here is what keeps a pass that offered
+    // only repeats -- two lines and a microsecond timing -- from reading as a target whose paths
+    // went away, and it is where a total that did not grow between passes explains itself.
+    if 0 == suppressed {
+        info!(
+            "{:?} to build and validate {} path(s) for {}",
+            duration2,
+            paths.len(),
+            cert_filename
+        );
+    } else {
+        info!(
+            "{:?} to build and validate {} path(s) for {}; {} of the {} offered had been reported already and were not validated again",
+            duration2,
+            paths.len() - suppressed,
+            cert_filename,
+            suppressed,
+            paths.len()
+        );
+    }
     Ok(())
 }
 

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -762,7 +762,15 @@ fn App() -> Element {
         retained_paths
             .read()
             .iter()
-            .map(|r| path_entries(prepared.environment(), &r.path, Some(&r.cps), &r.cpr))
+            .map(|r| {
+                path_entries(
+                    prepared.environment(),
+                    &r.path,
+                    Some(&r.cps),
+                    &r.cpr,
+                    Some(r.duration_ms),
+                )
+            })
             .collect()
     };
 


### PR DESCRIPTION
- Adjust download-related log message to fire after checking the last modified map
- Include elapsed time for a path in the manifest
- Change a few debug logs to info, including an item re: suppressing duplicate path