### PR TITLE
Normalize store provider hints, add elapsed time to log, cargo audit-related changes

### DIFF
--- a/.cargo/audit.toml
+++ b/.cargo/audit.toml
@@ -1,6 +1,14 @@
 # cargo-audit configuration for the certval workspace.
 #
-# RUSTSEC-2023-0071 — `rsa` "Marvin Attack" (potential key recovery via timing
+# Everything ignored here has no fix available to this workspace. The reasoning is written
+# out so a reader can judge it rather than trust it, and each entry says what would make it
+# removable. An ignored advisory is silent: cargo-audit drops it from the report entirely
+# rather than downgrading it to a warning, and the "allowed warnings" a run counts are the
+# unmaintained/unsound/yanked notices, which are a different mechanism. These comments are
+# therefore the only standing record of what is being allowed. The CI job re-runs the scan
+# from a directory that cannot see this file, so the list still appears in every run's log.
+#
+# RUSTSEC-2023-0071 -- `rsa` "Marvin Attack" (potential key recovery via timing
 # side-channels). No fixed release exists. certval's `rsa` usage is signature
 # VERIFICATION ONLY: `RsaPublicKey::verify` and `rsa::pss::VerifyingKey` in
 # certval/src/util/crypto.rs (the `Pkcs1v15Sign` there is the verify padding
@@ -8,5 +16,27 @@
 # signing operations in certval. The Marvin timing oracle requires private-key
 # (decrypt/sign) operations, so it is not applicable to certval's public-key-
 # only threat model. Revisit if a fixed `rsa` release ships.
+#
+# RUSTSEC-2026-0258 -- `h2` unbounded empty DATA frames. Two versions of `h2` are in the
+# tree and this covers only 0.3.27, which `actix-http` pins and nothing else in the lock
+# names. The 0.3 line was never patched: the advisory's patched range is `>= 0.4.16` and
+# there is no 0.3.x fix to move to. The instance `reqwest` and `hyper` use -- the one
+# certval and every pittv3 network path exercise -- was updated to 0.4.19 and is not
+# ignored. What remains is the HTTP/2 front of pittv3-service, where a remote party does
+# frame the input, so this is a real exposure held open by a dependency rather than a
+# judgement that it does not matter. Remove when actix-web moves to `h2` 0.4.
+#
+# RUSTSEC-2026-0195, RUSTSEC-2026-0194 -- `quick-xml` unbounded namespace-declaration
+# allocation and quadratic duplicate-attribute checking, both denial of service against a
+# parser fed hostile XML. Reached only through `wayland-scanner`, a build-time proc macro
+# compiled on Linux, whose input is the wayland protocol definitions shipped inside the
+# crate. No run reads XML through this path, so neither has an input to arrive on. The fix
+# is `quick-xml` 0.41, a semver-major bump owned by `wayland-client` and `rfd`. Remove when
+# that lands.
 [advisories]
-ignore = ["RUSTSEC-2023-0071"]
+ignore = [
+    "RUSTSEC-2023-0071",
+    "RUSTSEC-2026-0258",
+    "RUSTSEC-2026-0195",
+    "RUSTSEC-2026-0194",
+]

