### PR TITLE
Rework the settings-related actions in desktop and WASM apps

### DIFF
--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -4,16 +4,22 @@
 //! [`EditSettings`] is renderer-agnostic and persistence-free: it receives an initial model and
 //! reports the edited model through `on_save`, so desktop (file-backed) and web (server- or
 //! localStorage-backed) frontends share the form. `EditSettingsFile` (feature `std`) is the
-//! keeps today's read/write-a-JSON-file behavior.
+//! desktop wrapper that reads and writes the JSON file the CLI's `-s` argument names.
 //!
 //! Presentation is defaults-first: each field shows its effective value (the model value or the
 //! certval default), editing a field records an override, and Reset to defaults discards all
 //! overrides. The revocation tab presents a composed mode selection with the individual settings
 //! under an advanced disclosure.
 //!
-//! Every frontend presents every tab, including settings it cannot act on: a browser has no
-//! filesystem and, until a fetch relay exists, no way to retrieve CRLs or OCSP responses. Those
-//! groups carry a notice saying so rather than being hidden, for two reasons. A user
+//! The form edits a *store* and does not choose which one: Save writes to it, Revert to Saved
+//! re-reads it, and Reset to defaults touches only the form. Which store that is, and any action on
+//! the store as a whole -- pointing at another one, deleting it -- belongs to the frontend, whose
+//! chrome names it. What the form does own is knowing when it holds edits the store has not seen,
+//! which it reports through `on_dirty_change` so the frontend can guard the navigation it owns.
+//!
+//! Every frontend presents every tab it can act on at all: a browser has no
+//! filesystem and, until a fetch relay exists, no way to retrieve CRLs or OCSP responses. Groups it
+//! can still author carry a notice saying so rather than being hidden, for two reasons. A user
 //! who learned the form in one frontend finds the same tabs in the next, and the settings file is
 //! shared across all of them (`pittv3 -s`, the desktop editor, the browser's import/export), so
 //! authoring a value that only takes effect elsewhere is a legitimate thing to do. What each
@@ -538,6 +544,37 @@ const TABS: &[(SettingsTab, &str)] = &[
     (SettingsTab::Folders, "Folders & files"),
 ];
 
+/// An action that would throw away unsaved edits, held while the confirmation is on screen.
+///
+/// Confirmed inside the form rather than through a dialog toolkit: `rfd` is a desktop dependency and
+/// the browser has `window.confirm`, so a shared control is the only way both frontends ask the same
+/// question. Navigating away is not here — the sidebar is outside this component, which is what
+/// `on_dirty_change` exists for.
+#[derive(Clone, Copy, PartialEq, Eq)]
+enum PendingDiscard {
+    Reset,
+    Revert,
+}
+
+impl PendingDiscard {
+    /// What the confirmation asks.
+    fn prompt(self) -> &'static str {
+        match self {
+            Self::Reset => "Reset every field to its certval default?",
+            Self::Revert => "Reload the saved settings?",
+        }
+    }
+
+    /// The label on the button that goes through with it, naming the action rather than agreeing —
+    /// "OK" beside a warning tells the reader nothing about what they are about to do.
+    fn confirm_label(self) -> &'static str {
+        match self {
+            Self::Reset => "Reset",
+            Self::Revert => "Revert",
+        }
+    }
+}
+
 /// Whether a tab has anything to offer the frontend showing it.
 ///
 /// Folders and files name paths on a machine the browser has no way to reach, so it is left out
