### PR TITLE
Various PITTv3 changes plus add support for TaSource re-initialization 

### DIFF
--- a/.github/workflows/certval.yml
+++ b/.github/workflows/certval.yml
@@ -100,6 +100,9 @@ jobs:
       # Its store selector holds the only CAPI code no job compiles, so re-including it is a real
       # gain whenever that cost is acceptable; the tests are headless and do not open a window.
       - run: cargo test --workspace --exclude pittv3-gui --exclude pittv3-gui-lib --exclude pittv3-wasm --exclude pittv3-relay --exclude pittv3-service
+      # pittv3-lib's Web PKI tests need a verifier for the signatures that material carries, which
+      # the default features do not bring. Without this leg they compile away and prove nothing.
+      - run: cargo test -p pittv3-lib --features std,rsa
       - run: cargo test -p certval --features capi
       # pittv3 pulls pittv3-lib/capi and certval/capi in behind it, so this covers the whole chain
       # in one run. Note the runner is not elevated: the LocalMachine paths return PermissionDenied

--- a/certval/src/source/ta_source.rs
+++ b/certval/src/source/ta_source.rs
@@ -285,7 +285,19 @@ impl TaSource {
     }
 
     /// Processes any buffers passed to the instance, i.e., via new_from_cbor
+    ///
+    /// Calling this again after pushing more buffers is supported, and yields the same store as
+    /// initializing once with all of them: the parsed vector and the indexes are rebuilt from the
+    /// buffers rather than added to. Appending instead left every anchor in `tas` twice, and
+    /// [`get_trust_anchors`](TrustAnchorSource::get_trust_anchors) walks that vector directly.
+    ///
+    /// Rebuilt rather than parsing only what is new, which is what
+    /// [`CertSource`](crate::CertSource) does: that store keeps its parsed vector index-aligned with
+    /// its buffers, leaving a `None` where one will not parse, so the count of parsed entries says
+    /// exactly how far it got. Here a buffer that fails to parse is dropped instead, so that count
+    /// would name the wrong buffer as soon as one did. Anchors are few and this runs rarely.
     pub fn initialize(&mut self) -> Result<()> {
+        self.tas.clear();
         populate_parsed_ta_vector(&self.buffers, &mut self.tas);
         self.index_tas();
         Ok(())
@@ -299,6 +311,10 @@ impl TaSource {
     /// index_tas builds internally used maps based on key identifiers and names. It must be called
     /// after populating the `tas` and `buffers` fields and before use.
     pub fn index_tas(&mut self) {
+        // Rebuilt, not added to: an index left from a previous call names a position in a vector
+        // that no longer holds what it did.
+        self.skid_map.clear();
+        self.name_map.clear();
         for (i, ta) in self.tas.iter().enumerate() {
             let hex_skid = hex_skid_from_ta(ta);
             // a TA whose key identifier cannot be computed (e.g. malformed public key) is left out
@@ -458,6 +474,62 @@ fn populate_parsed_ta_vector(
             Err(e) => error!("Failed to parse TrustAnchorChoice: {:?}", e),
         }
     }
+}
+
+#[cfg(feature = "std")]
+#[test]
+fn initialize_again_after_appending_test() {
+    use crate::{ta_folder_to_vec, PkiEnvironment};
+    use hex_literal::hex;
+
+    let mut pe = PkiEnvironment::default();
+    pe.populate_5280_pki_environment();
+
+    let mut ta_store = TaSource::new();
+    let ta_store_folder = format!(
+        "{}{}",
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/examples/ta_store_with_bad"
+    );
+    ta_folder_to_vec(
+        &pe,
+        &ta_store_folder,
+        &mut ta_store,
+        crate::TimeOfInterest::disabled(),
+    )
+    .unwrap();
+    ta_store.initialize().unwrap();
+
+    let buffers_before = ta_store.buffers.len();
+    let parsed_before = ta_store.tas.len();
+    assert_eq!(buffers_before, parsed_before);
+
+    // An anchor the folder does not hold, pushed the way a caller adds one it obtained elsewhere.
+    let extra = std::fs::read(format!(
+        "{}{}",
+        env!("CARGO_MANIFEST_DIR"),
+        "/tests/examples/DigiCertGlobalCAG2.der"
+    ))
+    .unwrap();
+    ta_store.push(CertFile {
+        filename: "DigiCertGlobalCAG2.der".to_string(),
+        bytes: extra,
+    });
+    assert_eq!(ta_store.buffers.len(), buffers_before + 1);
+
+    ta_store.initialize().unwrap();
+
+    // Grew by exactly the buffer that was added. Appending instead of rebuilding gave
+    // 2 * parsed_before + 1 here, and `get_trust_anchors` walks this vector directly.
+    assert_eq!(ta_store.tas.len(), parsed_before + 1);
+    assert_eq!(
+        ta_store.get_trust_anchors().unwrap().len(),
+        parsed_before + 1
+    );
+
+    // And the indexes address the rebuilt vector rather than the one they were built over.
+    let good = hex!("6C8A94A277B180721D817A16AAF2DCCE66EE45C0");
+    assert!(ta_store.get_trust_anchor_by_skid(&good).is_ok());
 }
 
 #[cfg(feature = "std")]

--- a/certval/tests/pkits.rs
+++ b/certval/tests/pkits.rs
@@ -729,9 +729,9 @@ pub fn pkits_guts_sync(
                     cpool.push(ca);
                 }
 
-                for i in 0..case.intermediate_ca_file_names.len() {
-                    chain.push(cpool[i].clone());
-                    chain2.push(cpool[i].clone());
+                for ca in &cpool {
+                    chain.push(ca.clone());
+                    chain2.push(ca.clone());
                 }
 
                 let mut cert_path = CertificationPath::new(ta.clone(), chain, ee);
@@ -791,7 +791,7 @@ pub fn pkits_guts_sync(
 
                 let mut cpr = CertificationPathResults::new();
                 #[cfg(not(feature = "revocation"))]
-                let r = pe.validate_path(&pe, &tmp_settings, &mut cert_path, &mut cpr);
+                let r = pe.validate_path(pe, &tmp_settings, &mut cert_path, &mut cpr);
 
                 #[cfg(feature = "revocation")]
                 let mut r = pe.validate_path(&pe, &tmp_settings, &mut cert_path, &mut cpr);
@@ -832,7 +832,7 @@ pub fn pkits_guts_sync(
                         CertificationPath::new(ta, CertificateChain::default(), ta_as_cert);
                     let mut cpr = CertificationPathResults::new();
                     #[cfg(not(feature = "revocation"))]
-                    let r = pe.validate_path(&pe, &tmp_settings, &mut cert_path2, &mut cpr);
+                    let r = pe.validate_path(pe, &tmp_settings, &mut cert_path2, &mut cpr);
 
                     #[cfg(feature = "revocation")]
                     let mut r = pe.validate_path(&pe, &tmp_settings, &mut cert_path2, &mut cpr);

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -540,7 +540,7 @@ const TABS: &[(SettingsTab, &str)] = &[
     (SettingsTab::TrustAndPath, "Trust anchors & path"),
     (SettingsTab::Target, "Target"),
     (SettingsTab::Revocation, "Revocation"),
-    (SettingsTab::Fetching, "Fetching"),
+    (SettingsTab::Fetching, "SIA/AIA"),
     (SettingsTab::Folders, "Folders & files"),
 ];
 
@@ -641,15 +641,12 @@ pub fn EditSettings(
     // same place.
     let mut model = use_signal(|| initial.clone());
     let mut baseline = use_signal(|| initial.clone());
-    // Folders and files first: it is what a person opening Settings most often came to change, and
-    // the two folder defaults landing there made it the tab that answers "where will this run put
-    // things". Falls back to the first tab a frontend actually shows -- the browser has no
-    // filesystem, so `tab_applies` hides Folders there and defaulting to it would open the form on a
-    // tab that is not in the bar.
-    let mut tab = use_signal(|| match tab_applies(SettingsTab::Folders, &caps) {
-        true => SettingsTab::Folders,
-        false => SettingsTab::Policy,
-    });
+    // Target first, because it carries the time of interest -- the sharp corner of this form. A
+    // stale one changes every verdict in a run without changing anything a reader would look at:
+    // certificates valid then and expired now still validate, and revocation data published since
+    // is refused as not yet valid. Opening here puts it in front of the person before they set
+    // anything else. Shown in every frontend, unlike Folders, so no fallback is needed.
+    let mut tab = use_signal(|| SettingsTab::Target);
     // Set when a discarding action is asked for while there are unsaved edits, so the confirmation
     // is rendered here rather than through a dialog toolkit neither frontend shares.
     let mut pending = use_signal(|| None::<PendingDiscard>);
@@ -724,19 +721,19 @@ pub fn EditSettings(
                         }
                     }
                     OidListEditor {
-                        label: "Initial policy set",
+                        label: "Policy set",
                         value: m.initial_policy_set.clone(),
                         onchange: move |v| model.write().initial_policy_set = v,
                     }
                 },
                 SettingsTab::NameConstraints => rsx! {
                     NameSubtreesEditor {
-                        label: "Initial permitted subtrees",
+                        label: "Permitted subtrees",
                         value: m.initial_permitted_subtrees.clone(),
                         onchange: move |v| model.write().initial_permitted_subtrees = v,
                     }
                     NameSubtreesEditor {
-                        label: "Initial excluded subtrees",
+                        label: "Excluded subtrees",
                         value: m.initial_excluded_subtrees.clone(),
                         onchange: move |v| model.write().initial_excluded_subtrees = v,
                     }
@@ -768,7 +765,7 @@ pub fn EditSettings(
                             onchange: move |v| model.write().use_validator_filter_when_building = Some(v),
                         }
                         NumberRow {
-                            label: "Initial path length constraint",
+                            label: "Path length constraint",
                             value: m.initial_path_length_constraint.map(|v| v as u64),
                             placeholder: "15",
                             onchange: move |v: Option<u64>| {
@@ -915,12 +912,6 @@ pub fn EditSettings(
                                 onchange: move |v| model.write().check_crldp_http = Some(v),
                             }
                             BoolRow {
-                                label: "Fetch CRLs from LDAP CRL DPs (no LDAP support)",
-                                checked: m.check_crldp_ldap.unwrap_or(false),
-                                overridden: m.check_crldp_ldap.is_some(),
-                                onchange: move |v| model.write().check_crldp_ldap = Some(v),
-                            }
-                            BoolRow {
                                 label: "Allow stale CRLs within grace periods",
                                 checked: m.crl_grace_periods_as_last_resort.unwrap_or(true),
                                 overridden: m.crl_grace_periods_as_last_resort.is_some(),
@@ -957,12 +948,6 @@ pub fn EditSettings(
                             checked: m.retrieve_from_aia_sia_http.unwrap_or(true),
                             overridden: m.retrieve_from_aia_sia_http.is_some(),
                             onchange: move |v| model.write().retrieve_from_aia_sia_http = Some(v),
-                        }
-                        BoolRow {
-                            label: "Retrieve from LDAP AIA and SIA (no LDAP support)",
-                            checked: m.retrieve_from_aia_sia_ldap.unwrap_or(false),
-                            overridden: m.retrieve_from_aia_sia_ldap.is_some(),
-                            onchange: move |v| model.write().retrieve_from_aia_sia_ldap = Some(v),
                         }
                         NumberRow {
                             label: "Maximum AIA/SIA certificates",

--- a/pittv3-gui-lib/src/gui_settings_model.rs
+++ b/pittv3-gui-lib/src/gui_settings_model.rs
@@ -89,8 +89,6 @@ pub struct SettingsModel {
     pub check_ocsp_from_aia: Option<bool>,
     /// Fetch CRLs from HTTP CRL DP locations when determining status
     pub check_crldp_http: Option<bool>,
-    /// Fetch CRLs from LDAP CRL DP locations when determining status (no LDAP support at present)
-    pub check_crldp_ldap: Option<bool>,
     /// Nonce handling for OCSP requests
     pub ocsp_aia_nonce_setting: Option<OcspNonceSetting>,
     /// Allow stale CRLs within grace periods as a last resort
@@ -103,8 +101,6 @@ pub struct SettingsModel {
     // ---- fetching ----
     /// Retrieve certificates from HTTP AIA and SIA locations while building paths
     pub retrieve_from_aia_sia_http: Option<bool>,
-    /// Retrieve certificates from LDAP AIA and SIA locations (no LDAP support at present)
-    pub retrieve_from_aia_sia_ldap: Option<bool>,
     /// Maximum number of certificates to retrieve via AIA and SIA
     pub max_aia_sia_certs: Option<u64>,
 
@@ -182,7 +178,6 @@ impl SettingsModel {
             check_ocsp_from_aia: present(cps, PS_CHECK_OCSP_FROM_AIA)
                 .then(|| cps.get_check_ocsp_from_aia()),
             check_crldp_http: present(cps, PS_CHECK_CRLDP_HTTP).then(|| cps.get_check_crldp_http()),
-            check_crldp_ldap: present(cps, PS_CHECK_CRLDP_LDAP).then(|| cps.get_check_crldp_ldap()),
             ocsp_aia_nonce_setting: present(cps, PS_OCSP_AIA_NONCE_SETTING)
                 .then(|| cps.get_ocsp_aia_nonce_setting()),
             crl_grace_periods_as_last_resort: present(cps, PS_CRL_GRACE_PERIODS_AS_LAST_RESORT)
@@ -192,8 +187,6 @@ impl SettingsModel {
             crl_timeout_secs: present(cps, PS_CRL_TIMEOUT).then(|| cps.get_crl_timeout().as_secs()),
             retrieve_from_aia_sia_http: present(cps, PS_RETRIEVE_FROM_AIA_SIA_HTTP)
                 .then(|| cps.get_retrieve_from_aia_sia_http()),
-            retrieve_from_aia_sia_ldap: present(cps, PS_RETRIEVE_FROM_AIA_SIA_LDAP)
-                .then(|| cps.get_retrieve_from_aia_sia_ldap()),
             max_aia_sia_certs: present(cps, PS_MAX_AIA_SIA_CERTS)
                 .then(|| cps.get_max_aia_sia_certs()),
             require_country_code_indicator: present(cps, PS_REQUIRE_COUNTRY_CODE_INDICATOR)
@@ -350,9 +343,6 @@ impl SettingsModel {
         set_or_remove(cps, PS_CHECK_CRLDP_HTTP, &self.check_crldp_http, |c, v| {
             c.set_check_crldp_http(v)
         });
-        set_or_remove(cps, PS_CHECK_CRLDP_LDAP, &self.check_crldp_ldap, |c, v| {
-            c.set_check_crldp_ldap(v)
-        });
         set_or_remove(
             cps,
             PS_OCSP_AIA_NONCE_SETTING,
@@ -379,12 +369,6 @@ impl SettingsModel {
             PS_RETRIEVE_FROM_AIA_SIA_HTTP,
             &self.retrieve_from_aia_sia_http,
             |c, v| c.set_retrieve_from_aia_sia_http(v),
-        );
-        set_or_remove(
-            cps,
-            PS_RETRIEVE_FROM_AIA_SIA_LDAP,
-            &self.retrieve_from_aia_sia_ldap,
-            |c, v| c.set_retrieve_from_aia_sia_ldap(v),
         );
         set_or_remove(
             cps,

--- a/pittv3-lib/src/der_or_pem.rs
+++ b/pittv3-lib/src/der_or_pem.rs
@@ -27,13 +27,14 @@ pub use certval::{CERT_BUNDLE_EXTENSIONS, SINGLE_CERT_EXTENSIONS, TA_BUNDLE_EXTE
 /// Returns DER bytes given a buffer that may be PEM or DER encoded.
 ///
 /// DER is detected by its leading tag rather than by attempting a parse: `SEQUENCE` covers
-/// certificates and the certificate variant of `TrustAnchorChoice`, and the two context tags cover
-/// the `tbsCert` and `taInfo` variants of a DER-encoded RFC 5914 `TrustAnchorChoice`. An input that
-/// opens with an encapsulation boundary goes to [`decode_pem_to_der`]; anything else to
-/// [`decode_bare_base64`], for a file that is base64 with no boundaries at all. A failure means the
-/// bytes are none of the three.
+/// certificates and the certificate variant of `TrustAnchorChoice`, and `[2]` covers its `taInfo`
+/// variant, which is how a DER-encoded RFC 5914 trust anchor arrives. The remaining variant,
+/// `tbsCert` (`[1]`), is not accepted: nothing produces one. An input that opens with an
+/// encapsulation boundary goes to [`decode_pem_to_der`]; anything else to [`decode_bare_base64`],
+/// for a file that is base64 with no boundaries at all. A failure means the bytes are none of the
+/// three.
 pub fn maybe_pem(bytes: &[u8]) -> Result<Vec<u8>> {
-    if !bytes.is_empty() && matches!(bytes[0], 0x30 | 0xA1 | 0xA2) {
+    if !bytes.is_empty() && matches!(bytes[0], 0x30 | 0xA2) {
         return Ok(bytes.to_vec());
     }
     // Tolerate non-standard PEM: decode_pem_to_der accepts wrapping widths other than 64. Armor
@@ -68,7 +69,7 @@ pub fn certs_in(bytes: &[u8]) -> Result<Vec<Vec<u8>>> {
     }
     // Bare DER is one object, already in the encoding the caller wants. Same leading tags as
     // maybe_pem, for the same reason.
-    if matches!(bytes.first(), Some(0x30 | 0xA1 | 0xA2)) {
+    if matches!(bytes.first(), Some(0x30 | 0xA2)) {
         return Ok(vec![bytes.to_vec()]);
     }
     // One object with no boundaries around it. Tried before the armor check below because that

--- a/pittv3-lib/src/pitt_log.rs
+++ b/pittv3-lib/src/pitt_log.rs
@@ -1166,7 +1166,11 @@ fn render_uri_checks(f: &mut dyn Write, path: &CertificationPath, reports: &UriC
     if reports.is_empty() {
         return;
     }
-    let mut certs: Vec<Vec<u8>> = vec![path.trust_anchor.encoded_ta.clone()];
+    // The anchor by the certificate it carries, matching the key the checker recorded it under --
+    // an anchor holding no certificate was never checked and simply does not appear.
+    let mut certs: Vec<Vec<u8>> = crate::uri_check::anchor_certificate_der(&path.trust_anchor)
+        .into_iter()
+        .collect();
     certs.extend(path.intermediates.iter().map(|ca| ca.as_bytes().to_vec()));
     certs.push(path.target.as_bytes().to_vec());
 

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -19,7 +19,7 @@ use certval::util::pdv_utilities::*;
 use certval::*;
 
 use crate::pitt_log::*;
-use crate::uri_check::UriCheckReports;
+use crate::uri_check::{anchor_certificate_der, UriCheckReports};
 #[cfg(feature = "remote")]
 use crate::uri_check::{check_uris_in_cert, ReqwestFetcher, UriCheckOptions};
 use crate::{
@@ -988,18 +988,31 @@ async fn check_path_uris(
     path: &CertificationPath,
     reports: &mut UriCheckReports,
 ) {
-    let mut ordered: Vec<Vec<u8>> = vec![path.trust_anchor.encoded_ta.clone()];
-    ordered.extend(path.intermediates.iter().map(|ca| ca.as_bytes().to_vec()));
-    ordered.push(path.target.as_bytes().to_vec());
+    // The anchor contributes the certificate it carries, not the `TrustAnchorChoice` wrapping it:
+    // that wrapper is not a certificate this checker can parse, and handing it over produced one
+    // "failed to parse target certificate" line for the anchor and a second for the certificate
+    // below it, whose issuer it is. An anchor with no certificate to give -- a `taInfo` holding
+    // only a name and a key -- contributes nothing and leaves the certificate below without an
+    // issuer, which is the honest state rather than a parse failure.
+    let mut ordered: Vec<Option<Vec<u8>>> = vec![anchor_certificate_der(&path.trust_anchor)];
+    ordered.extend(
+        path.intermediates
+            .iter()
+            .map(|ca| Some(ca.as_bytes().to_vec())),
+    );
+    ordered.push(Some(path.target.as_bytes().to_vec()));
 
     let fetcher = ReqwestFetcher::new();
-    for (i, der) in ordered.iter().enumerate() {
+    for (i, slot) in ordered.iter().enumerate() {
+        let Some(der) = slot else {
+            continue;
+        };
         if reports.contains(der) {
             continue;
         }
         let issuer = match i {
             0 => None,
-            _ => ordered.get(i - 1).map(|b| b.as_slice()),
+            _ => ordered.get(i - 1).and_then(|s| s.as_deref()),
         };
         // `auto_discover` off: the issuer is known from the path, so following an AIA pointer to
         // find one would be answering a question this run has already answered -- and adopting

--- a/pittv3-lib/src/std_utils.rs
+++ b/pittv3-lib/src/std_utils.rs
@@ -19,9 +19,11 @@ use certval::util::pdv_utilities::*;
 use certval::*;
 
 use crate::pitt_log::*;
-use crate::uri_check::{anchor_certificate_der, UriCheckReports};
+use crate::uri_check::UriCheckReports;
 #[cfg(feature = "remote")]
-use crate::uri_check::{check_uris_in_cert, ReqwestFetcher, UriCheckOptions};
+use crate::uri_check::{
+    anchor_certificate_der, check_uris_in_cert, ReqwestFetcher, UriCheckOptions,
+};
 use crate::{
     args::Pittv3Args,
     report::{

--- a/pittv3-lib/src/uri_check.rs
+++ b/pittv3-lib/src/uri_check.rs
@@ -28,6 +28,9 @@ use alloc::vec::Vec;
 
 use serde::{Deserialize, Serialize};
 
+use certval::{get_certificate_from_trust_anchor, PDVTrustAnchorChoice};
+use der::Encode;
+
 use crate::report::CertSummary;
 
 /// Which extension carried a URI. Rendered in the "Extension" column of the results grid.
@@ -80,6 +83,27 @@ pub struct UriCheckOptions<'a> {
     pub is_trust_anchor: bool,
     /// Hosts or URIs to skip, reported as blocklisted rather than fetched.
     pub blocklist: &'a [String],
+}
+
+/// The certificate a trust anchor carries, DER-encoded, or `None` when it carries none —
+/// **the key a URI report is filed under, and nothing more.**
+///
+/// An anchor is held as its `TrustAnchorChoice` encoding: a certificate outright in the
+/// `certificate` variant, and one wrapped in the `taInfo` variant, which is the form a `.ta` file
+/// and a DoD InstallRoot stream both store. A `taInfo` carrying only a name and a public key has no
+/// certificate to give, and neither has the `tbsCert` variant, which nothing produces.
+///
+/// **Not for validation.** A `TrustAnchorInfo` carries `CertPathControls` — the policy set, policy
+/// flags, name constraints and path length an RFC 5937 run enforces — and none of that is in the
+/// certificate it wraps. Substituting the certificate for the anchor anywhere on the validation
+/// path would discard those constraints silently, which is the opposite of what an anchor that
+/// bothers to state them is asking for. Path validation takes the `PDVTrustAnchorChoice` whole.
+///
+/// The re-encoded certificate is the right identity for a per-certificate record: the same
+/// certificate met as an intermediate on another path must produce the same bytes, or the record
+/// describes the role rather than the material.
+pub fn anchor_certificate_der(ta: &PDVTrustAnchorChoice) -> Option<Vec<u8>> {
+    get_certificate_from_trust_anchor(&ta.decoded_ta).and_then(|cert| cert.to_der().ok())
 }
 
 /// The URI check results for one run, keyed by the certificate they describe.

--- a/pittv3-lib/tests/path_dedupe.rs
+++ b/pittv3-lib/tests/path_dedupe.rs
@@ -1,0 +1,103 @@
+//! A chain reported once is not reported again, across calls that share one [`PathValidationStats`].
+//!
+//! Dynamic path building validates a target more than once: each pass hands the builder a higher
+//! threshold and revalidates what comes back, so the same chain is routinely offered again. The
+//! totals and the result-folder indices are keyed on what was *reported*, so a chain counted twice
+//! makes a run announce more paths than it found — which is how a desktop run reported ten paths
+//! where the same material yielded five in the browser (fixed in `4cf9a933`).
+//!
+//! The condition the defect needed is an early exit: with `validate_all` off the validation loop
+//! stops at the first success, so any candidate after it goes unreached. Recording a chain where it
+//! was *validated* therefore missed exactly those, and they were counted again next time. Recording
+//! where it is *offered* is what this pins.
+//! Gated on `rsa` as well as `std`: without a verifier for the Web PKI's signatures no path
+//! validates, the loop never stops early, and the test would pass without exercising what it is for.
+//! `certval.yml` runs it as its own leg for that reason -- a default-feature test run skips it.
+#![cfg(all(feature = "std", feature = "rsa"))]
+
+use certval::*;
+use ciborium::de::from_reader;
+use pittv3_lib::stats::PathValidationStats;
+use pittv3_lib::std_utils::{validate_cert_bytes, ValidateOpts};
+
+/// Inside the baked end entity's validity window (2021-12-13 .. 2022-12-12), so the run judges the
+/// material rather than the calendar. Pinned for the same reason the PKITS tests pin theirs: a real
+/// end entity expires, and a test that reads "now" stops testing what it was written for.
+const TOI: u64 = 1_654_041_600; // 2022-06-01T00:00:00Z
+
+/// The one baked end entity with more than one route to an anchor, which is what the defect needed.
+const MULTI_PATH_EE: &str = "twitter.com.der";
+
+fn settings() -> CertificationPathSettings {
+    let mut cps = CertificationPathSettings::new();
+    cps.set_time_of_interest(TimeOfInterest::from_unix_secs(TOI).unwrap());
+    // No revocation: this is about counting chains, and a fetch would make the test depend on a
+    // responder still answering for certificates this old.
+    cps.set_check_revocation_status(false);
+    cps
+}
+
+/// The Web PKI material the `options_no_std` and `options_std_app` entry points embed.
+fn environment(cps: &CertificationPathSettings) -> PkiEnvironment {
+    let mut cert_source =
+        CertSource::new_from_cbor(include_bytes!("../resources/ca.cbor").as_slice()).unwrap();
+    cert_source.initialize(cps).unwrap();
+    let mut ta_store = TaSource::new_from_cbor(include_bytes!("../resources/ta.cbor")).unwrap();
+    ta_store.initialize().unwrap();
+
+    let mut pe = PkiEnvironment::default();
+    pe.populate_5280_pki_environment();
+    pe.add_trust_anchor_source(Box::new(ta_store));
+    pe.add_certificate_source(Box::new(cert_source));
+    pe
+}
+
+fn multi_path_target() -> (String, Vec<u8>) {
+    let bap: BuffersAndPaths =
+        from_reader(include_bytes!("../resources/ee.cbor").as_slice()).unwrap();
+    bap.buffers
+        .iter()
+        .find(|cf| cf.filename.ends_with(MULTI_PATH_EE))
+        .map(|cf| (cf.filename.clone(), cf.bytes.clone()))
+        .unwrap_or_else(|| panic!("the embedded end entity store must hold {MULTI_PATH_EE}"))
+}
+
+#[test]
+fn a_chain_already_reported_is_not_counted_again() {
+    let cps = settings();
+    let pe = environment(&cps);
+    // Stops at the first valid path, leaving the second candidate unreached -- the state the
+    // defect needed, and the default a run uses unless asked for every path.
+    let opts = ValidateOpts {
+        validate_all: false,
+        ..Default::default()
+    };
+    let (name, bytes) = multi_path_target();
+
+    let mut stats = PathValidationStats::default();
+    let mut uris = vec![];
+    let _ = tokio_test::block_on(validate_cert_bytes(
+        &pe, &cps, &name, &bytes, &mut stats, &opts, &mut uris, 0,
+    ));
+
+    assert!(
+        stats.valid_paths_per_target > 0,
+        "a path has to validate for the loop to stop early; without that this test proves nothing"
+    );
+
+    let first = stats.paths_per_target;
+    assert!(
+        first > 1,
+        "the target must offer more than one candidate or the early exit has nothing to skip, got {first}"
+    );
+
+    // The same target again with the same stats, as the next dynamic-building pass does.
+    let _ = tokio_test::block_on(validate_cert_bytes(
+        &pe, &cps, &name, &bytes, &mut stats, &opts, &mut uris, 0,
+    ));
+
+    assert_eq!(
+        stats.paths_per_target, first,
+        "every chain was already reported, so the second call must add nothing"
+    );
+}

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -27,7 +27,9 @@ use pittv3_gui_lib::validate::certs_in;
 use pittv3_gui_lib::PITTV3_CSS;
 use pittv3_lib::installroot::installroot_from_bytes;
 use pittv3_lib::report::{RevocationStatus, TargetReport, ValidationReport};
-use pittv3_lib::uri_check::{check_uris_in_cert, UriCheckOptions, UriCheckReport, UriCheckReports};
+use pittv3_lib::uri_check::{
+    anchor_certificate_der, check_uris_in_cert, UriCheckOptions, UriCheckReport, UriCheckReports,
+};
 
 use pittv3_gui_lib::export::{
     path_entries, paths_text, pool_includes_ca_store, pool_includes_ta_store, stamped_export_name,
@@ -1369,16 +1371,28 @@ fn App() -> Element {
             // the loop happens to visit things in.
             let mut work: Vec<(Vec<u8>, Option<Vec<u8>>, bool)> = vec![];
             for r in retained_paths.read().iter() {
-                let mut ordered = vec![r.path.trust_anchor.encoded_ta.clone()];
-                ordered.extend(r.path.intermediates.iter().map(|ca| ca.as_bytes().to_vec()));
-                ordered.push(r.path.target.as_bytes().to_vec());
-                for (i, der) in ordered.iter().enumerate() {
+                // The certificate the anchor carries rather than its `TrustAnchorChoice` wrapper,
+                // and nothing at all when it carries none. Same rule as the desktop's
+                // `check_path_uris`, keyed the same way so one renderer serves both.
+                let mut ordered: Vec<Option<Vec<u8>>> =
+                    vec![anchor_certificate_der(&r.path.trust_anchor)];
+                ordered.extend(
+                    r.path
+                        .intermediates
+                        .iter()
+                        .map(|ca| Some(ca.as_bytes().to_vec())),
+                );
+                ordered.push(Some(r.path.target.as_bytes().to_vec()));
+                for (i, slot) in ordered.iter().enumerate() {
+                    let Some(der) = slot else {
+                        continue;
+                    };
                     if work.iter().any(|(seen, _, _)| seen == der) {
                         continue;
                     }
                     let issuer = match i {
                         0 => None,
-                        _ => ordered.get(i - 1).cloned(),
+                        _ => ordered.get(i - 1).and_then(|s| s.clone()),
                     };
                     work.push((der.clone(), issuer, i == 0));
                 }


### PR DESCRIPTION
- certval: Clean up internal TA store state to support re-initialization
- certval tests: address clippy warnings only visible with --no-default-features
- Stop accepting the tbsCert variant of TrustAnchorChoice, nothing produces one and certval maps it to None
- Accept TrustAnchorChoice in the URI checker but only when the instance is a certificate or contains a certificate
- add pittv3-lib to CI; add a count-focused multi-path test
- tighten settings view
