### PR TITLE
add a bool return to populate_parsed_cert_vector

### DIFF
--- a/certval/src/source/cert_source.rs
+++ b/certval/src/source/cert_source.rs
@@ -520,12 +520,16 @@ impl CertSource {
     /// Processes any buffers passed to the instance, i.e., via new_from_cbor
     ///
     /// Can be called again after more buffers have been added with only the ones not already parsed
-    /// beung parsed, and the key identifier and name maps are rebuilt over the result. That allows a
+    /// being parsed, and the key identifier and name maps are rebuilt over the result. That allows a
     /// caller to have one instance while appending certificates fetched from AIA and SIA instead of
     /// discarding it and deserializing a fresh one to get a vector that lines up with its buffers.
     pub fn initialize(&mut self, cps: &CertificationPathSettings) -> Result<()> {
-        self.populate_parsed_cert_vector(cps)?;
-        self.index_certs();
+        // Both maps are rebuilt from `certs`, so running them over an unchanged vector produces
+        // exactly what is already there. Parsing reports whether it appended anything, which is
+        // the same question.
+        if self.populate_parsed_cert_vector(cps)? {
+            self.index_certs();
+        }
         Ok(())
     }
 
@@ -985,7 +989,7 @@ impl CertSource {
     ///
     /// Only the buffers that have not been parsed yet are parsed, with the index alignment determining
     /// which.
-    fn populate_parsed_cert_vector(&mut self, cps: &CertificationPathSettings) -> Result<()> {
+    fn populate_parsed_cert_vector(&mut self, cps: &CertificationPathSettings) -> Result<bool> {
         let time_of_interest = cps.get_time_of_interest();
         let already_parsed = self.certs.len();
         for (i, cert_file) in self
@@ -1039,7 +1043,12 @@ impl CertSource {
                 self.certs.push(None);
             }
         }
-        Ok(())
+        // Whether anything was appended, so a caller knows whether the maps built over `certs` are
+        // still current. One entry is pushed per buffer processed -- a certificate that fails to
+        // parse or is invalid at the time of interest pushes `None` rather than being skipped,
+        // since the positions are what the maps and the partial paths address -- so the length
+        // answers it exactly.
+        Ok(already_parsed != self.certs.len())
     }
 
     /// index_certs prepares internally used key identifier and name maps after the caller has modified

--- a/pittv3-lib/src/options_std.rs
+++ b/pittv3-lib/src/options_std.rs
@@ -1283,9 +1283,10 @@ async fn generate_and_validate(
         // later passes only what came back from AIA and SIA, since the source is the same one.
         //
         // Skipped entirely on pass 0 for a graph that came out of memory, which arrives parsed and
-        // indexed. Not merely redundant: `index_certs` rebuilds both maps whether or not anything
-        // was added to parse, so calling it would give back the larger half of what holding the
-        // graph saved.
+        // indexed. `initialize` would find nothing to parse and skip the reindex on its own, so
+        // this is belt and braces rather than the only thing standing between the memory tier and a
+        // full rebuild of both maps -- kept because the guard states the condition here, where the
+        // graph is held, instead of leaving it to a return value in another crate.
         //TODO refactor to make TaSource.tas and CertSource.certs RefCells with on demand parsing
         //instead of holding all certs parsed all the time?
         if !(graph_already_parsed && 0 == pass) {


### PR DESCRIPTION
- to enable skipping an unnecessary reindex