@@ -583,13 +620,53 @@ pub fn EditSettings(
     #[props(default)]
     extra_folder_rows: Option<Element>,
     on_save: EventHandler<SettingsModel>,
-    on_close: EventHandler<()>,
+    /// Asked to re-read the store this frontend is backed by -- the file at the settings path on
+    /// the desktop, localStorage in the browser -- and hand it back as a fresh `initial`.
+    ///
+    /// The handler replaces the model *outside* this component, which is why it is a request rather
+    /// than something done here: seeding happens once per mount (see `model` below), so the caller
+    /// remounts the form to make the new values take. What it must not do is change *which* store is
+    /// being edited: on the desktop that is the settings-file path, and a Revert that silently
+    /// repointed it would mean "reload my store" in the browser and "abandon the file I am editing"
+    /// on the desktop, from one button with one label.
+    on_reload: EventHandler<()>,
+    /// Reports whether the form holds edits that are not in the store yet.
+    ///
+    /// The frontend owns navigation -- a sidebar here, a view signal there -- and neither is
+    /// reachable from inside this component, so it cannot guard the one way out of the form that
+    /// matters. It reports the state instead and lets each frontend warn in its own idiom.
+    on_dirty_change: EventHandler<bool>,
 ) -> Element {
+    // `baseline` is what "unsaved" is measured against; it moves on save, and both start from the
+    // same place.
     let mut model = use_signal(|| initial.clone());
+    let mut baseline = use_signal(|| initial.clone());
     let mut tab = use_signal(|| SettingsTab::Policy);
+    // Set when a discarding action is asked for while there are unsaved edits, so the confirmation
+    // is rendered here rather than through a dialog toolkit neither frontend shares.
+    let mut pending = use_signal(|| None::<PendingDiscard>);
 
     let m = model();
     let mode = m.revocation_mode();
+    let dirty = m != baseline();
+
+    // Follow `initial` rather than only its first value. A frontend can repoint this form at a
+    // different store without unmounting it -- the desktop's settings-path box does exactly that,
+    // per keystroke -- and a form still showing the previous store's values would save them into
+    // the new one. `initial` is a prop and so not reactive on its own, hence `use_reactive`.
+    //
+    // Relying on the caller to force a remount instead was tried and is not enough: it works when
+    // the caller replaces the value wholesale, and silently does not when the path is edited in
+    // place.
+    use_effect(use_reactive!(|initial| {
+        model.set(initial.clone());
+        baseline.set(initial);
+    }));
+
+    // Report on every change rather than only on the edges: the frontend holds a plain bool, and
+    // reseeding above replaces `model` without the frontend touching anything, which an
+    // edge-triggered report would never mention.
+    use_effect(move || on_dirty_change.call(model() != baseline()));
 
     rsx! {
         div { class: "settings-editor",
@@ -912,18 +989,66 @@ pub fn EditSettings(
                 },
             }
 
+            if let Some(p) = pending() {
+                div { class: "capability-notice",
+                    "{p.prompt()} Unsaved changes will be lost."
+                    div { class: "settings-actions",
+                        button {
+                            r#type: "button",
+                            onclick: move |_| {
+                                match p {
+                                    PendingDiscard::Reset => model.set(SettingsModel::default()),
+                                    PendingDiscard::Revert => on_reload.call(()),
+                                }
+                                pending.set(None);
+                            },
+                            "{p.confirm_label()}"
+                        }
+                        button {
+                            r#type: "button",
+                            onclick: move |_| pending.set(None),
+                            "Cancel"
+                        }
+                    }
+                }
+            }
+
             div { class: "settings-actions",
                 button {
                     r#type: "button",
-                    onclick: move |_| on_save.call(model()),
+                    onclick: move |_| {
+                        on_save.call(model());
+                        // Optimistic: the frontend owns the write and reports a failure in its own
+                        // status line, which stays on screen with the edits still in the form. The
+                        // alternative -- plumbing the outcome back -- buys a correct flag for the
+                        // case where the user can already see what happened.
+                        baseline.set(model());
+                    },
                     "Save"
                 }
                 button {
                     r#type: "button",
-                    onclick: move |_| model.set(SettingsModel::default()),
+                    onclick: move |_| {
+                        match dirty {
+                            true => pending.set(Some(PendingDiscard::Revert)),
+                            false => on_reload.call(()),
+                        }
+                    },
+                    "Revert to Saved"
+                }
+                button {
+                    r#type: "button",
+                    onclick: move |_| {
+                        match dirty {
+                            true => pending.set(Some(PendingDiscard::Reset)),
+                            false => model.set(SettingsModel::default()),
+                        }
+                    },
                     "Reset to defaults"
                 }
-                button { r#type: "button", onclick: move |_| on_close.call(()), "Close" }
+                if dirty {
+                    span { class: "hint", "Unsaved changes" }
+                }
             }
         }
     }
@@ -931,23 +1056,38 @@ pub fn EditSettings(
 
 /// Desktop wrapper for [`EditSettings`] that reads the JSON settings file at `path` into the form
 /// and writes the edited settings back on save, preserving settings the form does not cover.
+///
+/// The file is re-read whenever `path` or `reload_token` changes, and the form follows, so the box
+/// naming the file and the values on screen cannot drift apart.
 #[cfg(feature = "std")]
 #[component]
 pub fn EditSettingsFile(
     path: String,
+    /// Changed by the caller to ask for the file to be read again when `path` has not moved --
+    /// Revert to Saved, or a delete that leaves nothing to read. Any new value will do; the value
+    /// itself carries no meaning.
+    #[props(default)]
+    reload_token: usize,
     /// Passed to [`EditSettings`]; see its documentation.
     #[props(default)]
     extra_folder_rows: Option<Element>,
-    on_close: EventHandler<()>,
+    /// Passed to [`EditSettings`]; the caller satisfies it by changing `reload_token`.
+    on_reload: EventHandler<()>,
+    /// Passed to [`EditSettings`]; see its documentation.
+    on_dirty_change: EventHandler<bool>,
 ) -> Element {
-    let initial = use_hook({
-        let path = path.clone();
-        move || SettingsModel::from_cps(&FileSettingsStore::new(path).load())
-    });
+    // Both are props, so neither is reactive on its own; `use_reactive` is what makes a change in
+    // either re-read the file. A missing path reads as an empty settings map -- all defaults --
+    // which is what makes a half-typed path harmless and a deleted file resolve to defaults.
+    let initial = use_memo(use_reactive!(|path, reload_token| {
+        let _ = reload_token;
+        SettingsModel::from_cps(&FileSettingsStore::new(path).load())
+    }));
 
-    // A failed write is reported here rather than only logged. Saving closes the form, so a silent
-    // failure looks exactly like a successful save until the settings are next read back.
-    let mut save_error = use_signal(String::new);
+    // Both outcomes of a save are reported in the same place. Saving used to close the form, which
+    // is why only the failure needed saying; now that the form stays put, a save that says nothing
+    // is indistinguishable from a click that missed.
+    let mut status = use_signal(String::new);
 
     let save_path = path.clone();
     let on_save = move |edited: SettingsModel| {
@@ -957,24 +1097,24 @@ pub fn EditSettingsFile(
         edited.apply(&mut cps);
         if let Err(e) = store.save(&cps) {
             error!("{e}");
-            // leave the form open so the edits are not lost with the file they could not reach
-            save_error.set(e);
+            // the edits stay in the form rather than being lost with the file they could not reach
+            status.set(e);
             return;
         }
-        save_error.set(String::new());
-        on_close.call(());
+        status.set("Settings saved".to_string());
     };
 
     rsx! {
-        if !save_error().is_empty() {
-            p { class: "capability-notice", "{save_error}" }
+        if !status().is_empty() {
+            p { class: "capability-notice", "{status}" }
         }
         EditSettings {
-            initial,
+            initial: initial(),
             caps: Capabilities::desktop(),
             extra_folder_rows,
             on_save,
-            on_close: move |_| on_close.call(()),
+            on_reload,
+            on_dirty_change,
         }
     }
 }

--- a/pittv3-gui-lib/src/gui_settings_model.rs
+++ b/pittv3-gui-lib/src/gui_settings_model.rs
@@ -531,6 +531,11 @@ mod tests {
         let mut cps = CertificationPathSettings::new();
         cps.set_check_revocation_status(false);
         cps.set_ignore_expired(true);
+        // A setting the model has no field for, so nothing here can express an opinion about it.
+        cps.0.insert(
+            PS_MAX_CRL_FETCH_BYTES.to_string(),
+            CertificationPathProcessingTypes::U64(1024),
+        );
 
         let model = SettingsModel {
             ignore_expired: Some(false),
@@ -542,6 +547,36 @@ mod tests {
         assert!(!cps.0.contains_key(PS_CHECK_REVOCATION_STATUS));
         assert!(cps.get_check_revocation_status());
         assert!(!cps.get_ignore_expired());
+        // The uncovered half of this test's name. It is also why the desktop offers a Delete
+        // button beside its settings path: Reset to defaults followed by Save clears every key the
+        // form can express and leaves the rest of the file standing, so it is not a full reset.
+        assert_eq!(
+            cps.0.get(PS_MAX_CRL_FETCH_BYTES),
+            Some(&CertificationPathProcessingTypes::U64(1024))
+        );
+    }
+
+    /// Reset to defaults is `SettingsModel::default()`, and Save applies it over the stored file.
+    /// What that clears, and what it leaves, is the whole argument for a separate Delete, so it is
+    /// pinned here rather than left to be re-derived from `apply`.
+    #[test]
+    fn resetting_to_defaults_clears_every_covered_key() {
+        let mut cps = CertificationPathSettings::new();
+        cps.set_check_revocation_status(false);
+        cps.set_ignore_expired(true);
+        cps.set_require_country_code_indicator(true);
+        cps.0.insert(
+            PS_MAX_CRL_FETCH_BYTES.to_string(),
+            CertificationPathProcessingTypes::U64(1024),
+        );
+
+        SettingsModel::default().apply(&mut cps);
+
+        assert_eq!(
+            cps.0.keys().collect::<Vec<_>>(),
+            vec![PS_MAX_CRL_FETCH_BYTES],
+            "only settings the form cannot express should survive a reset"
+        );
     }
 
     #[test]

--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -248,6 +248,48 @@ async fn confirm_purge(folder: &str) -> bool {
         == rfd::MessageDialogResult::Yes
 }
 
+/// Confirms deleting the settings file, which the same rule as [`confirm_purge`] says must ask:
+/// certificates and CRLs can generally be fetched again, and a set of hand-tuned settings cannot.
+///
+/// Names the path rather than saying "the settings file" because the box beside this button may be
+/// pointing at somebody else's -- a bundle carries `inputs/settings.json`, and reproducing a run
+/// from one is exactly when this button is within reach.
+async fn confirm_delete_settings(path: &str) -> bool {
+    rfd::AsyncMessageDialog::new()
+        .set_title("Delete settings file")
+        .set_description(format!(
+            "Delete {path}?\n\nThe form goes back to certval's defaults, and the next run uses them \
+             too. Settings this form does not show are removed with the file. This cannot be undone."
+        ))
+        .set_buttons(rfd::MessageButtons::YesNo)
+        .show()
+        .await
+        == rfd::MessageDialogResult::Yes
+}
+
+/// Whether it is all right to do something that discards the settings form's edits: either there
+/// are none, or the user said so.
+///
+/// Naming the two ways out together keeps every caller the same shape. Repointing the settings path
+/// discards edits exactly as navigating away does — the form re-reads the file it is now aimed at —
+/// so the buttons that repoint it ask the same question the sidebar does.
+async fn leave_settings_ok(dirty: bool) -> bool {
+    !dirty || confirm_discard_settings().await
+}
+
+/// Confirms leaving the settings form with edits that have not been saved.
+async fn confirm_discard_settings() -> bool {
+    rfd::AsyncMessageDialog::new()
+        .set_title("Unsaved settings")
+        .set_description(
+            "The settings form has changes that have not been saved.\n\nLeaving discards them.",
+        )
+        .set_buttons(rfd::MessageButtons::YesNo)
+        .show()
+        .await
+        == rfd::MessageDialogResult::Yes
+}
+
 /// Where a file dialog should open: the folder that kind of dialog last used, falling back to the
 /// user's home as it always did when nothing has been remembered yet.
 fn dialog_dir(purpose: DialogPurpose) -> std::path::PathBuf {
@@ -1182,6 +1224,13 @@ pub(crate) fn App() -> Element {
     // not exist — read_settings treats a missing path as "all defaults".
     let mut s_settings =
         use_signal(|| saved_or_default(sa.settings.clone(), default_settings_path));
+    // Bumped to ask the settings form to read its file again when the path has not changed --
+    // Revert to Saved, and Delete, which leaves nothing to read. The form seeds once per mount, so
+    // it is keyed on this alongside the path.
+    let mut s_settings_gen = use_signal(|| 0usize);
+    // Whether the settings form holds edits the file has not seen. The form reports it because only
+    // the form knows; it is held here because the sidebar that navigates away from the form is here.
+    let mut s_settings_dirty = use_signal(|| false);
     let s_crl_folder = use_signal(|| saved_or_default(sa.crl_folder.clone(), default_crl_folder));
     let s_cleanup = use_signal(|| sa.cleanup);
     let s_ta_cleanup = use_signal(|| sa.ta_cleanup);
@@ -1613,7 +1662,24 @@ pub(crate) fn App() -> Element {
             items: VIEWS.iter().map(|(_, label)| *label).collect::<Vec<_>>(),
             selected,
             busy_item: if s_running() { Some(results_index) } else { None },
-            on_select: move |i: usize| s_view.set(VIEWS[i].0),
+            // Leaving the settings form is the only way to discard its edits now that saving no
+            // longer navigates away, so it is the one transition that asks. Selecting Settings
+            // again while already there is not a departure and must not prompt.
+            on_select: move |i: usize| {
+                let to = VIEWS[i].0;
+                let leaving_dirty =
+                    s_view() == View::Settings && to != View::Settings && s_settings_dirty();
+                match leaving_dirty {
+                    true => {
+                        spawn(async move {
+                            if leave_settings_ok(true).await {
+                                s_view.set(to);
+                            }
+                        });
+                    }
+                    false => s_view.set(to),
+                }
+            },
             {
                 match s_view() {
                     View::Validate => {
@@ -2047,12 +2113,76 @@ pub(crate) fn App() -> Element {
                                                                                 r#type: "text",
                                                                                 name: "settings",
                                                                                 value: "{s_settings}",
-                                                                                oninput: move |ev| s_settings.set(ev.value()),
+                                                                                // Committed on exit, not per keystroke: this path drives a
+                                                                                // file read and reseeds the form below, so a half-typed
+                                                                                // path would read as "missing" and blank the form on the
+                                                                                // way to a name that does exist. Same reason the datetime
+                                                                                // row uses onchange. Committing once also makes the
+                                                                                // unsaved-edits question askable, which it is not per
+                                                                                // character.
+                                                                                onchange: move |ev| {
+                                                                                    let typed = ev.value();
+                                                                                    spawn(async move {
+                                                                                        if leave_settings_ok(s_settings_dirty()).await {
+                                                                                            s_settings.set(typed);
+                                                                                            return;
+                                                                                        }
+                                                                                        // Declined, so the path does not move -- but the box
+                                                                                        // is still showing what was typed. Rewriting the
+                                                                                        // signal it is bound to is what puts it back.
+                                                                                        let unchanged = s_settings();
+                                                                                        s_settings.set(unchanged);
+                                                                                    });
+                                                                                },
                                                                             }
                                     button {
                                                                                 r#type: "button",
-                                                                                onclick: move |_| pick_file_into(s_settings, "PITTv3 Settings", &["json"]),
+                                                                                onclick: move |_| {
+                                                                                    spawn(async move {
+                                                                                        if !leave_settings_ok(s_settings_dirty()).await {
+                                                                                            return;
+                                                                                        }
+                                                                                        pick_file_into(s_settings, "PITTv3 Settings", &["json"]).await;
+                                                                                    });
+                                                                                },
                                                                                 "..."
+                                                                            }
+                                    // Actions on the file itself, beside the box that names it and
+                                    // not among the form's actions below: these change *which*
+                                    // settings are being edited, or whether they exist at all,
+                                    // where Save and Revert act on whichever file is named here.
+                                    button {
+                                                                                r#type: "button",
+                                                                                onclick: move |_| {
+                                                                                    spawn(async move {
+                                                                                        if !leave_settings_ok(s_settings_dirty()).await {
+                                                                                            return;
+                                                                                        }
+                                                                                        if let Some(p) = default_settings_path() {
+                                                                                            s_settings.set(p);
+                                                                                        }
+                                                                                    });
+                                                                                },
+                                                                                "Default"
+                                                                            }
+                                    button {
+                                                                                r#type: "button",
+                                                                                onclick: move |_| {
+                                                                                    spawn(async move {
+                                                                                        let path = s_settings();
+                                                                                        if !confirm_delete_settings(&path).await {
+                                                                                            return;
+                                                                                        }
+                                                                                        match std::fs::remove_file(&path) {
+                                                                                            // The form re-reads on remount and a missing
+                                                                                            // file loads as an empty settings map, which
+                                                                                            // is the same thing as all defaults.
+                                                                                            Ok(()) => s_settings_gen += 1,
+                                                                                            Err(e) => error!("Failed to delete {path}: {e}"),
+                                                                                        }
+                                                                                    });
+                                                                                },
+                                                                                "Delete"
                                                                             }
                                 }
                             }
@@ -2067,6 +2197,10 @@ pub(crate) fn App() -> Element {
                             } else {
                                 EditSettingsFile {
                                     path: s_settings(),
+                                    // The other reason to read the file again: the same one, on
+                                    // request (Revert to Saved) or because it is no longer there
+                                    // (Delete).
+                                    reload_token: s_settings_gen(),
                                     // Folders the run writes to, and the actions that maintain
                                     // them, beside the folders it reads from. They persist with the
                                     // rest of the args rather than into the settings file, which
@@ -2189,7 +2323,8 @@ pub(crate) fn App() -> Element {
                                             span { class: "hint", "{s_folder_status}" }
                                         }
                                     }),
-                                    on_close: move |_| s_view.set(View::Validate),
+                                    on_reload: move |_| s_settings_gen += 1,
+                                    on_dirty_change: move |d| s_settings_dirty.set(d),
                                 }
                             }
                         }

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -96,6 +96,9 @@ const VIEW_LABELS: &[&str] = &[
     "Help",
 ];
 
+/// Index of the Settings view within [`VIEW_LABELS`]
+const SETTINGS_VIEW: usize = 1;
+
 /// Index of the Results view within [`VIEW_LABELS`]
 const RESULTS_VIEW: usize = 2;
 
@@ -290,6 +293,29 @@ fn is_touch_device() -> bool {
     false
 }
 
+/// Confirms leaving the settings form with edits that have not been saved.
+///
+/// The browser's own dialog rather than a rendered control: this has to block the navigation, and
+/// the navigation is the sidebar's, outside the form. The desktop asks the same question through
+/// `rfd`, which is why neither is in the shared component.
+#[cfg(target_family = "wasm")]
+fn confirm_discard_settings() -> bool {
+    web_sys::window()
+        .and_then(|w| {
+            w.confirm_with_message(
+                "The settings form has changes that have not been saved.\n\nLeaving discards them.",
+            )
+            .ok()
+        })
+        // No window is not a reason to trap someone in the form.
+        .unwrap_or(true)
+}
+
+#[cfg(not(target_family = "wasm"))]
+fn confirm_discard_settings() -> bool {
+    true
+}
+
 /// Reads all files carried by a form event into (name, bytes) pairs
 async fn read_files(ev: &FormEvent) -> Vec<(String, Vec<u8>)> {
     let mut out = vec![];
@@ -334,6 +360,9 @@ fn App() -> Element {
     let mut use_rev_cache = use_signal(load_use_rev_cache);
     // Transient status line for the settings-file load/save controls (cleared on next action)
     let mut settings_status = use_signal(String::new);
+    // Whether the settings form holds edits local storage has not seen. The form reports it because
+    // only the form knows; it is held here because the sidebar that navigates away from it is here.
+    let mut settings_dirty = use_signal(|| false);
     let mut targets = use_signal(Vec::<TargetReport>::new);
     // Wall clock for the run that produced `targets`. `from_targets` sums what the paths report,
     // which is the validating alone -- with retrieval through the service that is a small fraction
@@ -625,15 +654,17 @@ fn App() -> Element {
         store_service_status.set(m);
     });
 
-    // Persist the settings whenever the model changes, and mark the prepared environment stale
-    // (settings can affect partial-path discovery). Reading the model here subscribes this effect
-    // to every field at once — the single-signal equivalent of the per-field reads this replaced.
+    // Mark the prepared environment stale whenever the model changes (settings can affect
+    // partial-path discovery). Reading the model here subscribes this effect to every field at once
+    // — the single-signal equivalent of the per-field reads this replaced.
+    //
+    // Persistence is deliberately NOT here. It used to be, which made *loading a settings file* a
+    // save: the load replaces the model, the effect wrote it to localStorage, and the settings the
+    // user had saved were gone with no way to ask for them back. localStorage is this frontend's
+    // equivalent of the desktop's `~/.pittv3/settings.json`, and on the desktop pointing the box at
+    // somebody else's file does not overwrite yours. Saving is what writes; see `persist_settings`.
     use_effect(move || {
-        let mut cps = LocalStorageSettingsStore.load();
-        settings().apply(&mut cps);
-        if let Err(e) = LocalStorageSettingsStore.save(&cps) {
-            settings_status.set(e);
-        }
+        settings();
         env_dirty.set(true);
         // Settings are what genuinely invalidates a cached determination, so this is where the cache
         // is dropped rather than in the effect watching uploads and chased certificates. A cached
@@ -680,10 +711,28 @@ fn App() -> Element {
     });
 
     // Replaces the whole model, remounting the form so it reseeds from the new values. Used by
-    // Reset to defaults and by loading a settings file.
+    // loading a settings file and by Revert to Saved.
+    //
+    // Deliberately does not persist: a load is not a save. What the run uses and what localStorage
+    // holds are two different things here, exactly as the desktop's settings path and its file are.
     let mut replace_settings = move |model: SettingsModel| {
         settings.set(model);
         form_gen += 1;
+    };
+
+    // Writes the model to localStorage, which is this frontend's saved settings -- what a fresh page
+    // starts from and what Revert to Saved returns to. Called only by Save, so that "saved" means
+    // what somebody chose to save. Merges over the stored map rather than replacing it, keeping
+    // settings the form does not surface, which is what the desktop's file-backed save also does.
+    //
+    // Reports the outcome rather than setting the status itself, so a failed write cannot be
+    // overwritten by the caller's success message -- localStorage refuses in private browsing and
+    // when the origin's quota is full, and a save that says it worked when it did not is the one
+    // failure the user cannot see.
+    let persist_settings = move |model: &SettingsModel| -> Result<(), String> {
+        let mut cps = LocalStorageSettingsStore.load();
+        model.apply(&mut cps);
+        LocalStorageSettingsStore.save(&cps)
     };
 
     // The time a run validates against, for stamping reports: the chosen time of interest, or the
@@ -886,7 +935,12 @@ fn App() -> Element {
             }
         };
         replace_settings(SettingsModel::from_cps(&cps));
-        settings_status.set(format!("Loaded settings from {name}"));
+        // Says it is not saved because nothing on screen would otherwise show it. The desktop has a
+        // path box naming the file it is editing; here the only difference between a loaded file and
+        // the saved settings is invisible, and Revert to Saved is how it is undone.
+        settings_status.set(format!(
+            "Loaded settings from {name}. Runs use them now; Save keeps them, Revert to Saved discards them."
+        ));
     };
 
     // loads a certificate into the aggregated list; validation happens when the Validate button
@@ -1317,7 +1371,18 @@ fn App() -> Element {
             AppShell {
                 items: VIEW_LABELS.to_vec(),
                 selected: view(),
-                on_select: move |i: usize| view.set(i),
+                // Leaving the settings form is the only way to discard its edits now that saving no
+                // longer navigates away, so it is the one transition that asks. `window.confirm`
+                // rather than a rendered control: the sidebar is outside the form, and blocking the
+                // navigation is the whole point.
+                on_select: move |i: usize| {
+                    let leaving_dirty =
+                        view() == SETTINGS_VIEW && i != SETTINGS_VIEW && settings_dirty();
+                    if leaving_dirty && !confirm_discard_settings() {
+                        return;
+                    }
+                    view.set(i);
+                },
                 match view() {
                     0 => rsx! {
                         // The tier governs the whole run, so it is stated before the trust material
@@ -1609,11 +1674,28 @@ fn App() -> Element {
                                 revocation_default: Some(
                                     tier().retrieves() || have_revocation_uploads(),
                                 ),
-                                on_save: move |edited| {
+                                on_save: move |edited: SettingsModel| {
+                                    let outcome = persist_settings(&edited);
+                                    // The run uses the edits either way: failing to persist them is
+                                    // not a reason to discard them.
                                     settings.set(edited);
-                                    settings_status.set("Settings saved".to_string());
+                                    settings_status
+                                        .set(match outcome {
+                                            Ok(()) => "Settings saved".to_string(),
+                                            Err(e) => e,
+                                        });
                                 },
-                                on_close: move |_| view.set(0),
+                                // Back to what local storage holds -- what Save, or a loaded
+                                // settings file, last put there. `replace_settings` is the existing
+                                // wholesale-replacement path and remounts the form, which is how
+                                // the new values reach it.
+                                on_reload: move |_| {
+                                    replace_settings(
+                                        SettingsModel::from_cps(&LocalStorageSettingsStore.load()),
+                                    );
+                                    settings_status.set("Settings reloaded".to_string());
+                                },
+                                on_dirty_change: move |d| settings_dirty.set(d),
                             }
                         }
                         fieldset {


### PR DESCRIPTION
- Harmonize buttons: Save, Revert to Saved, Reset to defaults. Saving reports in a status line and stays on the form; the sidebar is how you leave it. Dropped the Close button that was an artifact of when the form was a dialog.
- Revert to Saved re-reads the settings file identified in the Settings file box.
- The desktop settings-file row gains Default, which fills the box from ~/.pittv3/settings.json, and Delete, which confirms while naming the path.
- Manually editting the settings path commits on field exit rather than per keystroke.
- The form reports unsaved edits.
- Browser localStorage is written by Save alone. Loading a settings file fills the form and the run without committing, so Revert to Saved returns to what was saved.
- Reset to defaults clears the 36 settings the form covers and leaves the rest of the file standing.