### PR TITLE
Settings and tooltip mods to pittv3

### DIFF
--- a/pittv3-gui/src/gui.rs
+++ b/pittv3-gui/src/gui.rs
@@ -2948,3 +2948,86 @@ pub(crate) fn App() -> Element {
         }
     }
 }
+
+/// A row that gives no `title` falls back to `arg_help(name)`, and `arg_help` is a string-keyed
+/// match with no compile-time tie to anything: add a row, or rename an argument, and the tooltip
+/// silently becomes empty with nothing failing to build.
+///
+/// This reads the source it is testing rather than a list kept beside it, because a list is the
+/// thing that goes stale. `include_str!` is compile-time, so there is no generation step.
+#[cfg(test)]
+mod tooltip_coverage {
+    use pittv3_lib::help::arg_help;
+
+    /// The components in `gui_rows` that call `tooltip(title, name)`, i.e. the ones that fall back
+    /// to `arg_help`. A component missing from this list is not checked, so keep it in step with
+    /// the `tooltip(` call sites in `pittv3-gui-lib/src/gui_rows.rs`.
+    const TOOLTIP_ROWS: &[&str] = &[
+        "TextRow",
+        "BrowseRow",
+        "TimeRow",
+        "CheckboxCell",
+        "CheckboxRow",
+        "PathListRow",
+    ];
+
+    /// The text between `{` at `open` and its matching `}`.
+    fn block(src: &str, open: usize) -> &str {
+        let bytes = src.as_bytes();
+        let mut depth = 0usize;
+        for (i, c) in bytes.iter().enumerate().skip(open) {
+            match c {
+                b'{' => depth += 1,
+                b'}' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return &src[open..i];
+                    }
+                }
+                _ => {}
+            }
+        }
+        &src[open..]
+    }
+
+    /// The `name: "…"` a row states outright, or `None` when it forwards a caller's -- the local
+    /// helper components in this file take `name` as a parameter and pass it along, so the literal
+    /// is at their call site and is checked when that call site is visited.
+    fn literal_name(block: &str) -> Option<&str> {
+        let rest = block.split("name: \"").nth(1)?;
+        rest.split('"').next()
+    }
+
+    #[test]
+    fn every_row_relying_on_arg_help_has_an_entry() {
+        let src = include_str!("gui.rs");
+        let mut checked = 0;
+        for component in TOOLTIP_ROWS {
+            let pattern = format!("{component} {{");
+            let mut from = 0;
+            while let Some(offset) = src[from..].find(&pattern) {
+                let open = from + offset + pattern.len() - 1;
+                from = open + 1;
+                let block = block(src, open);
+                // A row that states its own text never reaches the fallback.
+                if block.contains("title:") {
+                    continue;
+                }
+                let Some(name) = literal_name(block) else {
+                    continue;
+                };
+                checked += 1;
+                assert!(
+                    !arg_help(name).is_empty(),
+                    "{component} {name:?} gives no title and has no arg_help entry, so its tooltip is empty"
+                );
+            }
+        }
+        // Guards against the scan silently matching nothing -- a renamed component or a change in
+        // how rows are written would otherwise turn this test into an assertion about nothing.
+        assert!(
+            checked >= 10,
+            "only {checked} rows were checked; the scan has stopped finding them"
+        );
+    }
+}

--- a/pittv3-lib/src/help.rs
+++ b/pittv3-lib/src/help.rs
@@ -196,6 +196,28 @@ pub fn arg_help(name: &str) -> &'static str {
             "at the time of interest; a time of interest of 0 keeps all of them.",
         ),
         "list-name-constraints" => "Outputs all name constraints found in certificates present in CBOR file.",
