### PR TITLE
Unused settings item cleanup

### DIFF
--- a/certval/src/util/error.rs
+++ b/certval/src/util/error.rs
@@ -52,10 +52,6 @@ pub enum PathValidationStatus {
     /// has not CertPathControls or that has a CertPathControls that does not assert a name or wrap
     /// a Certificate.
     MissingTrustAnchorName,
-    /// ProhibitedAlg occurs when an algorithm constraint is violated.
-    ProhibitedAlg,
-    /// ProhibitedKeySize occurs when a key size constraint is violated.
-    ProhibitedKeySize,
     /// EncodingError occurs when an object cannot be parsed (though this is more likely to manifest
     /// as an Asn1Error).
     EncodingError,
@@ -63,9 +59,6 @@ pub enum PathValidationStatus {
     MissingCertificate,
     /// NoPathsFounds occurs when the certification path builder fails to find any candidate paths.
     NoPathsFound,
-    /// CountryCodeViolation occurs when a target certificate is not compliant with operative PS_PERM_COUNTRIES
-    /// or PS_EXCL_COUNTRIES items in a CertificationPathSettings instance.
-    CountryCodeViolation,
     /// CertificateRevoked occurs when a CertificationPath contains a certificate that has been revoked.
     CertificateRevoked,
     /// CertificateRevokedEndEntity occurs when a CertificationPath contains an end entity certificate that has been revoked.
@@ -184,12 +177,9 @@ impl fmt::Display for PathValidationStatus {
             }
             PathValidationStatus::MissingTrustAnchor => write!(f, "MissingTrustAnchor"),
             PathValidationStatus::MissingTrustAnchorName => write!(f, "MissingTrustAnchorName"),
-            PathValidationStatus::ProhibitedAlg => write!(f, "ProhibitedAlg"),
-            PathValidationStatus::ProhibitedKeySize => write!(f, "ProhibitedKeySize"),
             PathValidationStatus::EncodingError => write!(f, "EncodingError"),
             PathValidationStatus::MissingCertificate => write!(f, "MissingCertificate"),
             PathValidationStatus::NoPathsFound => write!(f, "NoPathsFound"),
-            PathValidationStatus::CountryCodeViolation => write!(f, "CountryCodeViolation"),
             PathValidationStatus::CertificateRevoked => write!(f, "CertificateRevoked"),
             PathValidationStatus::CertificateRevokedEndEntity => {
                 write!(f, "CertificateRevokedEndEntity")
@@ -265,12 +255,9 @@ fn error_test() {
     let _s = format!("{}", PathValidationStatus::UnprocessedCriticalExtension);
     let _s = format!("{}", PathValidationStatus::MissingTrustAnchor);
     let _s = format!("{}", PathValidationStatus::MissingTrustAnchorName);
-    let _s = format!("{}", PathValidationStatus::ProhibitedAlg);
-    let _s = format!("{}", PathValidationStatus::ProhibitedKeySize);
     let _s = format!("{}", PathValidationStatus::EncodingError);
     let _s = format!("{}", PathValidationStatus::MissingCertificate);
     let _s = format!("{}", PathValidationStatus::NoPathsFound);
-    let _s = format!("{}", PathValidationStatus::CountryCodeViolation);
     let _s = format!("{}", PathValidationStatus::CertificateRevoked);
     let _s = format!("{}", PathValidationStatus::CertificateRevokedEndEntity);
     let _s = format!(

--- a/certval/src/validator/path_settings.rs
+++ b/certval/src/validator/path_settings.rs
@@ -281,16 +281,6 @@ pub static PS_CRL_TIMEOUT_DEFAULT: Duration = Duration::from_secs(60);
 /// `PS_CRL_TIMEOUT` is used to a u64 that expresses the maximum amount of time to spend downloading a CRL expressed in seconds.
 pub static PS_CRL_TIMEOUT: &str = "psCrlTimeout";
 
-/// `PS_ENFORCE_ALG_AND_KEY_SIZE_CONSTRAINTS` is used to retrieve a boolean value from a [`CertificationPathSettings`]
-/// object. The default value is false. When true, certification path validation should ensure the
-/// no operative algorithm or key size constraints are violated.
-pub static PS_ENFORCE_ALG_AND_KEY_SIZE_CONSTRAINTS: &str = "psEnforceAlgAndKeySizeConstraints";
-
-/// `PS_USE_VALIDATOR_FILTER_WHEN_BUILDING` is used to retrieve a boolean value from a [`CertificationPathSettings`]
-/// object. The default value is true. When true, certification path building should employ relevant
-/// certification path validation practices during path building (see RFC 4158).
-pub static PS_USE_VALIDATOR_FILTER_WHEN_BUILDING: &str = "psUseValidatorFilterWhenBuilding";
-
 /// `PS_CHECK_REVOCATION_STATUS` is used to retrieve a boolean value from a [`CertificationPathSettings`]
 /// object. The default value is true. When true, certification path validation should perform
 /// revocation status checks via available means, i.e., CRLs, OCSP, etc.
@@ -338,12 +328,6 @@ pub static PS_RETAIN_EXPIRED_KEPT_CRLS: &str = "psRetainExpiredKeptCrls";
 /// object. The default value is true. When true, certification path validation should process CRLs
 /// using grace periods only after exhausting other notionally current options.
 pub static PS_CRL_GRACE_PERIODS_AS_LAST_RESORT: &str = "psCrlGracePeriodsAsLastResort";
-
-/// `PS_IGNORE_EXPIRED` is used to retrieve a boolean value from a [`CertificationPathSettings`]
-/// object. The default value is false. When true, certification path validation should ignore certificate
-/// expiry errors. This is useful only in limited cases, such as when processing iOS device certificates
-/// issued by expired CAs (see warning in Apple's Over-the-Air Profile Delivery and Configuration specification).
-pub static PS_IGNORE_EXPIRED: &str = "psIgnoreExpired";
 
 /// `PS_OCSP_AIA_NONCE_SETTING` is used to retrieve an i8 value indicating an enumerated value that
 /// determines whether or not OCSP requests associated with OCSP responders arrived at via AIA extensions
@@ -413,21 +397,6 @@ pub static PS_MAX_AIA_FETCH_BYTES_DEFAULT: u64 = 4 * 1024 * 1024;
 /// `PS_CERTIFICATES` is used to retrieve a set of potentially useful certificates from a [`CertificationPathSettings`]
 /// object.
 pub static PS_CERTIFICATES: &str = "psCertificates";
-
-/// `PS_REQUIRE_COUNTRY_CODE_INDICATOR` is used to retrieve a boolean value from a [`CertificationPathSettings`]
-/// object. The default value is false. When true, certification path validation should process require
-/// target certificates to feature a subjectDirectoryAttributes extension containing a country code.
-pub static PS_REQUIRE_COUNTRY_CODE_INDICATOR: &str = "psRequireCountryCodeIndicator";
-
-/// `PS_PERM_COUNTRIES` is used to retrieve a Strings value, i.e., vector of String, from a [`CertificationPathSettings`]
-/// object. When present, target certificates featuring a subjectDirectoryAttributes extension containing a country code
-/// will be evaluated to affirm the values in the certificate are permitted.
-pub static PS_PERM_COUNTRIES: &str = "psPermCountries";
-
-/// `PS_EXCL_COUNTRIES` is used to retrieve a Strings value, i.e., vector of String, from a [`CertificationPathSettings`]
-/// object. When present, target certificates featuring a subjectDirectoryAttributes extension containing a country code
-/// will be evaluated to affirm the values in the certificate are not exluded.
-pub static PS_EXCL_COUNTRIES: &str = "psExclCountries";
 
 /// PS_TRUST_ANCHOR_FOLDER is used to retrieve a String value containing the full path of a folder containing trust anchors
 pub static PS_TRUST_ANCHOR_FOLDER: &str = "psTrustAnchorFolder";
@@ -762,8 +731,6 @@ cps_gets_and_sets_with_default!(
 );
 cps_gets_and_sets_with_default!(PS_CRL_TIMEOUT, Duration, PS_CRL_TIMEOUT_DEFAULT);
 
-cps_gets_and_sets_with_default!(PS_ENFORCE_ALG_AND_KEY_SIZE_CONSTRAINTS, bool, false);
-cps_gets_and_sets_with_default!(PS_USE_VALIDATOR_FILTER_WHEN_BUILDING, bool, true);
 cps_gets_and_sets_with_default!(PS_CHECK_REVOCATION_STATUS, bool, true);
 cps_gets_and_sets_with_default!(PS_CHECK_OCSP_FROM_AIA, bool, true);
 cps_gets_and_sets_with_default!(PS_RETRIEVE_FROM_AIA_SIA_HTTP, bool, true);
@@ -773,7 +740,6 @@ cps_gets_and_sets_with_default!(PS_CHECK_CRLDP_HTTP, bool, true);
 cps_gets_and_sets_with_default!(PS_CHECK_CRLDP_LDAP, bool, false);
 cps_gets_and_sets_with_default!(PS_RETAIN_EXPIRED_KEPT_CRLS, bool, false);
 cps_gets_and_sets_with_default!(PS_CRL_GRACE_PERIODS_AS_LAST_RESORT, bool, true);
-cps_gets_and_sets_with_default!(PS_IGNORE_EXPIRED, bool, false);
 cps_gets_and_sets_with_default!(
     PS_OCSP_AIA_NONCE_SETTING,
     OcspNonceSetting,
@@ -794,9 +760,6 @@ cps_gets_and_sets_with_default!(
 cps_gets_and_sets_with_default!(PS_MAX_AIA_FETCH_BYTES, u64, PS_MAX_AIA_FETCH_BYTES_DEFAULT);
 // PS_MAXIMUM_PATH_DEPTH (ditch this and use PS_INITIAL_PATH_LENGTH_CONSTRAINT)
 // PS_CERTIFICATES (will need lifetime aware macro)
-cps_gets_and_sets_with_default!(PS_REQUIRE_COUNTRY_CODE_INDICATOR, bool, false);
-cps_gets_and_sets!(PS_PERM_COUNTRIES, Strings);
-cps_gets_and_sets!(PS_EXCL_COUNTRIES, Strings);
 cps_gets_and_sets_with_default!(PS_REQUIRE_TA_STORE, bool, true);
 cps_gets_and_sets_with_default!(PS_FORBID_SELF_SIGNED_EE, bool, false);
 
@@ -904,9 +867,7 @@ fn test_default_gets_cps() {
     assert!(cps.get_enforce_trust_anchor_validity());
     assert!(!cps.get_extended_key_usage_path());
     assert_eq!(Duration::from_secs(60), cps.get_crl_timeout());
-    assert!(!cps.get_enforce_alg_and_key_size_constraints());
 
-    assert!(cps.get_use_validator_filter_when_building());
     assert!(cps.get_check_revocation_status());
     assert!(cps.get_check_ocsp_from_aia());
     assert!(cps.get_retrieve_from_aia_sia_http());
@@ -915,14 +876,12 @@ fn test_default_gets_cps() {
     assert!(cps.get_check_crldp_http());
     assert!(!cps.get_check_crldp_ldap());
     assert!(cps.get_crl_grace_periods_as_last_resort());
-    assert!(!cps.get_ignore_expired());
     assert_eq!(
         OcspNonceSetting::DoNotSendNonce,
         cps.get_ocsp_aia_nonce_setting()
     );
     assert_eq!(Duration::from_secs(0), cps.get_revocation_max_age());
     assert_eq!(2000, cps.get_max_aia_sia_certs());
-    assert!(!cps.get_require_country_code_indicator());
 
     assert_eq!(vec![ANY_POLICY.to_string()], cps.get_initial_policy_set());
     assert!(!cps.get_cbor_ta_store());
@@ -932,8 +891,6 @@ fn test_default_gets_cps() {
 fn test_no_default_gets_cps() {
     let cps = CertificationPathSettings::default();
 
-    assert_eq!(None, cps.get_perm_countries());
-    assert_eq!(None, cps.get_excl_countries());
     assert_eq!(None, cps.get_initial_permitted_subtrees());
     let mut bufs1 = BTreeMap::new();
     assert_eq!(
@@ -1007,11 +964,7 @@ fn test_default_sets_cps() {
     assert!(cps.get_extended_key_usage_path());
     cps.set_crl_timeout(Duration::from_secs(120));
     assert_eq!(Duration::from_secs(120), cps.get_crl_timeout());
-    cps.set_enforce_alg_and_key_size_constraints(true);
-    assert!(cps.get_enforce_alg_and_key_size_constraints());
 
-    cps.set_use_validator_filter_when_building(false);
-    assert!(!cps.get_use_validator_filter_when_building());
     cps.set_check_revocation_status(false);
     assert!(!cps.get_check_revocation_status());
     cps.set_check_ocsp_from_aia(false);
@@ -1033,9 +986,6 @@ fn test_default_sets_cps() {
     cps.set_crl_grace_periods_as_last_resort(false);
     assert!(!cps.get_crl_grace_periods_as_last_resort());
 
-    cps.set_ignore_expired(true);
-    assert!(cps.get_ignore_expired());
-
     cps.set_ocsp_aia_nonce_setting(OcspNonceSetting::SendNonceRequireMatch);
     assert_eq!(
         OcspNonceSetting::SendNonceRequireMatch,
@@ -1046,9 +996,6 @@ fn test_default_sets_cps() {
     assert_eq!(Duration::from_secs(3600), cps.get_revocation_max_age());
     cps.set_max_aia_sia_certs(500);
     assert_eq!(500, cps.get_max_aia_sia_certs());
-
-    cps.set_require_country_code_indicator(true);
-    assert!(cps.get_require_country_code_indicator());
 
     cps.set_initial_policy_set(vec![ID_CE_POLICY_MAPPINGS.to_string()]);
     assert_eq!(
@@ -1067,12 +1014,6 @@ fn test_no_default_sets_cps() {
     use x509_cert::ext::pkix::name::GeneralName;
 
     let mut cps = CertificationPathSettings::default();
-
-    let v = vec!["US".to_string()];
-    cps.set_perm_countries(v.clone());
-    assert_eq!(&v, &cps.get_perm_countries().unwrap());
-    cps.set_excl_countries(v.clone());
-    assert_eq!(&v, &cps.get_excl_countries().unwrap());
 
     assert_eq!(None, cps.get_initial_permitted_subtrees());
     let mut bufs1 = BTreeMap::new();

--- a/certval/src/validator/path_validator.rs
+++ b/certval/src/validator/path_validator.rs
@@ -71,7 +71,6 @@ pub fn validate_path_rfc5280(
     cp: &mut CertificationPath,
     cpr: &mut CertificationPathResults,
 ) -> Result<()> {
-    //enforce_alg_and_key_size_constraints(pe, cps, cp, cpr)?;
     check_validity(pe, cps, cp, cpr)?;
     if cps.get_require_ta_store() {
         if pe.is_cert_a_trust_anchor(&cp.target).is_ok() {
@@ -119,7 +118,6 @@ pub fn validate_path_rfc5280(
 
     check_basic_constraints(pe, cps, cp, cpr)?;
     check_names(pe, cps, cp, cpr)?;
-    //check_country_codes(pe, cps, cp, cpr)?;
     // Certificate policy processing is always graph-based (RFC 9618).
     check_certificate_policies_graph(pe, cps, cp, cpr)?;
     check_key_usage(pe, cps, cp, cpr)?;
@@ -1050,31 +1048,6 @@ pub fn verify_signatures(
     }
     Ok(())
 }
-
-/*
-/// `enforce_alg_and_key_size_constraints` enforces algorithm and key size constraints, if any.
-pub fn enforce_alg_and_key_size_constraints(
-    _pe: &PkiEnvironment,
-    _cps: &CertificationPathSettings,
-    _cp: &mut CertificationPath,
-    _cpr: &mut CertificationPathResults,
-) -> Result<()> {
-    //TODO - implement alg and key size constraints enforcement
-    Ok(())
-}
-
-/// `check_country_codes` ensures the target certificate from a CertificationPath does not violate any
-/// constraints defined in the `PS_PERM_COUNTRIES` and `PS_EXCL_COUNTRIES` values from the [`CertificationPathSettings`].
-pub fn check_country_codes(
-    _pe: &PkiEnvironment,
-    _cps: &CertificationPathSettings,
-    _cp: &mut CertificationPath,
-    _cpr: &mut CertificationPathResults,
-) -> Result<()> {
-    //TODO - implement country code enforcement
-    Ok(())
-}
-*/
 
 #[cfg(test)]
 mod tests {

--- a/certval/tests/path_settings.rs
+++ b/certval/tests/path_settings.rs
@@ -46,7 +46,6 @@ fn settings_serialization_test() {
     let ekus = vec![ID_KP_SERVER_AUTH.to_string()];
     cps.set_extended_key_usage(ekus);
     cps.set_extended_key_usage_path(false);
-    cps.set_enforce_alg_and_key_size_constraints(false);
     cps.set_check_revocation_status(false);
     cps.set_check_ocsp_from_aia(false);
     cps.set_check_ocsp_from_aia(false);
@@ -56,13 +55,7 @@ fn settings_serialization_test() {
     cps.set_check_crldp_http(false);
     cps.set_check_crldp_ldap(false);
     cps.set_crl_grace_periods_as_last_resort(false);
-    cps.set_ignore_expired(false);
     cps.set_ocsp_aia_nonce_setting(OcspNonceSetting::DoNotSendNonce);
-    cps.set_require_country_code_indicator(false);
-    let permcountries = vec!["AA".to_string()];
-    cps.set_perm_countries(permcountries);
-    let exclcountries = vec!["BB".to_string()];
-    cps.set_perm_countries(exclcountries);
     let fs = KeyUsages::DigitalSignature | KeyUsages::KeyEncipherment;
     cps.set_target_key_usage(fs);
 

--- a/pittv3-gui-lib/src/gui_settings.rs
+++ b/pittv3-gui-lib/src/gui_settings.rs
@@ -758,12 +758,6 @@ pub fn EditSettings(
                             overridden: m.require_ta_store.is_some(),
                             onchange: move |v| model.write().require_ta_store = Some(v),
                         }
-                        BoolRow {
-                            label: "Filter candidate paths while building",
-                            checked: m.use_validator_filter_when_building.unwrap_or(true),
-                            overridden: m.use_validator_filter_when_building.is_some(),
-                            onchange: move |v| model.write().use_validator_filter_when_building = Some(v),
-                        }
                         NumberRow {
                             label: "Path length constraint",
                             value: m.initial_path_length_constraint.map(|v| v as u64),
@@ -797,21 +791,9 @@ pub fn EditSettings(
                             overridden: m.forbid_self_signed_ee.is_some(),
                             onchange: move |v| model.write().forbid_self_signed_ee = Some(v),
                         }
-                        BoolRow {
-                            label: "Enforce algorithm and key size constraints",
-                            checked: m.enforce_alg_and_key_size_constraints.unwrap_or(false),
-                            overridden: m.enforce_alg_and_key_size_constraints.is_some(),
-                            onchange: move |v| model.write().enforce_alg_and_key_size_constraints = Some(v),
-                        }
                         TimeOfInterestRow {
                             value: m.time_of_interest,
                             onchange: move |v| model.write().time_of_interest = v,
-                        }
-                        BoolRow {
-                            label: "Ignore expired certificates when building",
-                            checked: m.ignore_expired.unwrap_or(false),
-                            overridden: m.ignore_expired.is_some(),
-                            onchange: move |v| model.write().ignore_expired = Some(v),
                         }
                     }
                 },

--- a/pittv3-gui-lib/src/gui_settings_model.rs
+++ b/pittv3-gui-lib/src/gui_settings_model.rs
@@ -59,8 +59,6 @@ pub struct SettingsModel {
     pub require_ta_store: Option<bool>,
     /// Maximum number of non-self-issued intermediate certificates permitted in a path
     pub initial_path_length_constraint: Option<u8>,
-    /// Use validation checks to filter candidate paths while building
-    pub use_validator_filter_when_building: Option<bool>,
 
     // ---- target ----
     /// Key usage bits the target certificate must assert
@@ -71,14 +69,10 @@ pub struct SettingsModel {
     pub extended_key_usage_path: Option<bool>,
     /// Reject self-signed end entity certificates
     pub forbid_self_signed_ee: Option<bool>,
-    /// Enforce algorithm and key size constraints
-    pub enforce_alg_and_key_size_constraints: Option<bool>,
 
     // ---- time ----
     /// Time of interest as seconds since Unix epoch (0 disables validity checks)
     pub time_of_interest: Option<u64>,
-    /// Ignore expired certificates when building paths
-    pub ignore_expired: Option<bool>,
 
     // ---- revocation ----
     /// Master switch for revocation status determination
@@ -103,14 +97,6 @@ pub struct SettingsModel {
     pub retrieve_from_aia_sia_http: Option<bool>,
     /// Maximum number of certificates to retrieve via AIA and SIA
     pub max_aia_sia_certs: Option<u64>,
-
-    // ---- countries ----
-    /// Require country codes in target certificates to satisfy the permitted/excluded lists
-    pub require_country_code_indicator: Option<bool>,
-    /// Permitted country codes
-    pub perm_countries: Option<Vec<String>>,
-    /// Excluded country codes
-    pub excl_countries: Option<Vec<String>>,
 
     // ---- folders and files (desktop-only tab) ----
     /// Folder containing trust anchors
@@ -156,22 +142,14 @@ impl SettingsModel {
             require_ta_store: present(cps, PS_REQUIRE_TA_STORE).then(|| cps.get_require_ta_store()),
             initial_path_length_constraint: present(cps, PS_INITIAL_PATH_LENGTH_CONSTRAINT)
                 .then(|| cps.get_initial_path_length_constraint()),
-            use_validator_filter_when_building: present(cps, PS_USE_VALIDATOR_FILTER_WHEN_BUILDING)
-                .then(|| cps.get_use_validator_filter_when_building()),
             target_key_usage: cps.get_target_key_usage(),
             extended_key_usage: cps.get_extended_key_usage(),
             extended_key_usage_path: present(cps, PS_EXTENDED_KEY_USAGE_PATH)
                 .then(|| cps.get_extended_key_usage_path()),
             forbid_self_signed_ee: present(cps, PS_FORBID_SELF_SIGNED_EE)
                 .then(|| cps.get_forbid_self_signed_ee()),
-            enforce_alg_and_key_size_constraints: present(
-                cps,
-                PS_ENFORCE_ALG_AND_KEY_SIZE_CONSTRAINTS,
-            )
-            .then(|| cps.get_enforce_alg_and_key_size_constraints()),
             time_of_interest: present(cps, PS_TIME_OF_INTEREST)
                 .then(|| cps.get_time_of_interest().as_unix_secs()),
-            ignore_expired: present(cps, PS_IGNORE_EXPIRED).then(|| cps.get_ignore_expired()),
             check_revocation_status: present(cps, PS_CHECK_REVOCATION_STATUS)
                 .then(|| cps.get_check_revocation_status()),
             check_crls: present(cps, PS_CHECK_CRLS).then(|| cps.get_check_crls()),
@@ -189,10 +167,6 @@ impl SettingsModel {
                 .then(|| cps.get_retrieve_from_aia_sia_http()),
             max_aia_sia_certs: present(cps, PS_MAX_AIA_SIA_CERTS)
                 .then(|| cps.get_max_aia_sia_certs()),
-            require_country_code_indicator: present(cps, PS_REQUIRE_COUNTRY_CODE_INDICATOR)
-                .then(|| cps.get_require_country_code_indicator()),
-            perm_countries: cps.get_perm_countries(),
-            excl_countries: cps.get_excl_countries(),
             trust_anchor_folder: cps.get_trust_anchor_folder(),
             certification_authority_folder: cps.get_certification_authority_folder(),
             download_folder: cps.get_download_folder(),
@@ -277,12 +251,6 @@ impl SettingsModel {
             &self.initial_path_length_constraint,
             |c, v| c.set_initial_path_length_constraint(v),
         );
-        set_or_remove(
-            cps,
-            PS_USE_VALIDATOR_FILTER_WHEN_BUILDING,
-            &self.use_validator_filter_when_building,
-            |c, v| c.set_use_validator_filter_when_building(v),
-        );
         set_or_remove(cps, PS_KEY_USAGE, &self.target_key_usage, |c, v| {
             c.set_target_key_usage(v)
         });
@@ -304,12 +272,6 @@ impl SettingsModel {
             &self.forbid_self_signed_ee,
             |c, v| c.set_forbid_self_signed_ee(v),
         );
-        set_or_remove(
-            cps,
-            PS_ENFORCE_ALG_AND_KEY_SIZE_CONSTRAINTS,
-            &self.enforce_alg_and_key_size_constraints,
-            |c, v| c.set_enforce_alg_and_key_size_constraints(v),
-        );
         match self.time_of_interest {
             Some(secs) => {
                 let toi = match TimeOfInterest::from_unix_secs(secs) {
@@ -322,9 +284,6 @@ impl SettingsModel {
                 cps.0.remove(PS_TIME_OF_INTEREST);
             }
         }
-        set_or_remove(cps, PS_IGNORE_EXPIRED, &self.ignore_expired, |c, v| {
-            c.set_ignore_expired(v)
-        });
         set_or_remove(
             cps,
             PS_CHECK_REVOCATION_STATUS,
@@ -376,18 +335,6 @@ impl SettingsModel {
             &self.max_aia_sia_certs,
             |c, v| c.set_max_aia_sia_certs(v),
         );
-        set_or_remove(
-            cps,
-            PS_REQUIRE_COUNTRY_CODE_INDICATOR,
-            &self.require_country_code_indicator,
-            |c, v| c.set_require_country_code_indicator(v),
-        );
-        set_or_remove(cps, PS_PERM_COUNTRIES, &self.perm_countries, |c, v| {
-            c.set_perm_countries(v)
-        });
-        set_or_remove(cps, PS_EXCL_COUNTRIES, &self.excl_countries, |c, v| {
-            c.set_excl_countries(v)
-        });
         set_or_remove(
             cps,
             PS_TRUST_ANCHOR_FOLDER,
@@ -491,7 +438,6 @@ mod tests {
             revocation_max_age_secs: Some(3600),
             crl_timeout_secs: Some(30),
             max_aia_sia_certs: Some(100),
-            perm_countries: Some(vec!["US".to_string()]),
             trust_anchor_folder: Some("/tas".to_string()),
             initial_permitted_subtrees: Some(NameConstraintsSettings {
                 dns_name: Some(vec!["example.com".to_string()]),
@@ -514,7 +460,7 @@ mod tests {
     fn apply_removes_none_fields_and_preserves_uncovered() {
         let mut cps = CertificationPathSettings::new();
         cps.set_check_revocation_status(false);
-        cps.set_ignore_expired(true);
+        cps.set_check_crldp_http(true);
         // A setting the model has no field for, so nothing here can express an opinion about it.
         cps.0.insert(
             PS_MAX_CRL_FETCH_BYTES.to_string(),
@@ -522,7 +468,7 @@ mod tests {
         );
 
         let model = SettingsModel {
-            ignore_expired: Some(false),
+            check_crldp_http: Some(false),
             ..Default::default()
         };
         model.apply(&mut cps);
@@ -530,7 +476,7 @@ mod tests {
         // check_revocation_status was None in the model, so the key is gone (default applies)
         assert!(!cps.0.contains_key(PS_CHECK_REVOCATION_STATUS));
         assert!(cps.get_check_revocation_status());
-        assert!(!cps.get_ignore_expired());
+        assert!(!cps.get_check_crldp_http());
         // The uncovered half of this test's name. It is also why the desktop offers a Delete
         // button beside its settings path: Reset to defaults followed by Save clears every key the
         // form can express and leaves the rest of the file standing, so it is not a full reset.
@@ -547,8 +493,7 @@ mod tests {
     fn resetting_to_defaults_clears_every_covered_key() {
         let mut cps = CertificationPathSettings::new();
         cps.set_check_revocation_status(false);
-        cps.set_ignore_expired(true);
-        cps.set_require_country_code_indicator(true);
+        cps.set_check_crldp_http(false);
         cps.0.insert(
             PS_MAX_CRL_FETCH_BYTES.to_string(),
             CertificationPathProcessingTypes::U64(1024),

--- a/pittv3-lib/src/pitt_log.rs
+++ b/pittv3-lib/src/pitt_log.rs
@@ -167,14 +167,6 @@ pub fn log_cps(f: &mut dyn Write, cps: &CertificationPathSettings) {
         .as_bytes(),
     )
     .expect("Unable to write manifest file");
-    f.write_all(
-        format!(
-            "Enforce algorithm and key size constraints: {}\n",
-            cps.get_enforce_alg_and_key_size_constraints()
-        )
-        .as_bytes(),
-    )
-    .expect("Unable to write manifest file");
     f.write_all(format!("Check revocation: {}\n", cps.get_check_revocation_status()).as_bytes())
         .expect("Unable to write manifest file");
 }
@@ -1238,7 +1230,6 @@ fn test_cps_log() {
     let ekus = vec![ID_KP_SERVER_AUTH.to_string()];
     cps.set_extended_key_usage(ekus);
     cps.set_extended_key_usage_path(false);
-    cps.set_enforce_alg_and_key_size_constraints(false);
     cps.set_check_revocation_status(false);
     cps.set_check_ocsp_from_aia(false);
     cps.set_check_ocsp_from_aia(false);
@@ -1248,13 +1239,7 @@ fn test_cps_log() {
     cps.set_check_crldp_http(false);
     cps.set_check_crldp_ldap(false);
     cps.set_crl_grace_periods_as_last_resort(false);
-    cps.set_ignore_expired(false);
     cps.set_ocsp_aia_nonce_setting(OcspNonceSetting::DoNotSendNonce);
-    cps.set_require_country_code_indicator(false);
-    let permcountries = vec!["AA".to_string()];
-    cps.set_perm_countries(permcountries);
-    let exclcountries = vec!["BB".to_string()];
-    cps.set_perm_countries(exclcountries);
     let fs = KeyUsages::DigitalSignature | KeyUsages::KeyEncipherment;
     cps.set_target_key_usage(fs);
 


### PR DESCRIPTION
- Remove the country code feature, including PathValidationStatus::CountryCodeViolation. This feature was requested in the previous library but never used.
- Remove no-longer-needed PS_IGNORE_EXPIRED setting
- Remove never-used PS_USE_VALIDATOR_FILTER_WHEN_BUILDING as inapplicable to the offline building focus
- Remove unused algorithm and key size constraint settings. These can already be enforced by a caller (and can be added back later if desired).