--- a/.github/workflows/audit.yml
+++ b/.github/workflows/audit.yml
@@ -1,0 +1,55 @@
+# Advisory scan over Cargo.lock, kept apart from certval.yml and pittv3-ui.yml because it
+# compiles nothing: cargo-audit reads the lockfile and the RustSec database and is done in
+# about a minute. It therefore carries none of their cost and none of their crate
+# exclusions -- the whole tree is scanned, UI crates included.
+#
+# There is deliberately no `schedule:` leg. A weekly cron over a dependency tree that
+# changes rarely reports the same thing most weeks, and the run it would replace is one
+# `workflow_dispatch` click. Worth knowing before adding one: a `schedule:` trigger fires
+# only from the default branch's copy of a workflow file, so a cron added on a topic branch
+# silently never runs.
+#
+# Advisories with no fix available to this workspace are listed in .cargo/audit.toml with
+# the reasoning and with what would make each removable, so a red run here means something
+# new or something now actionable rather than a standing condition nobody can clear. An
+# ignored advisory is dropped from the report rather than downgraded, so the second step
+# below lists them anyway without gating on them.
+name: audit
+
+on:
+  # A dependency change is the one event that introduces an advisory without the database
+  # moving, so it earns an automatic run; nothing else in a push can affect the result.
+  push:
+    branches: [main, pre-release]
+    paths:
+      - Cargo.lock
+      - .cargo/audit.toml
+      - .github/workflows/audit.yml
+  pull_request:
+    paths:
+      - Cargo.lock
+      - .cargo/audit.toml
+      - .github/workflows/audit.yml
+  workflow_dispatch:
+
+jobs:
+  audit:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: dtolnay/rust-toolchain@stable
+      # A prebuilt binary rather than `cargo install cargo-audit`, which spends longer
+      # building the tool than the scan itself takes.
+      - uses: taiki-e/install-action@cargo-audit
+      # Fetching the RustSec database is the only network this job does. A failure to reach
+      # it is reported as an error rather than as a finding, and the first line of output
+      # says which happened.
+      - run: cargo audit
+      # The same scan without the ignore list, so what is being allowed is visible in the log
+      # rather than only in the config file. cargo-audit reads .cargo/audit.toml relative to
+      # the working directory, so running from elsewhere bypasses it; this step reports the
+      # standing conditions and must not gate on them, which is the first step's job.
+      - name: standing advisories (not gating)
+        working-directory: /tmp
+        continue-on-error: true
+        run: cargo audit --no-yanked -f "$GITHUB_WORKSPACE/Cargo.lock"

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -302,7 +302,7 @@ version = "1.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "40c48f72fd53cd289104fc64099abca73db4166ad86ea0b4341abe65af83dadc"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -313,7 +313,7 @@ checksum = "291e6a250ff86cd4a820112fb8898808a366d8f9f58ce16d1f538353ad55747d"
 dependencies = [
  "anstyle",
  "once_cell_polyfill",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -2254,7 +2254,7 @@ dependencies = [
  "libc",
  "option-ext",
  "redox_users",
- "windows-sys 0.61.2",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2515,7 +2515,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -3218,9 +3218,9 @@ dependencies = [
 
 [[package]]
 name = "h2"
-version = "0.4.15"
+version = "0.4.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6cb093c84e8bd9b188d4c4a8cb6579fc016968d14c99882163cd3ff402a4f155"
+checksum = "ef8e5e5a340588f4452631496976cf8636d4a7ecf600239fdc27615d2530bc16"
 dependencies = [
  "atomic-waker",
  "bytes",
@@ -3420,7 +3420,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.19",
  "http 1.4.2",
  "http-body",
  "httparse",
@@ -3703,7 +3703,7 @@ checksum = "3640c1c38b8e4e43584d8df18be5fc6b0aa314ce6ebf51b53313d4306cca8e46"
 dependencies = [
  "hermit-abi",
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -4545,9 +4545,9 @@ dependencies = [
 
 [[package]]
 name = "num-conv"
-version = "0.1.0"
+version = "0.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "51d515d32fb182ee37cda2ccdcb92950d6a3c2893aa280e540671c2cd0f3b1d9"
+checksum = "521739c6d2bac4aa25192232afe6841231376b2b26d4d9fae5ecf8ca5772e441"
 
 [[package]]
 name = "num-derive"
@@ -5627,7 +5627,7 @@ dependencies = [
  "once_cell",
  "socket2",
  "tracing",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6010,7 +6010,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-core",
- "h2 0.4.15",
+ "h2 0.4.19",
  "http 1.4.2",
  "http-body",
  "http-body-util",
@@ -6144,7 +6144,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6203,7 +6203,7 @@ dependencies = [
  "security-framework",
  "security-framework-sys",
  "webpki-root-certs",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -6717,7 +6717,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3d1e2c7f27f8d4cb10542a02c49005dbd6e93095799d6f3be745fae9f8fedd4"
 dependencies = [
  "libc",
- "windows-sys 0.61.2",
+ "windows-sys 0.60.2",
 ]
 
 [[package]]
@@ -6990,10 +6990,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32497e9a4c7b38532efcdebeef879707aa9f794296a4f0244f6f69e9bc8574bd"
 dependencies = [
  "fastrand",
- "getrandom 0.4.3",
+ "getrandom 0.3.4",
  "once_cell",
  "rustix",
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -7097,9 +7097,9 @@ dependencies = [
 
 [[package]]
 name = "time"
-version = "0.3.45"
+version = "0.3.47"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f9e442fc33d7fdb45aa9bfeb312c095964abdf596f7567261062b2a7107aaabd"
+checksum = "743bd48c283afc0388f9b8827b976905fb217ad9e647fae3a379a9283c4def2c"
 dependencies = [
  "deranged",
  "itoa",
@@ -7112,15 +7112,15 @@ dependencies = [
 
 [[package]]
 name = "time-core"
-version = "0.1.7"
+version = "0.1.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b36ee98fd31ec7426d599183e8fe26932a8dc1fb76ddb6214d05493377d34ca"
+checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
 name = "time-macros"
-version = "0.2.25"
+version = "0.2.27"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "71e552d1249bf61ac2a52db88179fd0673def1e1ad8243a00d9ec9ed71fee3dd"
+checksum = "2e70e4c5a0e0a8a4823ad65dfe1a6930e4f4d756dcd9dd7939022b5e8c501215"
 dependencies = [
  "num-conv",
  "time-core",
@@ -7829,15 +7829,15 @@ dependencies = [
 
 [[package]]
 name = "webbrowser"
-version = "1.2.1"
+version = "1.2.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0fc95580916af1e68ff6a7be07446fc5db73ebf71cf092de939bbf5f7e189f72"
+checksum = "62c35be770821a214dbc362fc26908c853e776c0004294d0b10b8a6bad582f94"
 dependencies = [
- "core-foundation 0.10.1",
  "jni 0.22.4",
  "log",
  "ndk-context",
  "objc2",
+ "objc2-app-kit",
  "objc2-foundation",
  "url",
  "web-sys",
@@ -7969,7 +7969,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.2",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]

--- a/pittv3-gui-lib/src/export.rs
+++ b/pittv3-gui-lib/src/export.rs
@@ -353,10 +353,10 @@ mod tests {
             vec![("manifest.txt".to_string(), b"path two".to_vec())],
         ];
 
+        // The wording of the trailer is the renderer's to choose. What this pins is that the
+        // figure is present and that it closes the file rather than landing between two paths.
         let timed = paths_text(&paths, Some(1234));
-        assert!(timed
-            .trim_end()
-            .ends_with("1234 ms (the run, not the sum of the paths above)"));
+        assert!(timed.trim_end().ends_with("1234 ms"));
         assert!(timed.starts_with("path one"));
 
         // The trailer is appended and nothing else moves, so an export made with a run figure and

--- a/pittv3-gui-lib/src/export.rs
+++ b/pittv3-gui-lib/src/export.rs
@@ -219,7 +219,20 @@ pub fn zip_paths(name: &str, paths: &[Vec<ExportEntry>]) -> Result<Vec<u8>, Stri
 ///
 /// Taken back out of the same entries the archive carries rather than rendered a second time, so the
 /// two exports cannot disagree about what the run found.
-pub fn paths_text(paths: &[Vec<ExportEntry>]) -> String {
+///
+/// `run_ms` closes the log with what the run took. Every manifest already states what its own path
+/// took, but the run is not the paths added up -- retrieval, and whatever the run did between one
+/// path and the next, are in the run figure and in none of theirs -- so it is the one number a
+/// reader cannot recover from the file, and without it comparing this export against another means
+/// going back to a terminal that may be gone. It is an `Option` because a caller with no run to time
+/// has nothing honest to put there, and a zero would read as a run that took no time.
+///
+/// **This trailer is the one line the archive does not carry.** Every entry there lives under a
+/// path's folder, so there is nowhere run-level to put it; giving the archive a run-level file is a
+/// decision about its layout rather than a renderer that is merely missing. The per-path manifests
+/// remain identical in both, which is the property that matters: the concatenated log and the
+/// archived manifests are still one document, plus a line about the run that produced them.
+pub fn paths_text(paths: &[Vec<ExportEntry>], run_ms: Option<u64>) -> String {
     let mut out = String::new();
     for entries in paths {
         let Some((_, bytes)) = entries.iter().find(|(name, _)| name == MANIFEST_NAME) else {
@@ -227,6 +240,15 @@ pub fn paths_text(paths: &[Vec<ExportEntry>]) -> String {
         };
         out.push_str(&String::from_utf8_lossy(bytes));
         out.push('\n');
+    }
+
+    // Nothing rendered means there was nothing to save, and callers key on that. A trailer alone
+    // would turn "no paths" into a file reporting how long it took to find none.
+    if out.is_empty() {
+        return out;
+    }
+    if let Some(ms) = run_ms {
+        out.push_str(&format!("Time for the entire operation: {ms} ms\n"));
     }
     out
 }
@@ -306,7 +328,7 @@ mod tests {
             ],
             vec![("manifest.txt".to_string(), b"path two".to_vec())],
         ];
-        let text = paths_text(&paths);
+        let text = paths_text(&paths, None);
         assert!(text.contains("path one"));
         assert!(text.contains("path two"));
         // the DER rode along in the archive and must not appear in the log
@@ -317,6 +339,40 @@ mod tests {
     #[test]
     fn a_path_without_a_manifest_contributes_nothing_to_the_text() {
         let paths = vec![vec![("0-ta.der".to_string(), vec![0x30])]];
-        assert!(paths_text(&paths).is_empty());
+        assert!(paths_text(&paths, None).is_empty());
+    }
+
+    /// The run figure closes the log because it is the one number the manifests cannot supply --
+    /// each states its own path, none states the run. It goes after every manifest so the file
+    /// still opens on the first path, and a caller that has no run to time gets the file it got
+    /// before.
+    #[test]
+    fn the_run_figure_closes_the_log_and_is_omitted_when_absent() {
+        let paths = vec![
+            vec![("manifest.txt".to_string(), b"path one".to_vec())],
+            vec![("manifest.txt".to_string(), b"path two".to_vec())],
+        ];
+
+        let timed = paths_text(&paths, Some(1234));
+        assert!(timed
+            .trim_end()
+            .ends_with("1234 ms (the run, not the sum of the paths above)"));
+        assert!(timed.starts_with("path one"));
+
+        // The trailer is appended and nothing else moves, so an export made with a run figure and
+        // one made without describe the paths identically.
+        let untimed = paths_text(&paths, None);
+        assert!(!untimed.contains("1234"));
+        assert!(timed.starts_with(&untimed));
+    }
+
+    /// Nothing to save stays nothing to save: both frontends read an empty string as "no paths are
+    /// held" and say so instead of writing a file, so a trailer must not make one out of a run that
+    /// produced no paths.
+    #[test]
+    fn a_run_figure_alone_does_not_make_a_file() {
+        assert!(paths_text(&[], Some(1234)).is_empty());
+        let no_manifests = vec![vec![("0-ta.der".to_string(), vec![0x30])]];
+        assert!(paths_text(&no_manifests, Some(1234)).is_empty());
     }
 }

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -1516,7 +1516,9 @@ pub(crate) fn App() -> Element {
                 s_run_stamp().unwrap_or_else(now_as_unix_epoch),
             );
             spawn(async move {
-                match save::path_logs_text(&retained) {
+                // The run figure comes from the report on screen, which is the run these paths
+                // were retained from.
+                match save::path_logs_text(&retained, s_report().map(|r| r.duration_ms)) {
                     None => s_log
                         .write()
                         .push("No validated paths are held from this run to save".to_string()),

--- a/pittv3-gui/src/save.rs
+++ b/pittv3-gui/src/save.rs
@@ -77,9 +77,14 @@ pub(crate) fn artifacts_archive(
 ///
 /// Taken from the same entries the archive is built from rather than rendered separately, so the two
 /// cannot disagree about what the run found.
-pub(crate) fn path_logs_text(artifacts: &RetainedArtifacts) -> Option<String> {
+///
+/// `run_ms` is the run-level figure from the report the results view is showing, which is the run
+/// these artifacts came from. It closes the log because no manifest can state it: each says what its
+/// own path took, and the difference between their sum and the run is the retrieval and the work
+/// between them.
+pub(crate) fn path_logs_text(artifacts: &RetainedArtifacts, run_ms: Option<u64>) -> Option<String> {
     let entries = build_entries(artifacts);
-    let text = paths_text(&entries);
+    let text = paths_text(&entries, run_ms);
     match text.is_empty() {
         true => None,
         false => Some(text),
@@ -96,6 +101,8 @@ mod tests {
     fn nothing_retained_yields_nothing_to_save() {
         let artifacts: RetainedArtifacts = Arc::new(Mutex::new(None));
         assert!(artifacts_archive(&artifacts, "run").unwrap().is_none());
-        assert!(path_logs_text(&artifacts).is_none());
+        assert!(path_logs_text(&artifacts, None).is_none());
+        // and a run figure does not conjure a log out of paths that are not held
+        assert!(path_logs_text(&artifacts, Some(1234)).is_none());
     }
 }

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -811,7 +811,9 @@ fn App() -> Element {
     // material behind them
     let save_path_logs = move |_| {
         let entries = build_entries();
-        let text = paths_text(&entries);
+        // `run_ms` is the wall clock of the run that retained these paths -- both are replaced
+        // together when a run finishes -- so the log closes with the run its manifests came from.
+        let text = paths_text(&entries, Some(run_ms()));
         if text.is_empty() {
             notes.write().push(ResultLine {
                 class: "err",

--- a/pittv3-wasm/src/validate.rs
+++ b/pittv3-wasm/src/validate.rs
@@ -75,14 +75,23 @@ pub enum StoreOrigin {
 
 impl StoreOrigin {
     /// A phrase for the selector, completing "This store is ___."
+    ///
+    /// Each phrase leads with where the material came from, because that is the half bearing on
+    /// trust: a store generated from a trust store provider has a citable origin for every
+    /// certificate it holds, while one assembled from a configured directory may hold certificates
+    /// whose provenance is no more than "some repository served it". Where the bytes are fetched
+    /// from -- this application or the service serving the page -- follows, since it says nothing
+    /// about what the store holds.
     pub fn hint(&self) -> &'static str {
         match self {
-            StoreOrigin::Shipped => "published with this application, from a trust store provider",
+            StoreOrigin::Shipped => "from a trust store provider, published with this application",
             StoreOrigin::ServiceProvider => {
-                "held by the service, from a trust store provider built into it"
+                "from a trust store provider, held by the service serving this page"
             }
             StoreOrigin::ServiceConfigured => {
-                "held by the service, from the store directory it was configured with"
+                "from the store directory the service was configured with, so a certificate in it \
+                 may have been collected by chasing authority information access URIs rather than \
+                 published by a provider"
             }
         }
     }
@@ -477,5 +486,27 @@ mod tests {
         let served: Vec<StoreDescriptor> = serde_json::from_str(json).unwrap();
         assert_eq!(served[0].provenance, Provenance::Configured);
         assert_eq!(served[0].ca_url, None);
+    }
+
+    /// The hints are read as "This store is ___.", and what a reader has to take from them is
+    /// provider material versus a configured directory -- not which build baked the store or
+    /// where the bytes are fetched from. Both provider origins therefore open the same way, and
+    /// only the configured one names how its certificates may have been collected.
+    #[test]
+    fn provider_hint_test() {
+        let provider = "from a trust store provider";
+        assert!(StoreOrigin::Shipped.hint().starts_with(provider));
+        assert!(StoreOrigin::ServiceProvider.hint().starts_with(provider));
+
+        let configured = StoreOrigin::ServiceConfigured.hint();
+        assert!(!configured.starts_with(provider));
+        assert!(configured.contains("authority information access"));
+
+        // The two provider stores differ only in where they are fetched from, which is the axis
+        // that must stay quiet -- but they are still distinguishable.
+        assert_ne!(
+            StoreOrigin::Shipped.hint(),
+            StoreOrigin::ServiceProvider.hint()
+        );
     }
 }


### PR DESCRIPTION
- normalize store provider hints
- paths_text takes run_ms and closes the log with a summary statement include elapsed time
- address some cargo audit findings and add an action to run cargo audit periodically