+        "uri-target" => concat!(
+            "The certificate whose URIs are checked. Every HTTP URI in its AIA, SIA, CRL DP and ",
+            "freshest-CRL extensions is fetched and evaluated against this certificate. No store or ",
+            "trust anchors are needed: this check does not build or validate a path.",
+        ),
+        "uri-issuer" => concat!(
+            "The issuer of the target, used to verify a CRL signature and to ask an OCSP responder. ",
+            "Optional: without it those two checks report reachability alone, unless auto-discovery ",
+            "finds the issuer from the target's AIA.",
+        ),
+        "uri-auto" => concat!(
+            "Looks the issuer up from the target's AIA caIssuers URIs when none is supplied, so CRL ",
+            "signature and OCSP checks can still run. Turn it off to check only what the ",
+            "certificates in hand support.",
+        ),
+        "check-uris-when-validating" => concat!(
+            "Runs the URI checker over every certificate on each validated path and appends the ",
+            "results to that path's log. Each distinct certificate is checked once per run and its ",
+            "result is rendered into every path it appears on, so an intermediate common to forty ",
+            "paths is fetched for once. Trust anchors are scanned for their SIA only. Retrieves from ",
+            "the repositories the certificates name, so it needs network access.",
+        ),
         "check-uris" => concat!(
             "Checks the HTTP URIs carried in the AIA, SIA, CRL DP and freshest-CRL extensions of the ",
             "certificate at the given path, reporting per-URI reachability and correctness (the SIA/AIA ",

--- a/pittv3-wasm/src/main.rs
+++ b/pittv3-wasm/src/main.rs
@@ -766,6 +766,15 @@ fn App() -> Element {
         env_dirty.set(true);
     });
 
+    // What a loaded settings file held, kept whole until it is saved or discarded.
+    //
+    // `SettingsModel` has fields only for what the form can express, so parsing a file into one
+    // narrows it: every key the form does not surface is dropped on the spot. The desktop never
+    // loses those because its file stays on disk and a save re-reads it; local storage is this
+    // frontend's only store, so a narrowed load is unrecoverable. Holding the parsed map here gives
+    // Save and Download the same "start from what was loaded" base the desktop gets from the file.
+    let mut settings_base = use_signal(|| None::<CertificationPathSettings>);
+
     // Replaces the whole model, remounting the form so it reseeds from the new values. Used by
     // loading a settings file and by Revert to Saved.
     //
@@ -773,6 +782,10 @@ fn App() -> Element {
     // holds are two different things here, exactly as the desktop's settings path and its file are.
     let mut replace_settings = move |model: SettingsModel| {
         settings.set(model);
+        // Wholesale replacement abandons any base a previously loaded file established -- Revert to
+        // Saved goes back to local storage and must not carry the discarded file's extras with it.
+        // A caller with bytes worth preserving sets a new base after calling this.
+        settings_base.set(None);
         form_gen += 1;
     };
 
@@ -785,10 +798,16 @@ fn App() -> Element {
     // overwritten by the caller's success message -- localStorage refuses in private browsing and
     // when the origin's quota is full, and a save that says it worked when it did not is the one
     // failure the user cannot see.
-    let persist_settings = move |model: &SettingsModel| -> Result<(), String> {
-        let mut cps = LocalStorageSettingsStore.load();
+    let mut persist_settings = move |model: &SettingsModel| -> Result<(), String> {
+        let mut cps = settings_base().unwrap_or_else(|| LocalStorageSettingsStore.load());
         model.apply(&mut cps);
-        LocalStorageSettingsStore.save(&cps)
+        let outcome = LocalStorageSettingsStore.save(&cps);
+        if outcome.is_ok() {
+            // Everything the loaded file carried is in local storage now, so the base has nothing
+            // left to contribute and a later Revert to Saved returns to exactly this.
+            settings_base.set(None);
+        }
+        outcome
     };
 
     // The time a run validates against, for stamping reports: the chosen time of interest, or the
@@ -968,7 +987,10 @@ fn App() -> Element {
     let save_settings_file = move |_| {
         // Written from the model, not from run_settings: a time of interest the user did not choose
         // stays absent so the file remains portable, and the reader supplies its own current time.
-        let mut cps = LocalStorageSettingsStore.load();
+        // The loaded file when there is one, local storage otherwise -- the same base a Save would
+        // merge over, so a downloaded file carries what an imported one brought even when the form
+        // has no field for it.
+        let mut cps = settings_base().unwrap_or_else(|| LocalStorageSettingsStore.load());
         settings().apply(&mut cps);
         let json = serde_json::to_string_pretty(&cps).unwrap_or_default();
         let uri = format!(
@@ -1006,6 +1028,9 @@ fn App() -> Element {
             }
         };
         replace_settings(SettingsModel::from_cps(&cps));
+        // After the replacement, which clears any previous base: keep this file's own map so the
+        // settings it carries that the form cannot show survive a Save or a Download.
+        settings_base.set(Some(cps));
         // Says it is not saved because nothing on screen would otherwise show it. The desktop has a
         // path box naming the file it is editing; here the only difference between a loaded file and
         // the saved settings is invisible, and Revert to Saved is how it is undone.


### PR DESCRIPTION
- wasm: Preserve uploaded settings values that are not reflected in the UI
- Add missing URI checker tooltips and a test that every row has one